### PR TITLE
Annotate snippets 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 
+## [0.10.1] — January 4, 2024
+
+### Fixed
+
+ - Match `rustc`'s colors [#73](https://github.com/rust-lang/annotate-snippets-rs/pull/73)
+ - Allow highlighting one past the end of `source` [#74](https://github.com/rust-lang/annotate-snippets-rs/pull/74)
+
+### Compatibility
+
+- Set the minimum supported Rust version to `1.73.0` [#71](https://github.com/rust-lang/annotate-snippets-rs/pull/71)
+
+
 ## [0.10.0] - December 12, 2023
 
 ### Added
@@ -73,7 +85,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Update the syntax to Rust 2018 idioms. (#4)
 
 <!-- next-url -->
-[Unreleased]: https://github.com/rust-lang/annotate-snippets-rs/compare/0.10.0...HEAD
+[Unreleased]: https://github.com/rust-lang/annotate-snippets-rs/compare/0.10.1...HEAD
+[0.10.1]: https://github.com/rust-lang/annotate-snippets-rs/compare/0.10.0...0.10.1
 [0.10.0]: https://github.com/rust-lang/annotate-snippets-rs/compare/0.9.2...0.10.0
 [0.9.2]: https://github.com/rust-lang/annotate-snippets-rs/compare/0.9.1...0.9.2
 [0.9.1]: https://github.com/rust-lang/annotate-snippets-rs/compare/0.9.0...0.9.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "annotate-snippets"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anstyle",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annotate-snippets"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 rust-version = "1.73"  # MSRV
 authors = ["Zibi Braniecki <gandalf@mozilla.com>"]


### PR DESCRIPTION
This PR updates the `CHANGELOG.md` in preparation for `0.10.1`, as well as bumps the version number to `0.10.1`.