### PR TITLE
Fix to no copy when format with yansi_term

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@ coveralls = { repository = "rust-lang/annotate-snippets-rs", branch = "master", 
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-ansi_term = { version = "0.12", optional = true }
+yansi-term = { version = "0.1", optional = true }
 
 [dev-dependencies]
 glob = "0.3"
 serde_yaml = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 difference = "2.0"
-ansi_term = "0.12"
+yansi-term = "0.1"
 criterion = "0.3"
 
 [[bench]]
@@ -32,4 +32,4 @@ harness = false
 
 [features]
 default = []
-color = ["ansi_term"]
+color = ["yansi-term"]

--- a/src/formatter/style.rs
+++ b/src/formatter/style.rs
@@ -1,5 +1,4 @@
-//! Set of structures required to implement a stylesheet for
-//! [DisplayListFormatter](super::DisplayListFormatter).
+//! Set of structures required to implement a stylesheet
 //!
 //! In order to provide additional styling information for the
 //! formatter, a structs can implement `Stylesheet` and `Style`
@@ -8,7 +7,6 @@
 use std::fmt;
 
 /// StyleClass is a collection of named variants of style classes
-/// that DisplayListFormatter uses.
 pub enum StyleClass {
     /// Message indicating an error.
     Error,
@@ -33,8 +31,14 @@ pub enum StyleClass {
 
 /// This trait implements a return value for the `Stylesheet::get_style`.
 pub trait Style {
-    /// The method used by the DisplayListFormatter to style the message.
+    /// The method used to write text with formatter
     fn paint(&self, text: &str, f: &mut fmt::Formatter<'_>) -> fmt::Result;
+    /// The method used to write display function with formatter
+    fn paint_fn<'a>(
+        &self,
+        c: Box<dyn FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result + 'a>,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result;
     /// The method used by the DisplayListFormatter to display the message
     /// in bold font.
     fn bold(&self) -> Box<dyn Style>;

--- a/src/stylesheets/color.rs
+++ b/src/stylesheets/color.rs
@@ -1,6 +1,6 @@
-use std::fmt;
+use std::fmt::{self, Display};
 
-use ansi_term::{Color::Fixed, Style as AnsiTermStyle};
+use yansi_term::{Color::Fixed, Style as AnsiTermStyle};
 
 use crate::formatter::style::{Style, StyleClass, Stylesheet};
 
@@ -10,7 +10,15 @@ struct AnsiTermStyleWrapper {
 
 impl Style for AnsiTermStyleWrapper {
     fn paint(&self, text: &str, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.style.paint(text), f)
+        self.style.paint(text).fmt(f)
+    }
+
+    fn paint_fn<'a>(
+        &self,
+        c: Box<dyn FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result + 'a>,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        self.style.paint_fn(c).fmt(f)
     }
 
     fn bold(&self) -> Box<dyn Style> {

--- a/src/stylesheets/no_color.rs
+++ b/src/stylesheets/no_color.rs
@@ -9,6 +9,14 @@ impl Style for NoOpStyle {
         f.write_str(text)
     }
 
+    fn paint_fn<'a>(
+        &self,
+        c: Box<dyn FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result + 'a>,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        c(f)
+    }
+
     fn bold(&self) -> Box<dyn Style> {
         Box::new(NoOpStyle {})
     }

--- a/tests/diff/mod.rs
+++ b/tests/diff/mod.rs
@@ -1,5 +1,5 @@
-use ansi_term::Color::{Black, Green, Red};
 use difference::{Changeset, Difference};
+use yansi_term::Color::{Black, Green, Red};
 
 pub fn get_diff(left: &str, right: &str) -> String {
     let mut output = String::new();


### PR DESCRIPTION
This PR eliminates the need to reallocate while formatting. 
For this I have forked the `ansi_term` library to refactor to `fmt::Display` allowing to introduce flow with a closure that takes the current formatter as argument. 
It will depend on `yansi-term` instead of` ansi_term`, which I will keep.