### PR TITLE
Fix single char overflow display issue

### DIFF
--- a/src/display_list/from_snippet.rs
+++ b/src/display_list/from_snippet.rs
@@ -214,7 +214,7 @@ fn format_body(slice: &snippet::Slice, has_footer: bool) -> Vec<DisplayLine> {
                 };
                 match annotation.range {
                     (start, _) if start > line_end => true,
-                    (start, end) if start >= line_start && end <= line_end + 1 => {
+                    (start, end) if start >= line_start && end <= line_end => {
                         let range = (start - line_start, end - line_start);
                         body.insert(
                             body_idx + 1,

--- a/tests/fixtures/no-color/multiline_annotation3.txt
+++ b/tests/fixtures/no-color/multiline_annotation3.txt
@@ -1,0 +1,9 @@
+error[E####]: spacing error found
+  --> foo.txt:26:12
+   |
+26 |   This is an exampl
+   |  ____________^
+27 | | e of an edge case of an annotation overflowing
+   | |_^ this should not be on separate lines
+28 |   to exactly one character on next line.
+   |

--- a/tests/fixtures/no-color/multiline_annotation3.yaml
+++ b/tests/fixtures/no-color/multiline_annotation3.yaml
@@ -1,0 +1,16 @@
+slices:
+  - source: |-
+      This is an exampl
+      e of an edge case of an annotation overflowing
+      to exactly one character on next line.
+    line_start: 26
+    origin: foo.txt
+    fold: false
+    annotations:
+      - label: this should not be on separate lines
+        annotation_type: Error
+        range: [11, 19]
+title:
+  label: spacing error found
+  id: E####
+  annotation_type: Error


### PR DESCRIPTION
Fixes the error described in #16. Previously, when a single character of
an annotation overflows to a new line, the DisplayList would incorrectly
consider that character on the same line. This change fixes this and
adds a new fixture test for this case.