### PR TITLE
fix!: Take in byte spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,7 @@ dependencies = [
  "criterion",
  "difference",
  "glob",
+ "itertools 0.12.1",
  "serde",
  "snapbox",
  "toml",
@@ -241,7 +242,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -262,7 +263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -431,6 +432,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 anstyle = "1.0.4"
+itertools = "0.12.1"
 unicode-width = "0.1.11"
 
 [dev-dependencies]

--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -38,12 +38,12 @@ fn create_snippet(renderer: Renderer) {
                 SourceAnnotation {
                     label: "expected `Option<String>` because of return type",
                     annotation_type: AnnotationType::Warning,
-                    range: (5, 19),
+                    range: 5..19,
                 },
                 SourceAnnotation {
                     label: "expected enum `std::option::Option`",
                     annotation_type: AnnotationType::Error,
-                    range: (26, 724),
+                    range: 26..724,
                 },
             ],
         }],

--- a/examples/expected_type.rs
+++ b/examples/expected_type.rs
@@ -20,12 +20,12 @@ fn main() {
                 SourceAnnotation {
                     label: "",
                     annotation_type: AnnotationType::Error,
-                    range: (193, 195),
+                    range: 193..195,
                 },
                 SourceAnnotation {
                     label: "while parsing this struct",
                     annotation_type: AnnotationType::Info,
-                    range: (34, 50),
+                    range: 34..50,
                 },
             ],
         }],

--- a/examples/footer.rs
+++ b/examples/footer.rs
@@ -21,7 +21,7 @@ fn main() {
             fold: false,
             annotations: vec![SourceAnnotation {
                 label: "expected struct `annotate_snippets::snippet::Slice`, found reference",
-                range: (21, 24),
+                range: 21..24,
                 annotation_type: AnnotationType::Error,
             }],
         }],

--- a/examples/format.rs
+++ b/examples/format.rs
@@ -32,12 +32,12 @@ fn main() {
                 SourceAnnotation {
                     label: "expected `Option<String>` because of return type",
                     annotation_type: AnnotationType::Warning,
-                    range: (5, 19),
+                    range: 5..19,
                 },
                 SourceAnnotation {
                     label: "expected enum `std::option::Option`",
                     annotation_type: AnnotationType::Error,
-                    range: (26, 724),
+                    range: 26..724,
                 },
             ],
         }],

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -31,6 +31,8 @@
 //! };
 //! ```
 
+use std::ops::Range;
+
 /// Primary structure provided for formatting
 #[derive(Debug, Default)]
 pub struct Snippet<'a> {
@@ -71,7 +73,7 @@ pub enum AnnotationType {
 #[derive(Debug)]
 pub struct SourceAnnotation<'a> {
     /// The byte range of the annotation in the `source` string
-    pub range: (usize, usize),
+    pub range: Range<usize>,
     pub label: &'a str,
     pub annotation_type: AnnotationType,
 }

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -70,6 +70,7 @@ pub enum AnnotationType {
 /// An annotation for a `Slice`.
 #[derive(Debug)]
 pub struct SourceAnnotation<'a> {
+    /// The byte range of the annotation in the `source` string
     pub range: (usize, usize),
     pub label: &'a str,
     pub annotation_type: AnnotationType,

--- a/tests/fixtures/deserialize.rs
+++ b/tests/fixtures/deserialize.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Deserializer, Serialize};
+use std::ops::Range;
 
 use annotate_snippets::{
     renderer::Margin, Annotation, AnnotationType, Renderer, Slice, Snippet, SourceAnnotation,
@@ -122,7 +123,7 @@ where
 #[derive(Serialize, Deserialize)]
 #[serde(remote = "SourceAnnotation")]
 pub struct SourceAnnotationDef<'a> {
-    pub range: (usize, usize),
+    pub range: Range<usize>,
     #[serde(borrow)]
     pub label: &'a str,
     #[serde(with = "AnnotationTypeDef")]

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -14,7 +14,7 @@ fn test_i_29() {
             line_start: 1,
             origin: Some("<current file>"),
             annotations: vec![SourceAnnotation {
-                range: (19, 23),
+                range: 19..23,
                 label: "oops",
                 annotation_type: AnnotationType::Error,
             }],
@@ -41,7 +41,7 @@ fn test_point_to_double_width_characters() {
             line_start: 1,
             origin: Some("<current file>"),
             annotations: vec![SourceAnnotation {
-                range: (12, 16),
+                range: 12..16,
                 label: "world",
                 annotation_type: AnnotationType::Error,
             }],
@@ -69,7 +69,7 @@ fn test_point_to_double_width_characters_across_lines() {
             line_start: 1,
             origin: Some("<current file>"),
             annotations: vec![SourceAnnotation {
-                range: (4, 15),
+                range: 4..15,
                 label: "Good morning",
                 annotation_type: AnnotationType::Error,
             }],
@@ -100,12 +100,12 @@ fn test_point_to_double_width_characters_multiple() {
             origin: Some("<current file>"),
             annotations: vec![
                 SourceAnnotation {
-                    range: (0, 6),
+                    range: 0..6,
                     label: "Sushi1",
                     annotation_type: AnnotationType::Error,
                 },
                 SourceAnnotation {
-                    range: (11, 15),
+                    range: 11..15,
                     label: "Sushi2",
                     annotation_type: AnnotationType::Note,
                 },
@@ -136,7 +136,7 @@ fn test_point_to_double_width_characters_mixed() {
             line_start: 1,
             origin: Some("<current file>"),
             annotations: vec![SourceAnnotation {
-                range: (12, 23),
+                range: 12..23,
                 label: "New world",
                 annotation_type: AnnotationType::Error,
             }],

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -41,7 +41,7 @@ fn test_point_to_double_width_characters() {
             line_start: 1,
             origin: Some("<current file>"),
             annotations: vec![SourceAnnotation {
-                range: (6, 8),
+                range: (12, 16),
                 label: "world",
                 annotation_type: AnnotationType::Error,
             }],
@@ -69,7 +69,7 @@ fn test_point_to_double_width_characters_across_lines() {
             line_start: 1,
             origin: Some("<current file>"),
             annotations: vec![SourceAnnotation {
-                range: (2, 8),
+                range: (4, 15),
                 label: "Good morning",
                 annotation_type: AnnotationType::Error,
             }],
@@ -100,12 +100,12 @@ fn test_point_to_double_width_characters_multiple() {
             origin: Some("<current file>"),
             annotations: vec![
                 SourceAnnotation {
-                    range: (0, 3),
+                    range: (0, 6),
                     label: "Sushi1",
                     annotation_type: AnnotationType::Error,
                 },
                 SourceAnnotation {
-                    range: (6, 8),
+                    range: (11, 15),
                     label: "Sushi2",
                     annotation_type: AnnotationType::Note,
                 },
@@ -136,7 +136,7 @@ fn test_point_to_double_width_characters_mixed() {
             line_start: 1,
             origin: Some("<current file>"),
             annotations: vec![SourceAnnotation {
-                range: (6, 14),
+                range: (12, 23),
                 label: "New world",
                 annotation_type: AnnotationType::Error,
             }],


### PR DESCRIPTION
BREAKING CHANGE: This switches from char spans to byte spans

This PR is a draft implementation to address #77. While I think I fixed every issue in moving from char spans to byte spans, I am not entirely certain. I may look into adding more tests to ensure we are doing the write thing. This also doesn't address the fact that people could pass in char spans when updating the version, not realizing the change. We could do something to make it more apparent but I am not sure what that would be.