### PR TITLE
fix: Match rustc's colors

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -62,15 +62,30 @@ impl Renderer {
 
     /// Default terminal styling
     pub const fn styled() -> Self {
+        const BRIGHT_BLUE: Style = if cfg!(windows) {
+            AnsiColor::BrightCyan.on_default()
+        } else {
+            AnsiColor::BrightBlue.on_default()
+        };
         Self {
             stylesheet: Stylesheet {
                 error: AnsiColor::BrightRed.on_default().effects(Effects::BOLD),
-                warning: AnsiColor::BrightYellow.on_default().effects(Effects::BOLD),
-                info: AnsiColor::BrightBlue.on_default().effects(Effects::BOLD),
-                note: Style::new().effects(Effects::BOLD),
+                warning: if cfg!(windows) {
+                    AnsiColor::BrightYellow.on_default()
+                } else {
+                    AnsiColor::Yellow.on_default()
+                }
+                .effects(Effects::BOLD),
+                info: BRIGHT_BLUE.effects(Effects::BOLD),
+                note: AnsiColor::BrightGreen.on_default().effects(Effects::BOLD),
                 help: AnsiColor::BrightCyan.on_default().effects(Effects::BOLD),
-                line_no: AnsiColor::BrightBlue.on_default().effects(Effects::BOLD),
-                emphasis: Style::new().effects(Effects::BOLD),
+                line_no: BRIGHT_BLUE.effects(Effects::BOLD),
+                emphasis: if cfg!(windows) {
+                    AnsiColor::BrightWhite.on_default()
+                } else {
+                    Style::new()
+                }
+                .effects(Effects::BOLD),
                 none: Style::new(),
             },
             ..Self::plain()


### PR DESCRIPTION
This PR makes it so that we match `rustc`'s output regarding colors. See [here](https://github.com/rust-lang/rust/blob/e51e98dde6a60637b6a71b8105245b629ac3fe77/compiler/rustc_errors/src/emitter.rs#L2676-L2723) and [here](https://github.com/rust-lang/rust/blob/e51e98dde6a60637b6a71b8105245b629ac3fe77/compiler/rustc_errors/src/lib.rs#L1768-L1787) for `rustc`'s current color implementation.

Note: Where `rustc` uses `set_intense(true)`, that is the same as `Bright<color>` in `anstyle`.

Note: Most things are `BOLD` as `rustc` eventually sets most things bol (see the first link).

