### PR TITLE
Fix character split when strip code

### DIFF
--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -1,6 +1,7 @@
 use std::{
     cmp,
     fmt::{self, Display, Write},
+    iter::once,
 };
 
 pub mod style;
@@ -217,16 +218,21 @@ impl<'a> DisplayList<'a> {
                     } else {
                         false
                     };
+                    let mut ended = false;
                     let range = text
                         .char_indices()
+                        .chain(once((text.len(), '\0')))
                         .skip(left)
                         .take_while(|(_, ch)| {
+                            if ended {
+                                return false;
+                            }
                             // Make sure that the trimming on the right will fall within the terminal width.
                             // FIXME: `unicode_width` sometimes disagrees with terminals on how wide a `char` is.
                             // For now, just accept that sometimes the code line will be longer than desired.
                             taken += unicode_width::UnicodeWidthChar::width(*ch).unwrap_or(1);
                             if taken > right - left {
-                                return false;
+                                ended = true;
                             }
                             true
                         })
@@ -238,7 +244,7 @@ impl<'a> DisplayList<'a> {
                             }
                         });
 
-                    text[range.0.expect("One character at line")..=range.1].fmt(f)?;
+                    text[range.0.expect("One character at line")..range.1].fmt(f)?;
 
                     if cut_right {
                         // We have stripped some code after the right-most span end, make it clear we did so.

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -218,12 +218,17 @@ impl<'a> DisplayList<'a> {
                     } else {
                         false
                     };
+                    // Specifies that it will end on the next character, so it will return
+                    // until the next one to the final condition.
                     let mut ended = false;
                     let range = text
                         .char_indices()
-                        .chain(once((text.len(), '\0')))
                         .skip(left)
+                        // Complete char iterator with final character
+                        .chain(once((text.len(), '\0')))
+                        // Take until the next one to the final condition
                         .take_while(|(_, ch)| {
+                            // Fast return to iterate over final byte position
                             if ended {
                                 return false;
                             }
@@ -236,6 +241,7 @@ impl<'a> DisplayList<'a> {
                             }
                             true
                         })
+                        // Reduce to start and end byte position
                         .fold((None, 0), |acc, (i, _)| {
                             if acc.0.is_some() {
                                 (acc.0, i)
@@ -244,6 +250,7 @@ impl<'a> DisplayList<'a> {
                             }
                         });
 
+                    // Format text with margins
                     text[range.0.expect("One character at line")..range.1].fmt(f)?;
 
                     if cut_right {

--- a/tests/fixtures/no-color/strip_line_char.toml
+++ b/tests/fixtures/no-color/strip_line_char.toml
@@ -1,0 +1,25 @@
+[title]
+id = "E0308"
+label = "mismatched types"
+annotation_type = "Error"
+
+[[slices]]
+source = "                                                                                                                                                                                    let _: () = 42ñ"
+line_start = 4
+origin = "$DIR/whitespace-trimming.rs"
+
+[[slices.annotations]]
+label = "expected (), found integer"
+annotation_type = "Error"
+range = [192, 194]
+
+[opt]
+color = false
+anonymized_line_numbers = true
+[opt.margin]
+whitespace_left = 180
+span_left = 192
+span_right = 194
+label_right = 221
+column_width = 140
+max_line_len = 195

--- a/tests/fixtures/no-color/strip_line_char.txt
+++ b/tests/fixtures/no-color/strip_line_char.txt
@@ -1,0 +1,6 @@
+error[E0308]: mismatched types
+  --> $DIR/whitespace-trimming.rs:4:193
+   |
+LL | ...                   let _: () = 42ñ
+   |                                   ^^ expected (), found integer
+   |


### PR DESCRIPTION
I had made an error to strip code in margin. In cases such as coverage, it could panic. 