### PR TITLE
Fix display of annotation for double width characters

### DIFF
--- a/src/display_list/from_snippet.rs
+++ b/src/display_list/from_snippet.rs
@@ -409,7 +409,11 @@ fn format_body(
                                 });
                             }
                         } else {
-                            let range = (start - line_start_index, start - line_start_index + 1);
+                            let annotation_start_col = char_widths
+                                .iter()
+                                .take(start - line_start_index)
+                                .sum::<usize>();
+                            let range = (annotation_start_col, annotation_start_col + 1);
                             body.insert(
                                 body_idx + 1,
                                 DisplayLine::Source {
@@ -466,7 +470,11 @@ fn format_body(
                             });
                         }
 
-                        let end_mark = (end - line_start_index).saturating_sub(1);
+                        let end_mark = char_widths
+                            .iter()
+                            .take(end - line_start_index)
+                            .sum::<usize>()
+                            .saturating_sub(1);
                         let range = (end_mark - margin_left, (end_mark + 1) - margin_left);
                         body.insert(
                             body_idx + 1,

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -550,3 +550,31 @@ fn test_i_29() {
 
     assert_eq!(DisplayList::from(snippets).to_string(), expected);
 }
+
+#[test]
+fn test_point_to_double_width_characters() {
+    let snippets = Snippet {
+        slices: vec![snippet::Slice {
+            source: "こんにちは、世界",
+            line_start: 1,
+            origin: Some("<current file>"),
+            annotations: vec![snippet::SourceAnnotation {
+                range: (6, 8),
+                label: "world",
+                annotation_type: snippet::AnnotationType::Error,
+            }],
+            fold: false,
+        }],
+        title: None,
+        footer: vec![],
+        opt: Default::default(),
+    };
+
+    let expected = r#" --> <current file>:1:7
+  |
+1 | こんにちは、世界
+  |             ^^^^ world
+  |"#;
+
+    assert_eq!(DisplayList::from(snippets).to_string(), expected);
+}

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -578,3 +578,33 @@ fn test_point_to_double_width_characters() {
 
     assert_eq!(DisplayList::from(snippets).to_string(), expected);
 }
+
+#[test]
+fn test_point_to_double_width_characters_across_lines() {
+    let snippets = Snippet {
+        slices: vec![snippet::Slice {
+            source: "おはよう\nございます",
+            line_start: 1,
+            origin: Some("<current file>"),
+            annotations: vec![snippet::SourceAnnotation {
+                range: (2, 8),
+                label: "Good morning",
+                annotation_type: snippet::AnnotationType::Error,
+            }],
+            fold: false,
+        }],
+        title: None,
+        footer: vec![],
+        opt: Default::default(),
+    };
+
+    let expected = r#" --> <current file>:1:3
+  |
+1 |   おはよう
+  |  _____^
+2 | | ございます
+  | |______^ Good morning
+  |"#;
+
+    assert_eq!(DisplayList::from(snippets).to_string(), expected);
+}

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -608,3 +608,40 @@ fn test_point_to_double_width_characters_across_lines() {
 
     assert_eq!(DisplayList::from(snippets).to_string(), expected);
 }
+
+#[test]
+fn test_point_to_double_width_characters_multiple() {
+    let snippets = Snippet {
+        slices: vec![snippet::Slice {
+            source: "お寿司\n食べたい🍣",
+            line_start: 1,
+            origin: Some("<current file>"),
+            annotations: vec![
+                snippet::SourceAnnotation {
+                    range: (0, 3),
+                    label: "Sushi1",
+                    annotation_type: snippet::AnnotationType::Error,
+                },
+                snippet::SourceAnnotation {
+                    range: (6, 8),
+                    label: "Sushi2",
+                    annotation_type: snippet::AnnotationType::Note,
+                },
+            ],
+            fold: false,
+        }],
+        title: None,
+        footer: vec![],
+        opt: Default::default(),
+    };
+
+    let expected = r#" --> <current file>:1:1
+  |
+1 | お寿司
+  | ^^^^^^ Sushi1
+2 | 食べたい🍣
+  |     ---- note: Sushi2
+  |"#;
+
+    assert_eq!(DisplayList::from(snippets).to_string(), expected);
+}

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -645,3 +645,31 @@ fn test_point_to_double_width_characters_multiple() {
 
     assert_eq!(DisplayList::from(snippets).to_string(), expected);
 }
+
+#[test]
+fn test_point_to_double_width_characters_mixed() {
+    let snippets = Snippet {
+        slices: vec![snippet::Slice {
+            source: "こんにちは、新しいWorld！",
+            line_start: 1,
+            origin: Some("<current file>"),
+            annotations: vec![snippet::SourceAnnotation {
+                range: (6, 14),
+                label: "New world",
+                annotation_type: snippet::AnnotationType::Error,
+            }],
+            fold: false,
+        }],
+        title: None,
+        footer: vec![],
+        opt: Default::default(),
+    };
+
+    let expected = r#" --> <current file>:1:7
+  |
+1 | こんにちは、新しいWorld！
+  |             ^^^^^^^^^^^ New world
+  |"#;
+
+    assert_eq!(DisplayList::from(snippets).to_string(), expected);
+}


### PR DESCRIPTION
Hi there.
We're using this crate in [denoland/deno_lint](https://github.com/magurotuna/deno_lint) to display pretty diagnostics of the linter. By chance, I found that this crate doesn't work well if the source includes double width characters like:

```ts
const a = "こんにちは";
```

Specifically, if we attempt to point to `は` in this snippet by passing `(15, 16)` as range, annotate-snippets will give us:

```
  |
1 | const a = "こんにちは";
  |                ^
  |
```

where obviously `^` points to the wrong position.
These characters take up twice the size of ordinary characters like the alphabet, so displaying annotation for them requires special handling, which I implemented in this patch.