### PR TITLE
Show correct line numbers when fold ist set to true, fixes #52

### DIFF
--- a/tests/fixtures/no-color/issue_52.toml
+++ b/tests/fixtures/no-color/issue_52.toml
@@ -1,0 +1,16 @@
+[title]
+annotation_type = "Error"
+
+[[slices]]
+source = """
+
+
+invalid syntax
+"""
+line_start = 1
+origin = "path/to/error.rs"
+fold = true
+[[slices.annotations]]
+label = "error here"
+annotation_type = "Warning"
+range = [2,16]

--- a/tests/fixtures/no-color/issue_52.txt
+++ b/tests/fixtures/no-color/issue_52.txt
@@ -1,0 +1,7 @@
+error
+ --> path/to/error.rs:3:1
+  |
+...
+3 | invalid syntax
+  | -------------- error here
+  |


### PR DESCRIPTION
This pr changes the `format_header` function to use the line number that is already stored in `DisplayLine` instead of (wrongly) recomputing it.
Fixes #52 