### PR TITLE
Remove parsing of __ in title strings, fixes #53

### DIFF
--- a/src/display_list/from_snippet.rs
+++ b/src/display_list/from_snippet.rs
@@ -53,22 +53,11 @@ fn format_label(
 ) -> Vec<DisplayTextFragment<'_>> {
     let mut result = vec![];
     if let Some(label) = label {
-        for (idx, element) in label.split("__").enumerate() {
-            let element_style = match style {
-                Some(s) => s,
-                None => {
-                    if idx % 2 == 0 {
-                        DisplayTextStyle::Regular
-                    } else {
-                        DisplayTextStyle::Emphasis
-                    }
-                }
-            };
-            result.push(DisplayTextFragment {
-                content: element,
-                style: element_style,
-            });
-        }
+        let element_style = style.unwrap_or(DisplayTextStyle::Regular);
+        result.push(DisplayTextFragment {
+            content: label,
+            style: element_style,
+        });
     }
     result
 }

--- a/tests/dl_from_snippet.rs
+++ b/tests/dl_from_snippet.rs
@@ -262,20 +262,10 @@ fn test_format_label() {
             annotation: dl::Annotation {
                 annotation_type: dl::DisplayAnnotationType::Error,
                 id: None,
-                label: vec![
-                    dl::DisplayTextFragment {
-                        content: "This ",
-                        style: dl::DisplayTextStyle::Regular,
-                    },
-                    dl::DisplayTextFragment {
-                        content: "is",
-                        style: dl::DisplayTextStyle::Emphasis,
-                    },
-                    dl::DisplayTextFragment {
-                        content: " a title",
-                        style: dl::DisplayTextStyle::Regular,
-                    },
-                ],
+                label: vec![dl::DisplayTextFragment {
+                    content: "This __is__ a title",
+                    style: dl::DisplayTextStyle::Regular,
+                }],
             },
             source_aligned: true,
             continuation: false,


### PR DESCRIPTION
In #53 I reported the issue that `__` in titles gets parsed specially. This feature isn't documented anywhere, and doing a bit of git archaeology, I get lost 4 years ago with phrases like "more tests" adding the code. I can't figure out why someone would want this feature, but assume there was a reason when it was added, however, I'm not sure it is still useful. There doesn't seem any way to opt out of this feature, and as a result, error messages containing `__` get dropped (which is super confusing).

In the absence of feedback as the right way to proceed, I've made a diff removing the feature entirely. The alternative would be to document the feature, explain why it's useful, and explain how to avoid it (an alternative API? an escaping scheme?).