### PR TITLE
Fix too many anonymized line numbers

### DIFF
--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -303,7 +303,7 @@ impl DisplayListFormatter {
                 inline_marks,
                 line,
             } => {
-                let lineno = if self.anonymized_line_numbers {
+                let lineno = if self.anonymized_line_numbers  && lineno.is_some() {
                     Self::ANONYMIZED_LINE_NUM.to_string()
                 } else {
                     self.format_lineno(*lineno, lineno_width)

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -515,13 +515,26 @@ fn test_anon_lines() {
                 range: (0, 19),
             },
         },
+        DisplayLine::Source {
+            lineno: None,
+            inline_marks: vec![],
+            line: DisplaySourceLine::Empty,
+        },
+        DisplayLine::Source {
+            lineno: None,
+            inline_marks: vec![],
+            line: DisplaySourceLine::Content {
+                text: "abc".to_string(),
+                range: (0, 19),
+            },
+        },
     ]);
 
     let dlf = DisplayListFormatter::new(false, true);
 
     assert_eq!(
         dlf.format(&dl),
-        "LL | This is an example\nLL | of content lines"
+        "LL | This is an example\nLL | of content lines\n   |\n   | abc"
     );
 }
 


### PR DESCRIPTION
This expands the logic for replacing line numbers with `LL` so that line
numbers are only replaced, when they are actually provided.

When `lineno` is `None`, no `LL` should be shown in the output.