### PR TITLE
chore: Update `README.md` example to use `Renderer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,7 @@ Usage
 -----
 
 ```rust
-use annotate_snippets::{
-    display_list::{DisplayList, FormatOptions},
-    snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
-};
+use annotate_snippets::{Annotation, AnnotationType, Renderer, Slice, Snippet, SourceAnnotation};
 
 fn main() {
     let snippet = Snippet {
@@ -58,7 +55,7 @@ fn main() {
                 SourceAnnotation {
                     label: "",
                     annotation_type: AnnotationType::Error,
-                    range: (187, 189),
+                    range: (193, 195),
                 },
                 SourceAnnotation {
                     label: "while parsing this struct",
@@ -67,14 +64,10 @@ fn main() {
                 },
             ],
         }],
-        opt: FormatOptions {
-            color: true,
-            ..Default::default()
-        },
     };
 
-    let dl = DisplayList::from(snippet);
-    println!("{}", dl);
+    let renderer = Renderer::plain();
+    println!("{}", renderer.render(snippet));
 }
 ```
 


### PR DESCRIPTION
In #67 and  #69, I missed updating the `README.md` to use `Renderer`; this PR fixes that.

Note: Once this is merged, I will try to adjust the [`0.10.0`](https://github.com/rust-lang/annotate-snippets-rs/releases/tag/0.10.0) tag to the merge commit, but I am uncertain if I can.