### PR TITLE
Switch Travis CI URL back to .org

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 `annotate-snippets` is a Rust library for annotation of programming code slices.
 
 [![crates.io](https://img.shields.io/crates/v/annotate-snippets.svg)](https://crates.io/crates/annotate-snippets)
-[![Build Status](https://travis-ci.com/rust-lang/annotate-snippets-rs.svg?branch=master)](https://travis-ci.com/rust-lang/annotate-snippets-rs)
+[![Build Status](https://travis-ci.org/rust-lang/annotate-snippets-rs.svg?branch=master)](https://travis-ci.org/rust-lang/annotate-snippets-rs)
 [![Coverage Status](https://coveralls.io/repos/github/rust-lang/annotate-snippets-rs/badge.svg?branch=master)](https://coveralls.io/github/rust-lang/annotate-snippets-rs?branch=master)
 
 The library helps visualize meta information annotating source code slices.


### PR DESCRIPTION
The .com URL now returns "No Results Found". Not sure if there's a better solution here.