### PR TITLE
Fix SourceAnnotation ranges and refactor to `std::fmt::Display`

### DIFF
--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -47,7 +47,7 @@ fn create_snippet() {
                 SourceAnnotation {
                     label: "expected enum `std::option::Option`".to_string(),
                     annotation_type: AnnotationType::Error,
-                    range: (23, 745),
+                    range: (26, 724),
                 },
             ],
         }],
@@ -59,7 +59,7 @@ fn create_snippet() {
         footer: vec![],
         opt: FormatOptions {
             color: true,
-            anonymized_line_numbers: false,
+            ..Default::default()
         },
     };
 

--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -2,12 +2,12 @@
 #[macro_use]
 extern crate criterion;
 
-use criterion::black_box;
-use criterion::Criterion;
+use criterion::{black_box, Criterion};
 
-use annotate_snippets::display_list::DisplayList;
-use annotate_snippets::formatter::DisplayListFormatter;
-use annotate_snippets::snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation};
+use annotate_snippets::{
+    display_list::{DisplayList, FormatOptions},
+    snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
+};
 
 fn create_snippet() {
     let snippet = Snippet {
@@ -57,11 +57,14 @@ fn create_snippet() {
             annotation_type: AnnotationType::Error,
         }),
         footer: vec![],
+        opt: FormatOptions {
+            color: true,
+            anonymized_line_numbers: false,
+        },
     };
 
     let dl = DisplayList::from(snippet);
-    let dlf = DisplayListFormatter::new(true, false);
-    let _result = dlf.format(&dl);
+    let _result = dl.to_string();
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {

--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unit_arg)]
 #[macro_use]
 extern crate criterion;
 

--- a/examples/expected_type.rs
+++ b/examples/expected_type.rs
@@ -1,6 +1,7 @@
-use annotate_snippets::display_list::DisplayList;
-use annotate_snippets::formatter::DisplayListFormatter;
-use annotate_snippets::snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation};
+use annotate_snippets::{
+    display_list::DisplayList,
+    snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
+};
 
 fn main() {
     let snippet = Snippet {
@@ -32,9 +33,9 @@ fn main() {
                 },
             ],
         }],
+        opt: Default::default(),
     };
 
     let dl = DisplayList::from(snippet);
-    let dlf = DisplayListFormatter::new(true, false);
-    println!("{}", dlf.format(&dl));
+    println!("{}", dl);
 }

--- a/examples/expected_type.rs
+++ b/examples/expected_type.rs
@@ -1,5 +1,5 @@
 use annotate_snippets::{
-    display_list::DisplayList,
+    display_list::{DisplayList, FormatOptions},
     snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
 };
 
@@ -24,7 +24,7 @@ fn main() {
                 SourceAnnotation {
                     label: "".to_string(),
                     annotation_type: AnnotationType::Error,
-                    range: (208, 210),
+                    range: (205, 207),
                 },
                 SourceAnnotation {
                     label: "while parsing this struct".to_string(),
@@ -33,7 +33,10 @@ fn main() {
                 },
             ],
         }],
-        opt: Default::default(),
+        opt: FormatOptions {
+            color: true,
+            ..Default::default()
+        },
     };
 
     let dl = DisplayList::from(snippet);

--- a/examples/footer.rs
+++ b/examples/footer.rs
@@ -1,6 +1,7 @@
-use annotate_snippets::display_list::DisplayList;
-use annotate_snippets::formatter::DisplayListFormatter;
-use annotate_snippets::snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation};
+use annotate_snippets::{
+    display_list::DisplayList,
+    snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
+};
 
 fn main() {
     let snippet = Snippet {
@@ -29,9 +30,9 @@ fn main() {
                 annotation_type: AnnotationType::Error,
             }],
         }],
+        opt: Default::default(),
     };
 
     let dl = DisplayList::from(snippet);
-    let dlf = DisplayListFormatter::new(true, false);
-    println!("{}", dlf.format(&dl));
+    println!("{}", dl);
 }

--- a/examples/footer.rs
+++ b/examples/footer.rs
@@ -1,5 +1,5 @@
 use annotate_snippets::{
-    display_list::DisplayList,
+    display_list::{DisplayList, FormatOptions},
     snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
 };
 
@@ -30,7 +30,10 @@ fn main() {
                 annotation_type: AnnotationType::Error,
             }],
         }],
-        opt: Default::default(),
+        opt: FormatOptions {
+            color: true,
+            ..Default::default()
+        },
     };
 
     let dl = DisplayList::from(snippet);

--- a/examples/format.rs
+++ b/examples/format.rs
@@ -1,6 +1,7 @@
-use annotate_snippets::display_list::DisplayList;
-use annotate_snippets::formatter::DisplayListFormatter;
-use annotate_snippets::snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation};
+use annotate_snippets::{
+    display_list::DisplayList,
+    snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
+};
 
 fn main() {
     let snippet = Snippet {
@@ -50,9 +51,9 @@ fn main() {
             annotation_type: AnnotationType::Error,
         }),
         footer: vec![],
+        opt: Default::default(),
     };
 
     let dl = DisplayList::from(snippet);
-    let dlf = DisplayListFormatter::new(true, false);
-    println!("{}", dlf.format(&dl));
+    println!("{}", dl);
 }

--- a/examples/format.rs
+++ b/examples/format.rs
@@ -1,5 +1,5 @@
 use annotate_snippets::{
-    display_list::DisplayList,
+    display_list::{DisplayList, FormatOptions},
     snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
 };
 
@@ -41,7 +41,7 @@ fn main() {
                 SourceAnnotation {
                     label: "expected enum `std::option::Option`".to_string(),
                     annotation_type: AnnotationType::Error,
-                    range: (23, 745),
+                    range: (26, 724),
                 },
             ],
         }],
@@ -51,7 +51,10 @@ fn main() {
             annotation_type: AnnotationType::Error,
         }),
         footer: vec![],
-        opt: Default::default(),
+        opt: FormatOptions {
+            color: true,
+            ..Default::default()
+        },
     };
 
     let dl = DisplayList::from(snippet);

--- a/examples/multislice.rs
+++ b/examples/multislice.rs
@@ -1,6 +1,7 @@
-use annotate_snippets::display_list::DisplayList;
-use annotate_snippets::formatter::DisplayListFormatter;
-use annotate_snippets::snippet::{Annotation, AnnotationType, Slice, Snippet};
+use annotate_snippets::{
+    display_list::DisplayList,
+    snippet::{Annotation, AnnotationType, Slice, Snippet},
+};
 
 fn main() {
     let snippet = Snippet {
@@ -26,9 +27,9 @@ fn main() {
                 annotations: vec![],
             },
         ],
+        opt: Default::default(),
     };
 
     let dl = DisplayList::from(snippet);
-    let dlf = DisplayListFormatter::new(true, false);
-    println!("{}", dlf.format(&dl));
+    println!("{}", dl);
 }

--- a/examples/multislice.rs
+++ b/examples/multislice.rs
@@ -1,5 +1,5 @@
 use annotate_snippets::{
-    display_list::DisplayList,
+    display_list::{DisplayList, FormatOptions},
     snippet::{Annotation, AnnotationType, Slice, Snippet},
 };
 
@@ -27,7 +27,10 @@ fn main() {
                 annotations: vec![],
             },
         ],
-        opt: Default::default(),
+        opt: FormatOptions {
+            color: true,
+            ..Default::default()
+        },
     };
 
     let dl = DisplayList::from(snippet);

--- a/src/display_list/from_snippet.rs
+++ b/src/display_list/from_snippet.rs
@@ -5,8 +5,7 @@ use crate::snippet;
 fn format_label(label: Option<&str>, style: Option<DisplayTextStyle>) -> Vec<DisplayTextFragment> {
     let mut result = vec![];
     if let Some(label) = label {
-        let elements: Vec<&str> = label.split("__").collect();
-        for (idx, element) in elements.iter().enumerate() {
+        for (idx, element) in label.split("__").enumerate() {
             let element_style = match style {
                 Some(s) => s,
                 None => {
@@ -26,12 +25,12 @@ fn format_label(label: Option<&str>, style: Option<DisplayTextStyle>) -> Vec<Dis
     result
 }
 
-fn format_title(annotation: &snippet::Annotation) -> DisplayLine {
-    let label = annotation.label.clone().unwrap_or_default();
+fn format_title(annotation: snippet::Annotation) -> DisplayLine {
+    let label = annotation.label.unwrap_or_default();
     DisplayLine::Raw(DisplayRawLine::Annotation {
         annotation: Annotation {
             annotation_type: DisplayAnnotationType::from(annotation.annotation_type),
-            id: annotation.id.clone(),
+            id: annotation.id,
             label: format_label(Some(&label), Some(DisplayTextStyle::Emphasis)),
         },
         source_aligned: false,
@@ -39,9 +38,9 @@ fn format_title(annotation: &snippet::Annotation) -> DisplayLine {
     })
 }
 
-fn format_annotation(annotation: &snippet::Annotation) -> Vec<DisplayLine> {
+fn format_annotation(annotation: snippet::Annotation) -> Vec<DisplayLine> {
     let mut result = vec![];
-    let label = annotation.label.clone().unwrap_or_default();
+    let label = annotation.label.unwrap_or_default();
     for (i, line) in label.lines().enumerate() {
         result.push(DisplayLine::Raw(DisplayRawLine::Annotation {
             annotation: Annotation {
@@ -56,11 +55,14 @@ fn format_annotation(annotation: &snippet::Annotation) -> Vec<DisplayLine> {
     result
 }
 
-fn format_slice(slice: &snippet::Slice, is_first: bool, has_footer: bool) -> Vec<DisplayLine> {
+fn format_slice(mut slice: snippet::Slice, is_first: bool, has_footer: bool) -> Vec<DisplayLine> {
+    let main_range = slice.annotations.get(0).map(|x| x.range.0);
+    let row = slice.line_start;
+    let origin = slice.origin.take();
     let mut body = format_body(slice, has_footer);
+    let header = format_header(origin, main_range, row, &body, is_first);
     let mut result = vec![];
 
-    let header = format_header(slice, &body, is_first);
     if let Some(header) = header {
         result.push(header);
     }
@@ -69,46 +71,45 @@ fn format_slice(slice: &snippet::Slice, is_first: bool, has_footer: bool) -> Vec
 }
 
 fn format_header(
-    slice: &snippet::Slice,
+    origin: Option<String>,
+    main_range: Option<usize>,
+    mut row: usize,
     body: &[DisplayLine],
     is_first: bool,
 ) -> Option<DisplayLine> {
-    let main_annotation = slice.annotations.get(0);
-
     let display_header = if is_first {
         DisplayHeaderType::Initial
     } else {
         DisplayHeaderType::Continuation
     };
 
-    if let Some(annotation) = main_annotation {
+    if let Some(main_range) = main_range {
         let mut col = 1;
-        let mut row = slice.line_start;
 
-        for item in body.iter() {
+        for item in body {
             if let DisplayLine::Source {
                 line: DisplaySourceLine::Content { range, .. },
                 ..
             } = item
             {
-                if annotation.range.0 >= range.0 && annotation.range.0 <= range.1 {
-                    col = annotation.range.0 - range.0 + 1;
+                if main_range >= range.0 && main_range <= range.1 {
+                    col = main_range - range.0 + 1;
                     break;
                 }
                 row += 1;
             }
         }
-        if let Some(ref path) = slice.origin {
+        if let Some(path) = origin {
             return Some(DisplayLine::Raw(DisplayRawLine::Origin {
-                path: path.to_string(),
+                path,
                 pos: Some((row, col)),
                 header_type: display_header,
             }));
         }
     }
-    if let Some(ref path) = slice.origin {
+    if let Some(path) = origin {
         return Some(DisplayLine::Raw(DisplayRawLine::Origin {
-            path: path.to_string(),
+            path,
             pos: None,
             header_type: display_header,
         }));
@@ -175,15 +176,30 @@ fn fold_body(body: &[DisplayLine]) -> Vec<DisplayLine> {
     new_body
 }
 
-fn format_body(slice: &snippet::Slice, has_footer: bool) -> Vec<DisplayLine> {
-    let mut body = vec![];
+fn format_body(slice: snippet::Slice, has_footer: bool) -> Vec<DisplayLine> {
+    let source_len = slice.source.chars().count();
+    if let Some(bigger) = slice.annotations.iter().find_map(|x| {
+        if source_len < x.range.1 {
+            Some(x.range)
+        } else {
+            None
+        }
+    }) {
+        panic!(
+            "SourceAnnotation range `{:?}` is bigger than source length `{}`",
+            bigger, source_len
+        )
+    }
 
+    let mut body = vec![];
     let mut current_line = slice.line_start;
     let mut current_index = 0;
     let mut line_index_ranges = vec![];
 
-    for line in slice.source.lines() {
-        let line_length = line.chars().count() + 1;
+    let lines = slice.source.lines();
+    let lines_len = lines.clone().count();
+    for (i, line) in lines.enumerate() {
+        let line_length = line.chars().count();
         let line_range = (current_index, current_index + line_length);
         body.push(DisplayLine::Source {
             lineno: Some(current_line),
@@ -195,13 +211,14 @@ fn format_body(slice: &snippet::Slice, has_footer: bool) -> Vec<DisplayLine> {
         });
         line_index_ranges.push(line_range);
         current_line += 1;
-        current_index += line_length + 1;
+        if i + 1 < lines_len {
+            current_index += line_length + 1;
+        }
     }
 
     let mut annotation_line_count = 0;
-    let mut annotations = slice.annotations.clone();
-    for idx in 0..body.len() {
-        let (line_start, line_end) = line_index_ranges[idx];
+    let mut annotations = slice.annotations;
+    for (idx, (line_start, line_end)) in line_index_ranges.into_iter().enumerate() {
         // It would be nice to use filter_drain here once it's stable.
         annotations = annotations
             .into_iter()
@@ -214,7 +231,10 @@ fn format_body(slice: &snippet::Slice, has_footer: bool) -> Vec<DisplayLine> {
                 };
                 match annotation.range {
                     (start, _) if start > line_end => true,
-                    (start, end) if start >= line_start && end <= line_end => {
+                    (start, end)
+                        if start >= line_start && end <= line_end
+                            || start == line_end && end - start <= 1 =>
+                    {
                         let range = (start - line_start, end - line_start);
                         body.insert(
                             body_idx + 1,
@@ -305,6 +325,7 @@ fn format_body(slice: &snippet::Slice, has_footer: bool) -> Vec<DisplayLine> {
                                 ),
                             });
                         }
+
                         let range = (end - line_start, end - line_start + 1);
                         body.insert(
                             body_idx + 1,
@@ -368,22 +389,24 @@ fn format_body(slice: &snippet::Slice, has_footer: bool) -> Vec<DisplayLine> {
 }
 
 impl From<snippet::Snippet> for DisplayList {
-    fn from(snippet: snippet::Snippet) -> Self {
+    fn from(
+        snippet::Snippet {
+            title,
+            footer,
+            slices,
+        }: snippet::Snippet,
+    ) -> Self {
         let mut body = vec![];
-        if let Some(annotation) = snippet.title {
-            body.push(format_title(&annotation));
+        if let Some(annotation) = title {
+            body.push(format_title(annotation));
         }
 
-        for (idx, slice) in snippet.slices.iter().enumerate() {
-            body.append(&mut format_slice(
-                &slice,
-                idx == 0,
-                !snippet.footer.is_empty(),
-            ));
+        for (idx, slice) in slices.into_iter().enumerate() {
+            body.append(&mut format_slice(slice, idx == 0, !footer.is_empty()));
         }
 
-        for annotation in snippet.footer {
-            body.append(&mut format_annotation(&annotation));
+        for annotation in footer {
+            body.append(&mut format_annotation(annotation));
         }
 
         Self { body }

--- a/src/display_list/from_snippet.rs
+++ b/src/display_list/from_snippet.rs
@@ -1,6 +1,6 @@
 //! Trait for converting `Snippet` to `DisplayList`.
 use super::*;
-use crate::snippet;
+use crate::{formatter::get_term_style, snippet};
 
 fn format_label(label: Option<&str>, style: Option<DisplayTextStyle>) -> Vec<DisplayTextFragment> {
     let mut result = vec![];
@@ -388,12 +388,14 @@ fn format_body(slice: snippet::Slice, has_footer: bool) -> Vec<DisplayLine> {
     body
 }
 
+// TODO: From reference to DisplayList<'a>
 impl From<snippet::Snippet> for DisplayList {
     fn from(
         snippet::Snippet {
             title,
             footer,
             slices,
+            opt,
         }: snippet::Snippet,
     ) -> Self {
         let mut body = vec![];
@@ -409,7 +411,16 @@ impl From<snippet::Snippet> for DisplayList {
             body.append(&mut format_annotation(annotation));
         }
 
-        Self { body }
+        let FormatOptions {
+            color,
+            anonymized_line_numbers,
+        } = opt;
+
+        Self {
+            body,
+            stylesheet: get_term_style(color),
+            anonymized_line_numbers,
+        }
     }
 }
 

--- a/src/display_list/mod.rs
+++ b/src/display_list/mod.rs
@@ -27,97 +27,10 @@
 //! are `Source` lines.
 //!
 //! `DisplayList` does not store column alignment information, and those are
-//! only calculated by the `DisplayListFormatter` using information such as
+//! only calculated by the implementation of `std::fmt::Display` using information such as
 //! styling.
 //!
 //! The above snippet has been built out of the following structure:
-//!
-//! ```rust,ignore
-//! use annotate_snippets::display_list::*;
-//!
-//! let dl = DisplayList {
-//!     body: vec![
-//!         DisplayLine::Raw(DisplayRawLine::Annotation {
-//!             annotation: Annotation {
-//!                 annotation_type: DisplayAnnotationType::Error,
-//!                 id: Some("E0308".to_string()),
-//!                 label: vec![
-//!                     DisplayTextFragment {
-//!                         content: "mismatched types".to_string(),
-//!                         style: DisplayTextStyle::Regular,
-//!                     }
-//!                 ]
-//!             },
-//!             source_aligned: false,
-//!             continuation: false,
-//!         }),
-//!         DisplayLine::Raw(DisplayRawLine::Origin {
-//!             path: "src/format.rs".to_string(),
-//!             pos: Some((51, 5)),
-//!             header_type: DisplayHeaderType::Initial,
-//!         }),
-//!         DisplayLine::Source {
-//!             lineno: Some(151),
-//!             inline_marks: vec![
-//!                 DisplayMark {
-//!                     mark_type: DisplayMarkType::AnnotationStart,
-//!                     annotation_type: DisplayAnnotationType::Error,
-//!                 }
-//!             ],
-//!             line: DisplaySourceLine::Content {
-//!                 text: "  fn test() -> String {".to_string(),
-//!                 range: (0, 24)
-//!             }
-//!         },
-//!         DisplayLine::Source {
-//!             lineno: Some(152),
-//!             inline_marks: vec![
-//!                 DisplayMark {
-//!                     mark_type: DisplayMarkType::AnnotationThrough,
-//!                     annotation_type: DisplayAnnotationType::Error,
-//!                 }
-//!             ],
-//!             line: DisplaySourceLine::Content {
-//!                 text: "      return \"test\";".to_string(),
-//!                 range: (25, 46)
-//!             }
-//!         },
-//!         DisplayLine::Source {
-//!             lineno: Some(153),
-//!             inline_marks: vec![
-//!                 DisplayMark {
-//!                     mark_type: DisplayMarkType::AnnotationThrough,
-//!                     annotation_type: DisplayAnnotationType::Error,
-//!                 }
-//!             ],
-//!             line: DisplaySourceLine::Content {
-//!                 text: "  }".to_string(),
-//!                 range: (47, 51)
-//!             }
-//!         },
-//!         DisplayLine::Source {
-//!             lineno: None,
-//!             inline_marks: vec![],
-//!             line: DisplaySourceLine::Annotation {
-//!                 annotation: Annotation {
-//!                     annotation_type: DisplayAnnotationType::Error,
-//!                     id: None,
-//!                     label: vec![
-//!                         DisplayTextFragment {
-//!                             content: "expected `String`, for `&str`.".to_string(),
-//!                             style: DisplayTextStyle::Regular,
-//!                         }
-//!                     ]
-//!                 },
-//!                 range: (3, 4),
-//!                 annotation_type: DisplayAnnotationType::Error,
-//!                 annotation_part: DisplayAnnotationPart::MultilineEnd,
-//!             }
-//!
-//!         }
-//!     ]
-//! };
-//! ```
 mod from_snippet;
 mod structs;
 

--- a/src/display_list/mod.rs
+++ b/src/display_list/mod.rs
@@ -32,7 +32,7 @@
 //!
 //! The above snippet has been built out of the following structure:
 //!
-//! ```
+//! ```rust,ignore
 //! use annotate_snippets::display_list::*;
 //!
 //! let dl = DisplayList {

--- a/src/formatter/style.rs
+++ b/src/formatter/style.rs
@@ -5,57 +5,7 @@
 //! formatter, a structs can implement `Stylesheet` and `Style`
 //! traits.
 //!
-//! Example:
-//!
-//! ```
-//! use annotate_snippets::formatter::style::{Stylesheet, StyleClass, Style};
-//!
-//! struct HTMLStyle {
-//!   prefix: String,
-//!   postfix: String,
-//! };
-//!
-//! impl HTMLStyle {
-//!   fn new(prefix: &str, postfix: &str) -> Self {
-//!     HTMLStyle {
-//!       prefix: prefix.into(),
-//!       postfix: postfix.into()
-//!     }
-//!   }
-//! };
-//!
-//! impl Style for HTMLStyle {
-//!   fn paint(&self, text: &str) -> String {
-//!     format!("{}{}{}", self.prefix, text, self.postfix)
-//!   }
-//!
-//!   fn bold(&self) -> Box<Style> {
-//!     Box::new(HTMLStyle {
-//!       prefix: format!("{}<b>", self.prefix),
-//!       postfix: format!("</b>{}", self.postfix),
-//!     })
-//!   }
-//! }
-//!
-//! struct HTMLStylesheet {};
-//!
-//!
-//! impl Stylesheet for HTMLStylesheet {
-//!   fn get_style(&self, class: StyleClass) -> Box<Style> {
-//!     let s = match class {
-//!       StyleClass::Error => HTMLStyle::new("<span style='color:red'>", "</span>"),
-//!       StyleClass::Warning => HTMLStyle::new("<span style='color:orange'>", "</span>"),
-//!       StyleClass::Info => HTMLStyle::new("<span style='color:yellow'>", "</span>"),
-//!       StyleClass::Note => HTMLStyle::new("<span style='color:blue'>", "</span>"),
-//!       StyleClass::Help => HTMLStyle::new("<span style='color:green'>", "</span>"),
-//!       StyleClass::LineNo => HTMLStyle::new("<strong>", "</strong>"),
-//!       StyleClass::Emphasis => HTMLStyle::new("<i>", "</i>"),
-//!       StyleClass::None => HTMLStyle::new("", ""),
-//!     };
-//!     Box::new(s)
-//!   }
-//! }
-//! ```
+use std::fmt;
 
 /// StyleClass is a collection of named variants of style classes
 /// that DisplayListFormatter uses.
@@ -84,7 +34,7 @@ pub enum StyleClass {
 /// This trait implements a return value for the `Stylesheet::get_style`.
 pub trait Style {
     /// The method used by the DisplayListFormatter to style the message.
-    fn paint(&self, text: &str) -> String;
+    fn paint(&self, text: &str, f: &mut fmt::Formatter<'_>) -> fmt::Result;
     /// The method used by the DisplayListFormatter to display the message
     /// in bold font.
     fn bold(&self) -> Box<dyn Style>;

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -28,14 +28,18 @@
 //!             annotations: vec![],
 //!         },
 //!     ],
+//!     opt: Default::default(),
 //! };
 //! ```
+use crate::display_list::FormatOptions;
+
 /// Primary structure provided for formatting
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Snippet {
     pub title: Option<Annotation>,
     pub footer: Vec<Annotation>,
     pub slices: Vec<Slice>,
+    pub opt: FormatOptions,
 }
 
 /// Structure containing the slice of text to be annotated and

--- a/src/stylesheets/color.rs
+++ b/src/stylesheets/color.rs
@@ -1,15 +1,16 @@
-use crate::formatter::style::{Style, StyleClass, Stylesheet};
+use std::fmt;
 
-use ansi_term::Color::Fixed;
-use ansi_term::Style as AnsiTermStyle;
+use ansi_term::{Color::Fixed, Style as AnsiTermStyle};
+
+use crate::formatter::style::{Style, StyleClass, Stylesheet};
 
 struct AnsiTermStyleWrapper {
     style: AnsiTermStyle,
 }
 
 impl Style for AnsiTermStyleWrapper {
-    fn paint(&self, text: &str) -> String {
-        format!("{}", self.style.paint(text))
+    fn paint(&self, text: &str, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.style.paint(text), f)
     }
 
     fn bold(&self) -> Box<dyn Style> {
@@ -17,7 +18,7 @@ impl Style for AnsiTermStyleWrapper {
     }
 }
 
-pub struct AnsiTermStylesheet {}
+pub struct AnsiTermStylesheet;
 
 impl Stylesheet for AnsiTermStylesheet {
     fn get_style(&self, class: StyleClass) -> Box<dyn Style> {

--- a/src/stylesheets/color.rs
+++ b/src/stylesheets/color.rs
@@ -13,9 +13,7 @@ impl Style for AnsiTermStyleWrapper {
     }
 
     fn bold(&self) -> Box<dyn Style> {
-        Box::new(AnsiTermStyleWrapper {
-            style: self.style.clone(),
-        })
+        Box::new(AnsiTermStyleWrapper { style: self.style })
     }
 }
 

--- a/src/stylesheets/no_color.rs
+++ b/src/stylesheets/no_color.rs
@@ -1,10 +1,12 @@
+use std::fmt;
+
 use crate::formatter::style::{Style, StyleClass, Stylesheet};
 
 pub struct NoOpStyle {}
 
 impl Style for NoOpStyle {
-    fn paint(&self, text: &str) -> String {
-        text.to_string()
+    fn paint(&self, text: &str, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(text)
     }
 
     fn bold(&self) -> Box<dyn Style> {
@@ -12,7 +14,7 @@ impl Style for NoOpStyle {
     }
 }
 
-pub struct NoColorStylesheet {}
+pub struct NoColorStylesheet;
 
 impl Stylesheet for NoColorStylesheet {
     fn get_style(&self, _class: StyleClass) -> Box<dyn Style> {

--- a/tests/diff/mod.rs
+++ b/tests/diff/mod.rs
@@ -39,5 +39,5 @@ pub fn get_diff(left: &str, right: &str) -> String {
             }
         }
     }
-    return output;
+    output
 }

--- a/tests/dl_from_snippet.rs
+++ b/tests/dl_from_snippet.rs
@@ -1,5 +1,4 @@
-use annotate_snippets::display_list as dl;
-use annotate_snippets::snippet;
+use annotate_snippets::{display_list as dl, formatter::get_term_style, snippet};
 
 #[test]
 fn test_format_title() {
@@ -11,6 +10,7 @@ fn test_format_title() {
         }),
         footer: vec![],
         slices: vec![],
+        opt: Default::default(),
     };
     let output = dl::DisplayList {
         body: vec![dl::DisplayLine::Raw(dl::DisplayRawLine::Annotation {
@@ -25,6 +25,8 @@ fn test_format_title() {
             source_aligned: false,
             continuation: false,
         })],
+        stylesheet: get_term_style(input.opt.color),
+        anonymized_line_numbers: input.opt.anonymized_line_numbers,
     };
     assert_eq!(dl::DisplayList::from(input), output);
 }
@@ -44,6 +46,7 @@ fn test_format_slice() {
             annotations: vec![],
             fold: false,
         }],
+        opt: Default::default(),
     };
     let output = dl::DisplayList {
         body: vec![
@@ -74,6 +77,8 @@ fn test_format_slice() {
                 line: dl::DisplaySourceLine::Empty,
             },
         ],
+        stylesheet: get_term_style(input.opt.color),
+        anonymized_line_numbers: input.opt.anonymized_line_numbers,
     };
     assert_eq!(dl::DisplayList::from(input), output);
 }
@@ -103,6 +108,7 @@ fn test_format_slices_continuation() {
                 fold: false,
             },
         ],
+        opt: Default::default(),
     };
     let output = dl::DisplayList {
         body: vec![
@@ -153,6 +159,8 @@ fn test_format_slices_continuation() {
                 line: dl::DisplaySourceLine::Empty,
             },
         ],
+        stylesheet: get_term_style(input.opt.color),
+        anonymized_line_numbers: input.opt.anonymized_line_numbers,
     };
     assert_eq!(dl::DisplayList::from(input), output);
 }
@@ -178,6 +186,7 @@ fn test_format_slice_annotation_standalone() {
             }],
             fold: false,
         }],
+        opt: Default::default(),
     };
     let output = dl::DisplayList {
         body: vec![
@@ -225,6 +234,8 @@ fn test_format_slice_annotation_standalone() {
                 line: dl::DisplaySourceLine::Empty,
             },
         ],
+        stylesheet: get_term_style(input.opt.color),
+        anonymized_line_numbers: input.opt.anonymized_line_numbers,
     };
     assert_eq!(dl::DisplayList::from(input), output);
 }
@@ -239,6 +250,7 @@ fn test_format_label() {
             annotation_type: snippet::AnnotationType::Error,
         }],
         slices: vec![],
+        opt: Default::default(),
     };
     let output = dl::DisplayList {
         body: vec![dl::DisplayLine::Raw(dl::DisplayRawLine::Annotation {
@@ -263,6 +275,8 @@ fn test_format_label() {
             source_aligned: true,
             continuation: false,
         })],
+        stylesheet: get_term_style(input.opt.color),
+        anonymized_line_numbers: input.opt.anonymized_line_numbers,
     };
     assert_eq!(dl::DisplayList::from(input), output);
 }
@@ -286,6 +300,7 @@ fn test_i26() {
             origin: None,
             fold: false,
         }],
+        opt: Default::default(),
     };
 
     let _ = dl::DisplayList::from(input);

--- a/tests/fixtures/no-color/multiline_annotation.yaml
+++ b/tests/fixtures/no-color/multiline_annotation.yaml
@@ -31,7 +31,7 @@ slices:
         range: [5, 19]
       - label: expected enum `std::option::Option`, found ()
         annotation_type: Error
-        range: [23, 786]
+        range: [22, 765]
 title:
   label: mismatched types
   id: E0308

--- a/tests/fixtures/no-color/multiline_annotation2.yaml
+++ b/tests/fixtures/no-color/multiline_annotation2.yaml
@@ -9,7 +9,7 @@ slices:
     annotations:
       - label: missing fields `lineno`, `content`
         annotation_type: Error
-        range: [31, 129]
+        range: [31, 127]
 title:
   label: pattern does not mention fields `lineno`, `content`
   id: E0027

--- a/tests/fixtures/no-color/multiline_annotation3.yaml
+++ b/tests/fixtures/no-color/multiline_annotation3.yaml
@@ -9,7 +9,7 @@ slices:
     annotations:
       - label: this should not be on separate lines
         annotation_type: Error
-        range: [11, 19]
+        range: [11, 18]
 title:
   label: spacing error found
   id: E####

--- a/tests/fixtures/no-color/multiple_annotations.yaml
+++ b/tests/fixtures/no-color/multiple_annotations.yaml
@@ -13,11 +13,11 @@ slices:
     annotations:
       - label: Variable defined here
         annotation_type: Error
-        range: [101, 111]
+        range: [100, 110]
       - label: Referenced here
         annotation_type: Error
-        range: [187, 197]
+        range: [184, 194]
       - label: Referenced again here
         annotation_type: Error
-        range: [248, 258]
+        range: [243, 253]
 title: null

--- a/tests/fixtures/no-color/simple.yaml
+++ b/tests/fixtures/no-color/simple.yaml
@@ -8,7 +8,7 @@ slices:
     annotations:
       - label: unexpected token
         annotation_type: Error
-        range: [22, 25]
+        range: [20, 23]
       - label: expected one of `.`, `;`, `?`, or an operator here
         annotation_type: Warning
         range: [10, 11]

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -2,16 +2,10 @@ mod diff;
 mod snippet;
 
 use crate::snippet::SnippetDef;
-use annotate_snippets::display_list::DisplayList;
-use annotate_snippets::formatter::DisplayListFormatter;
-use annotate_snippets::snippet::Snippet;
+use annotate_snippets::{display_list::DisplayList, snippet::Snippet};
 use glob::glob;
 use serde::Deserialize;
-use std::error::Error;
-use std::fs::File;
-use std::io;
-use std::io::prelude::*;
-use std::path::Path;
+use std::{error::Error, fs::File, io, io::prelude::*, path::Path};
 
 fn read_file(path: &str) -> Result<String, io::Error> {
     let mut f = File::open(path)?;
@@ -41,8 +35,7 @@ fn test_fixtures() {
         let expected_out = read_file(&path_out).expect("Failed to read file");
 
         let dl = DisplayList::from(snippet);
-        let dlf = DisplayListFormatter::new(true, false);
-        let actual_out = dlf.format(&dl);
+        let actual_out = dl.to_string();
         println!("{}", expected_out);
         println!("{}", actual_out.trim_end());
 

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -1,5 +1,4 @@
 use annotate_snippets::display_list::*;
-use annotate_snippets::formatter::DisplayListFormatter;
 
 #[test]
 fn test_source_empty() {
@@ -9,9 +8,7 @@ fn test_source_empty() {
         line: DisplaySourceLine::Empty,
     }]);
 
-    let dlf = DisplayListFormatter::new(false, false);
-
-    assert_eq!(dlf.format(&dl), " |");
+    assert_eq!(dl.to_string(), " |");
 }
 
 #[test]
@@ -35,10 +32,8 @@ fn test_source_content() {
         },
     ]);
 
-    let dlf = DisplayListFormatter::new(false, false);
-
     assert_eq!(
-        dlf.format(&dl),
+        dl.to_string(),
         "56 | This is an example\n57 | of content lines"
     );
 }
@@ -63,9 +58,7 @@ fn test_source_annotation_standalone_singleline() {
         },
     }]);
 
-    let dlf = DisplayListFormatter::new(false, false);
-
-    assert_eq!(dlf.format(&dl), " | ^^^^^ Example string");
+    assert_eq!(dl.to_string(), " | ^^^^^ Example string");
 }
 
 #[test]
@@ -107,10 +100,8 @@ fn test_source_annotation_standalone_multiline() {
         },
     ]);
 
-    let dlf = DisplayListFormatter::new(false, false);
-
     assert_eq!(
-        dlf.format(&dl),
+        dl.to_string(),
         " | ----- help: Example string\n |             Second line"
     );
 }
@@ -239,9 +230,7 @@ fn test_source_annotation_standalone_multi_annotation() {
         },
     ]);
 
-    let dlf = DisplayListFormatter::new(false, false);
-
-    assert_eq!(dlf.format(&dl), " | ----- info: Example string\n |             Second line\n |       warning: This is a note\n |                Second line of the warning\n | ----- info: This is an info\n | ----- help: This is help\n |  This is an annotation of type none");
+    assert_eq!(dl.to_string(), " | ----- info: Example string\n |             Second line\n |       warning: This is a note\n |                Second line of the warning\n | ----- info: This is an info\n | ----- help: This is help\n |  This is an annotation of type none");
 }
 
 #[test]
@@ -268,10 +257,8 @@ fn test_fold_line() {
         },
     ]);
 
-    let dlf = DisplayListFormatter::new(false, false);
-
     assert_eq!(
-        dlf.format(&dl),
+        dl.to_string(),
         "    5 | This is line 5\n...\n10021 | ... and now we're at line 10021"
     );
 }
@@ -284,9 +271,7 @@ fn test_raw_origin_initial_nopos() {
         header_type: DisplayHeaderType::Initial,
     })]);
 
-    let dlf = DisplayListFormatter::new(false, false);
-
-    assert_eq!(dlf.format(&dl), "--> src/test.rs");
+    assert_eq!(dl.to_string(), "--> src/test.rs");
 }
 
 #[test]
@@ -297,9 +282,7 @@ fn test_raw_origin_initial_pos() {
         header_type: DisplayHeaderType::Initial,
     })]);
 
-    let dlf = DisplayListFormatter::new(false, false);
-
-    assert_eq!(dlf.format(&dl), "--> src/test.rs:23:15");
+    assert_eq!(dl.to_string(), "--> src/test.rs:23:15");
 }
 
 #[test]
@@ -310,9 +293,7 @@ fn test_raw_origin_continuation() {
         header_type: DisplayHeaderType::Continuation,
     })]);
 
-    let dlf = DisplayListFormatter::new(false, false);
-
-    assert_eq!(dlf.format(&dl), "::: src/test.rs:23:15");
+    assert_eq!(dl.to_string(), "::: src/test.rs:23:15");
 }
 
 #[test]
@@ -330,9 +311,7 @@ fn test_raw_annotation_unaligned() {
         continuation: false,
     })]);
 
-    let dlf = DisplayListFormatter::new(false, false);
-
-    assert_eq!(dlf.format(&dl), "error[E0001]: This is an error");
+    assert_eq!(dl.to_string(), "error[E0001]: This is an error");
 }
 
 #[test]
@@ -364,10 +343,8 @@ fn test_raw_annotation_unaligned_multiline() {
         }),
     ]);
 
-    let dlf = DisplayListFormatter::new(false, false);
-
     assert_eq!(
-        dlf.format(&dl),
+        dl.to_string(),
         "warning[E0001]: This is an error\n                Second line of the error"
     );
 }
@@ -387,9 +364,7 @@ fn test_raw_annotation_aligned() {
         continuation: false,
     })]);
 
-    let dlf = DisplayListFormatter::new(false, false);
-
-    assert_eq!(dlf.format(&dl), " = error[E0001]: This is an error");
+    assert_eq!(dl.to_string(), " = error[E0001]: This is an error");
 }
 
 #[test]
@@ -421,10 +396,8 @@ fn test_raw_annotation_aligned_multiline() {
         }),
     ]);
 
-    let dlf = DisplayListFormatter::new(false, false);
-
     assert_eq!(
-        dlf.format(&dl),
+        dl.to_string(),
         " = warning[E0001]: This is an error\n                   Second line of the error"
     );
 }
@@ -470,10 +443,8 @@ fn test_different_annotation_types() {
         }),
     ]);
 
-    let dlf = DisplayListFormatter::new(false, false);
-
     assert_eq!(
-        dlf.format(&dl),
+        dl.to_string(),
         "note: This is a note\nThis is just a string\n  Second line of none type annotation",
     );
 }
@@ -489,14 +460,12 @@ fn test_inline_marks_empty_line() {
         line: DisplaySourceLine::Empty,
     }]);
 
-    let dlf = DisplayListFormatter::new(false, false);
-
-    assert_eq!(dlf.format(&dl), " | |",);
+    assert_eq!(dl.to_string(), " | |",);
 }
 
 #[test]
 fn test_anon_lines() {
-    let dl = DisplayList::from(vec![
+    let mut dl = DisplayList::from(vec![
         DisplayLine::Source {
             lineno: Some(56),
             inline_marks: vec![],
@@ -528,24 +497,22 @@ fn test_anon_lines() {
         },
     ]);
 
-    let dlf = DisplayListFormatter::new(false, true);
-
+    dl.anonymized_line_numbers = true;
     assert_eq!(
-        dlf.format(&dl),
+        dl.to_string(),
         "LL | This is an example\nLL | of content lines\n   |\n   | abc"
     );
 }
 
 #[test]
 fn test_raw_origin_initial_pos_anon_lines() {
-    let dl = DisplayList::from(vec![DisplayLine::Raw(DisplayRawLine::Origin {
+    let mut dl = DisplayList::from(vec![DisplayLine::Raw(DisplayRawLine::Origin {
         path: "src/test.rs".to_string(),
         pos: Some((23, 15)),
         header_type: DisplayHeaderType::Initial,
     })]);
 
-    let dlf = DisplayListFormatter::new(false, true);
-
     // Using anonymized_line_numbers should not affect the inital position
-    assert_eq!(dlf.format(&dl), "--> src/test.rs:23:15");
+    dl.anonymized_line_numbers = true;
+    assert_eq!(dl.to_string(), "--> src/test.rs:23:15");
 }

--- a/tests/snippet/mod.rs
+++ b/tests/snippet/mod.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Deserializer, Serialize};
 
-use annotate_snippets::snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation};
+use annotate_snippets::{
+    display_list::FormatOptions,
+    snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
+};
 
 #[derive(Deserialize)]
 #[serde(remote = "Snippet")]
@@ -11,8 +14,28 @@ pub struct SnippetDef {
     #[serde(deserialize_with = "deserialize_annotations")]
     #[serde(default)]
     pub footer: Vec<Annotation>,
+    #[serde(deserialize_with = "deserialize_opt")]
+    #[serde(default)]
+    pub opt: FormatOptions,
     #[serde(deserialize_with = "deserialize_slices")]
     pub slices: Vec<Slice>,
+}
+
+fn deserialize_opt<'de, D>(deserializer: D) -> Result<FormatOptions, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    struct Wrapper(#[serde(with = "FormatOptionsDef")] FormatOptions);
+
+    Wrapper::deserialize(deserializer).map(|w| w.0)
+}
+
+#[derive(Deserialize)]
+#[serde(remote = "FormatOptions")]
+pub struct FormatOptionsDef {
+    pub color: bool,
+    pub anonymized_line_numbers: bool,
 }
 
 fn deserialize_slices<'de, D>(deserializer: D) -> Result<Vec<Slice>, D::Error>


### PR DESCRIPTION
In `test_i26` what should be the output?
panic or anything other than the label disappearing?

I would panic or even refactor to TryFrom. What you prefer

Fix #26 