### PR TITLE
feat: Add feature for testing colored output easier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,4 @@ harness = false
 
 [features]
 default = []
+testing-colors = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,15 @@
 //! options, such as color, or margins.
 //!
 //! Finally, `impl Display` into a final `String` output.
+//!
+//! # features
+//! - `testing-colors` - Makes [Renderer::styled] colors OS independent, which
+//! allows for easier testing when testing colored output. It should be added as
+//! a feature in `[dev-dependencies]`, which can be done with the following command:
+//! ```text
+//! cargo add annotate-snippets --dev --feature testing-colors
+//! ```
+//!
 
 pub mod renderer;
 mod snippet;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -61,8 +61,12 @@ impl Renderer {
     }
 
     /// Default terminal styling
+    ///
+    /// # Note
+    /// When testing styled terminal output, see the [`testing-colors` feature](crate#features)
     pub const fn styled() -> Self {
-        const BRIGHT_BLUE: Style = if cfg!(windows) {
+        const USE_WINDOWS_COLORS: bool = cfg!(windows) && !cfg!(feature = "testing-colors");
+        const BRIGHT_BLUE: Style = if USE_WINDOWS_COLORS {
             AnsiColor::BrightCyan.on_default()
         } else {
             AnsiColor::BrightBlue.on_default()
@@ -70,7 +74,7 @@ impl Renderer {
         Self {
             stylesheet: Stylesheet {
                 error: AnsiColor::BrightRed.on_default().effects(Effects::BOLD),
-                warning: if cfg!(windows) {
+                warning: if USE_WINDOWS_COLORS {
                     AnsiColor::BrightYellow.on_default()
                 } else {
                     AnsiColor::Yellow.on_default()
@@ -80,7 +84,7 @@ impl Renderer {
                 note: AnsiColor::BrightGreen.on_default().effects(Effects::BOLD),
                 help: AnsiColor::BrightCyan.on_default().effects(Effects::BOLD),
                 line_no: BRIGHT_BLUE.effects(Effects::BOLD),
-                emphasis: if cfg!(windows) {
+                emphasis: if USE_WINDOWS_COLORS {
                     AnsiColor::BrightWhite.on_default()
                 } else {
                     Style::new()


### PR DESCRIPTION
In [cargo#13461](https://github.com/rust-lang/cargo/pull/13461#discussion_r1501136340), it was noticed that the default colors being platform-specific made testing colored output quite challenging. This PR adds a feature that makes the colors the same across the board, which should be enabled when testing colored output.