### PR TITLE
Add option to anonymize line numbers

### DIFF
--- a/examples/expected_type.rs
+++ b/examples/expected_type.rs
@@ -37,6 +37,6 @@ fn main() {
     };
 
     let dl = DisplayList::from(snippet);
-    let dlf = DisplayListFormatter::new(true);
+    let dlf = DisplayListFormatter::new(true, false);
     println!("{}", dlf.format(&dl));
 }

--- a/examples/footer.rs
+++ b/examples/footer.rs
@@ -34,6 +34,6 @@ fn main() {
     };
 
     let dl = DisplayList::from(snippet);
-    let dlf = DisplayListFormatter::new(true);
+    let dlf = DisplayListFormatter::new(true, false);
     println!("{}", dlf.format(&dl));
 }

--- a/examples/format.rs
+++ b/examples/format.rs
@@ -55,6 +55,6 @@ fn main() {
     };
 
     let dl = DisplayList::from(snippet);
-    let dlf = DisplayListFormatter::new(true);
+    let dlf = DisplayListFormatter::new(true, false);
     println!("{}", dlf.format(&dl));
 }

--- a/examples/multislice.rs
+++ b/examples/multislice.rs
@@ -31,6 +31,6 @@ fn main() {
     };
 
     let dl = DisplayList::from(snippet);
-    let dlf = DisplayListFormatter::new(true);
+    let dlf = DisplayListFormatter::new(true, false);
     println!("{}", dlf.format(&dl));
 }

--- a/src/display_list/structs.rs
+++ b/src/display_list/structs.rs
@@ -131,7 +131,7 @@ pub enum DisplayMarkType {
     /// use annotate_snippets::display_list::*;
     /// use annotate_snippets::formatter::DisplayListFormatter;
     ///
-    /// let dlf = DisplayListFormatter::new(false); // Don't use colors
+    /// let dlf = DisplayListFormatter::new(false, false); // Don't use colors
     ///
     /// let dl = DisplayList {
     ///     body: vec![
@@ -161,7 +161,7 @@ pub enum DisplayMarkType {
     /// use annotate_snippets::display_list::*;
     /// use annotate_snippets::formatter::DisplayListFormatter;
     ///
-    /// let dlf = DisplayListFormatter::new(false); // Don't use colors
+    /// let dlf = DisplayListFormatter::new(false, false); // Don't use colors
     ///
     /// let dl = DisplayList {
     ///     body: vec![
@@ -214,7 +214,7 @@ pub enum DisplayHeaderType {
     /// use annotate_snippets::display_list::*;
     /// use annotate_snippets::formatter::DisplayListFormatter;
     ///
-    /// let dlf = DisplayListFormatter::new(false); // Don't use colors
+    /// let dlf = DisplayListFormatter::new(false, false); // Don't use colors
     ///
     /// let dl = DisplayList {
     ///     body: vec![
@@ -236,7 +236,7 @@ pub enum DisplayHeaderType {
     /// use annotate_snippets::display_list::*;
     /// use annotate_snippets::formatter::DisplayListFormatter;
     ///
-    /// let dlf = DisplayListFormatter::new(false); // Don't use colors
+    /// let dlf = DisplayListFormatter::new(false, false); // Don't use colors
     ///
     /// let dl = DisplayList {
     ///     body: vec![

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -54,7 +54,7 @@ pub struct DisplayListFormatter {
 }
 
 impl DisplayListFormatter {
-    pub const ANONYMIZED_LINE_NUM: &'static str = "LL";
+    const ANONYMIZED_LINE_NUM: &'static str = "LL";
 
     /// Constructor for the struct.
     ///
@@ -89,7 +89,7 @@ impl DisplayListFormatter {
                 ..
             } => {
                 if self.anonymized_line_numbers {
-                    2 // "LL"
+                    Self::ANONYMIZED_LINE_NUM.len()
                 } else {
                     cmp::max(lineno.to_string().len(), max)
                 }

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -46,7 +46,7 @@ fn test_fixtures() {
         let expected_out = read_file(&path_out).expect("Failed to read file");
 
         let dl = DisplayList::from(snippet);
-        let dlf = DisplayListFormatter::new(true);
+        let dlf = DisplayListFormatter::new(true, false);
         let actual_out = dlf.format(&dl);
         println!("{}", expected_out);
         println!("{}", actual_out.trim_end());


### PR DESCRIPTION
With the current diagnostics emitter of Rust, the `-Z ui-testing` flag
allows to 'anonymize' line numbers in the UI test output.

This means that a line such as:

     2 |     concat!(b'f');

is turned into:

    LL |     concat!(b'f');

This is done because it makes the diff of UI test output changes much
less noisy.

To support this with `annotate-snippet`, we add a second parameter to
`DisplayListFormatter` that, when true, replaces the line numbers in the
left column with the text `LL`. The replacement text is always `LL` and
it does not affect the initial location line number.

In the new `annotate-snippet` emitter in rustc, we can then use this
parameter depending on whether the `-Z ui-testing` flag is set or not.

Closes #2 
cc https://github.com/rust-lang/rust/issues/59346