### PR TITLE
fix: Allow highlighting one past end

### DIFF
--- a/src/renderer/display_list.rs
+++ b/src/renderer/display_list.rs
@@ -934,14 +934,15 @@ fn format_body(
 ) -> Vec<DisplayLine<'_>> {
     let source_len = slice.source.chars().count();
     if let Some(bigger) = slice.annotations.iter().find_map(|x| {
-        if source_len < x.range.1 {
+        // Allow highlighting one past the last character in the source.
+        if source_len + 1 < x.range.1 {
             Some(x.range)
         } else {
             None
         }
     }) {
         panic!(
-            "SourceAnnotation range `{:?}` is bigger than source length `{}`",
+            "SourceAnnotation range `{:?}` is beyond the end of buffer `{}`",
             bigger, source_len
         )
     }
@@ -1479,7 +1480,7 @@ mod tests {
             footer: vec![],
             slices: vec![snippet::Slice {
                 annotations: vec![snippet::SourceAnnotation {
-                    range: (0, source.len() + 1),
+                    range: (0, source.len() + 2),
                     label,
                     annotation_type: snippet::AnnotationType::Error,
                 }],

--- a/tests/fixtures/no-color/one_past.toml
+++ b/tests/fixtures/no-color/one_past.toml
@@ -1,0 +1,12 @@
+[snippet.title]
+label = "expected `.`, `=`"
+annotation_type = "Error"
+
+[[snippet.slices]]
+source = "asdf"
+line_start = 1
+origin = "Cargo.toml"
+[[snippet.slices.annotations]]
+label = ""
+annotation_type = "Error"
+range = [4, 5]

--- a/tests/fixtures/no-color/one_past.txt
+++ b/tests/fixtures/no-color/one_past.txt
@@ -1,0 +1,6 @@
+error: expected `.`, `=`
+ --> Cargo.toml:1:5
+  |
+1 | asdf
+  |     ^
+  |


### PR DESCRIPTION
Being able to highlight one past the end of the given source if the source provided is from `.lines()` (and got its newline stripped) or is the last line in the file and you want to highlight the next "character". `cargo` needs something to do this, so it doesn't have to remember to add a new line in either scenario.