### PR TITLE
feat!: Move to builder pattern for snippet creation

### DIFF
--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -4,12 +4,10 @@ extern crate criterion;
 
 use criterion::{black_box, Criterion};
 
-use annotate_snippets::{Annotation, AnnotationType, Renderer, Slice, Snippet, SourceAnnotation};
+use annotate_snippets::{Label, Renderer, Slice, Snippet};
 
 fn create_snippet(renderer: Renderer) {
-    let snippet = Snippet {
-        slices: vec![Slice {
-            source: r#") -> Option<String> {
+    let source = r#") -> Option<String> {
     for ann in annotations {
         match (ann.range.0, ann.range.1) {
             (None, None) => continue,
@@ -30,30 +28,15 @@ fn create_snippet(renderer: Renderer) {
             }
             _ => continue,
         }
-    }"#,
-            line_start: 51,
-            origin: Some("src/format.rs"),
-            fold: false,
-            annotations: vec![
-                SourceAnnotation {
-                    label: "expected `Option<String>` because of return type",
-                    annotation_type: AnnotationType::Warning,
-                    range: 5..19,
-                },
-                SourceAnnotation {
-                    label: "expected enum `std::option::Option`",
-                    annotation_type: AnnotationType::Error,
-                    range: 26..724,
-                },
-            ],
-        }],
-        title: Some(Annotation {
-            label: Some("mismatched types"),
-            id: Some("E0308"),
-            annotation_type: AnnotationType::Error,
-        }),
-        footer: vec![],
-    };
+    }"#;
+    let snippet = Snippet::error("mismatched types").id("E0308").slice(
+        Slice::new(source, 51)
+            .origin("src/format.rs")
+            .annotation(
+                Label::warning("expected `Option<String>` because of return type").span(5..19),
+            )
+            .annotation(Label::error("expected enum `std::option::Option`").span(26..724)),
+    );
 
     let _result = renderer.render(snippet).to_string();
 }

--- a/examples/expected_type.rs
+++ b/examples/expected_type.rs
@@ -1,35 +1,22 @@
-use annotate_snippets::{Annotation, AnnotationType, Renderer, Slice, Snippet, SourceAnnotation};
+use annotate_snippets::{Label, Renderer, Slice, Snippet};
 
 fn main() {
-    let snippet = Snippet {
-        title: Some(Annotation {
-            label: Some("expected type, found `22`"),
-            id: None,
-            annotation_type: AnnotationType::Error,
-        }),
-        footer: vec![],
-        slices: vec![Slice {
-            source: r#"                annotations: vec![SourceAnnotation {
+    let source = r#"                annotations: vec![SourceAnnotation {
                 label: "expected struct `annotate_snippets::snippet::Slice`, found reference"
                     ,
-                range: <22, 25>,"#,
-            line_start: 26,
-            origin: Some("examples/footer.rs"),
-            fold: true,
-            annotations: vec![
-                SourceAnnotation {
-                    label: "",
-                    annotation_type: AnnotationType::Error,
-                    range: 193..195,
-                },
-                SourceAnnotation {
-                    label: "while parsing this struct",
-                    annotation_type: AnnotationType::Info,
-                    range: 34..50,
-                },
-            ],
-        }],
-    };
+                range: <22, 25>,"#;
+    let snippet = Snippet::error("expected type, found `22`").slice(
+        Slice::new(source, 26)
+            .origin("examples/footer.rs")
+            .fold(true)
+            .annotation(
+                Label::error(
+                    "expected struct `annotate_snippets::snippet::Slice`, found reference",
+                )
+                .span(193..195),
+            )
+            .annotation(Label::info("while parsing this struct").span(34..50)),
+    );
 
     let renderer = Renderer::plain();
     println!("{}", renderer.render(snippet));

--- a/examples/footer.rs
+++ b/examples/footer.rs
@@ -1,31 +1,21 @@
-use annotate_snippets::{Annotation, AnnotationType, Renderer, Slice, Snippet, SourceAnnotation};
+use annotate_snippets::{Label, Renderer, Slice, Snippet};
 
 fn main() {
-    let snippet = Snippet {
-        title: Some(Annotation {
-            label: Some("mismatched types"),
-            id: Some("E0308"),
-            annotation_type: AnnotationType::Error,
-        }),
-        footer: vec![Annotation {
-            label: Some(
-                "expected type: `snippet::Annotation`\n   found type: `__&__snippet::Annotation`",
-            ),
-            id: None,
-            annotation_type: AnnotationType::Note,
-        }],
-        slices: vec![Slice {
-            source: "        slices: vec![\"A\",",
-            line_start: 13,
-            origin: Some("src/multislice.rs"),
-            fold: false,
-            annotations: vec![SourceAnnotation {
-                label: "expected struct `annotate_snippets::snippet::Slice`, found reference",
-                range: 21..24,
-                annotation_type: AnnotationType::Error,
-            }],
-        }],
-    };
+    let snippet = Snippet::error("mismatched types")
+        .id("E0308")
+        .slice(
+            Slice::new("        slices: vec![\"A\",", 13)
+                .origin("src/multislice.rs")
+                .annotation(
+                    Label::error(
+                        "expected struct `annotate_snippets::snippet::Slice`, found reference",
+                    )
+                    .span(21..24),
+                ),
+        )
+        .footer(Label::note(
+            "expected type: `snippet::Annotation`\n   found type: `__&__snippet::Annotation`",
+        ));
 
     let renderer = Renderer::plain();
     println!("{}", renderer.render(snippet));

--- a/examples/format.rs
+++ b/examples/format.rs
@@ -1,9 +1,7 @@
-use annotate_snippets::{Annotation, AnnotationType, Renderer, Slice, Snippet, SourceAnnotation};
+use annotate_snippets::{Label, Renderer, Slice, Snippet};
 
 fn main() {
-    let snippet = Snippet {
-        slices: vec![Slice {
-            source: r#") -> Option<String> {
+    let source = r#") -> Option<String> {
     for ann in annotations {
         match (ann.range.0, ann.range.1) {
             (None, None) => continue,
@@ -24,30 +22,15 @@ fn main() {
             }
             _ => continue,
         }
-    }"#,
-            line_start: 51,
-            origin: Some("src/format.rs"),
-            fold: false,
-            annotations: vec![
-                SourceAnnotation {
-                    label: "expected `Option<String>` because of return type",
-                    annotation_type: AnnotationType::Warning,
-                    range: 5..19,
-                },
-                SourceAnnotation {
-                    label: "expected enum `std::option::Option`",
-                    annotation_type: AnnotationType::Error,
-                    range: 26..724,
-                },
-            ],
-        }],
-        title: Some(Annotation {
-            label: Some("mismatched types"),
-            id: Some("E0308"),
-            annotation_type: AnnotationType::Error,
-        }),
-        footer: vec![],
-    };
+    }"#;
+    let snippet = Snippet::error("mismatched types").id("E0308").slice(
+        Slice::new(source, 51)
+            .origin("src/format.rs")
+            .annotation(
+                Label::warning("expected `Option<String>` because of return type").span(5..19),
+            )
+            .annotation(Label::error("expected enum `std::option::Option`").span(26..724)),
+    );
 
     let renderer = Renderer::plain();
     println!("{}", renderer.render(snippet));

--- a/examples/multislice.rs
+++ b/examples/multislice.rs
@@ -1,30 +1,9 @@
-use annotate_snippets::{Annotation, AnnotationType, Renderer, Slice, Snippet};
+use annotate_snippets::{Renderer, Slice, Snippet};
 
 fn main() {
-    let snippet = Snippet {
-        title: Some(Annotation {
-            label: Some("mismatched types"),
-            id: None,
-            annotation_type: AnnotationType::Error,
-        }),
-        footer: vec![],
-        slices: vec![
-            Slice {
-                source: "Foo",
-                line_start: 51,
-                origin: Some("src/format.rs"),
-                fold: false,
-                annotations: vec![],
-            },
-            Slice {
-                source: "Faa",
-                line_start: 129,
-                origin: Some("src/display.rs"),
-                fold: false,
-                annotations: vec![],
-            },
-        ],
-    };
+    let snippet = Snippet::error("mismatched types")
+        .slice(Slice::new("Foo", 51).origin("src/format.rs"))
+        .slice(Slice::new("Faa", 129).origin("src/display.rs"));
 
     let renderer = Renderer::plain();
     println!("{}", renderer.render(snippet));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,6 @@
 //! ```text
 //! cargo add annotate-snippets --dev --feature testing-colors
 //! ```
-//!
 
 pub mod renderer;
 mod snippet;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -2,31 +2,10 @@
 //!
 //! # Example
 //! ```
-//! use annotate_snippets::{Annotation, AnnotationType, Renderer, Slice, Snippet};
-//! let snippet = Snippet {
-//!     title: Some(Annotation {
-//!         label: Some("mismatched types"),
-//!         id: None,
-//!         annotation_type: AnnotationType::Error,
-//!     }),
-//!     footer: vec![],
-//!     slices: vec![
-//!         Slice {
-//!             source: "Foo",
-//!             line_start: 51,
-//!             origin: Some("src/format.rs"),
-//!             fold: false,
-//!             annotations: vec![],
-//!         },
-//!         Slice {
-//!             source: "Faa",
-//!             line_start: 129,
-//!             origin: Some("src/display.rs"),
-//!             fold: false,
-//!             annotations: vec![],
-//!         },
-//!     ],
-//!  };
+//! use annotate_snippets::{Renderer, Slice, Snippet};
+//! let snippet = Snippet::error("mismatched types")
+//!     .slice(Slice::new("Foo", 51).origin("src/format.rs"))
+//!     .slice(Slice::new("Faa", 129).origin("src/display.rs"));
 //!
 //!  let renderer = Renderer::styled();
 //!  println!("{}", renderer.render(snippet));

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -5,40 +5,121 @@
 //! ```
 //! use annotate_snippets::*;
 //!
-//! Snippet {
-//!     title: Some(Annotation {
-//!         label: Some("mismatched types"),
-//!         id: None,
-//!         annotation_type: AnnotationType::Error,
-//!     }),
-//!     footer: vec![],
-//!     slices: vec![
-//!         Slice {
-//!             source: "Foo",
-//!             line_start: 51,
-//!             origin: Some("src/format.rs"),
-//!             fold: false,
-//!             annotations: vec![],
-//!         },
-//!         Slice {
-//!             source: "Faa",
-//!             line_start: 129,
-//!             origin: Some("src/display.rs"),
-//!             fold: false,
-//!             annotations: vec![],
-//!         },
-//!     ],
-//! };
+//! Snippet::error("mismatched types")
+//!     .slice(Slice::new("Foo", 51).origin("src/format.rs"))
+//!     .slice(Slice::new("Faa", 129).origin("src/display.rs"));
 //! ```
 
 use std::ops::Range;
 
 /// Primary structure provided for formatting
-#[derive(Debug, Default)]
 pub struct Snippet<'a> {
-    pub title: Option<Annotation<'a>>,
-    pub footer: Vec<Annotation<'a>>,
-    pub slices: Vec<Slice<'a>>,
+    pub(crate) title: Label<'a>,
+    pub(crate) id: Option<&'a str>,
+    pub(crate) slices: Vec<Slice<'a>>,
+    pub(crate) footer: Vec<Label<'a>>,
+}
+
+impl<'a> Snippet<'a> {
+    pub fn title(title: Label<'a>) -> Self {
+        Self {
+            title,
+            id: None,
+            slices: vec![],
+            footer: vec![],
+        }
+    }
+
+    pub fn error(title: &'a str) -> Self {
+        Self::title(Label::error(title))
+    }
+
+    pub fn warning(title: &'a str) -> Self {
+        Self::title(Label::warning(title))
+    }
+
+    pub fn info(title: &'a str) -> Self {
+        Self::title(Label::info(title))
+    }
+
+    pub fn note(title: &'a str) -> Self {
+        Self::title(Label::note(title))
+    }
+
+    pub fn help(title: &'a str) -> Self {
+        Self::title(Label::help(title))
+    }
+
+    pub fn id(mut self, id: &'a str) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    pub fn slice(mut self, slice: Slice<'a>) -> Self {
+        self.slices.push(slice);
+        self
+    }
+
+    pub fn footer(mut self, footer: Label<'a>) -> Self {
+        self.footer.push(footer);
+        self
+    }
+}
+
+pub struct Label<'a> {
+    pub(crate) annotation_type: AnnotationType,
+    pub(crate) label: &'a str,
+}
+
+impl<'a> Label<'a> {
+    pub fn new(annotation_type: AnnotationType, label: &'a str) -> Self {
+        Self {
+            annotation_type,
+            label,
+        }
+    }
+    pub fn error(label: &'a str) -> Self {
+        Self::new(AnnotationType::Error, label)
+    }
+
+    pub fn warning(label: &'a str) -> Self {
+        Self::new(AnnotationType::Warning, label)
+    }
+
+    pub fn info(label: &'a str) -> Self {
+        Self::new(AnnotationType::Info, label)
+    }
+
+    pub fn note(label: &'a str) -> Self {
+        Self::new(AnnotationType::Note, label)
+    }
+
+    pub fn help(label: &'a str) -> Self {
+        Self::new(AnnotationType::Help, label)
+    }
+
+    pub fn label(mut self, label: &'a str) -> Self {
+        self.label = label;
+        self
+    }
+
+    /// Create a [SourceAnnotation] with the given span for a [Slice]
+    pub fn span(&self, span: Range<usize>) -> SourceAnnotation<'a> {
+        SourceAnnotation {
+            range: span,
+            label: self.label,
+            annotation_type: self.annotation_type,
+        }
+    }
+}
+
+impl From<AnnotationType> for Label<'_> {
+    fn from(annotation_type: AnnotationType) -> Self {
+        Label {
+            annotation_type,
+            label: "",
+        }
+    }
 }
 
 /// Structure containing the slice of text to be annotated and
@@ -46,15 +127,39 @@ pub struct Snippet<'a> {
 ///
 /// One `Slice` is meant to represent a single, continuous,
 /// slice of source code that you want to annotate.
-#[derive(Debug)]
 pub struct Slice<'a> {
-    pub source: &'a str,
-    pub line_start: usize,
-    pub origin: Option<&'a str>,
-    pub annotations: Vec<SourceAnnotation<'a>>,
-    /// If set explicitly to `true`, the snippet will fold
-    /// parts of the slice that don't contain any annotations.
-    pub fold: bool,
+    pub(crate) source: &'a str,
+    pub(crate) line_start: usize,
+    pub(crate) origin: Option<&'a str>,
+    pub(crate) annotations: Vec<SourceAnnotation<'a>>,
+    pub(crate) fold: bool,
+}
+
+impl<'a> Slice<'a> {
+    pub fn new(source: &'a str, line_start: usize) -> Self {
+        Self {
+            source,
+            line_start,
+            origin: None,
+            annotations: vec![],
+            fold: false,
+        }
+    }
+
+    pub fn origin(mut self, origin: &'a str) -> Self {
+        self.origin = Some(origin);
+        self
+    }
+
+    pub fn annotation(mut self, annotation: SourceAnnotation<'a>) -> Self {
+        self.annotations.push(annotation);
+        self
+    }
+
+    pub fn fold(mut self, fold: bool) -> Self {
+        self.fold = fold;
+        self
+    }
 }
 
 /// Types of annotations.
@@ -70,19 +175,12 @@ pub enum AnnotationType {
 }
 
 /// An annotation for a `Slice`.
+///
+/// This gets created by [Label::span].
 #[derive(Debug)]
 pub struct SourceAnnotation<'a> {
     /// The byte range of the annotation in the `source` string
-    pub range: Range<usize>,
-    pub label: &'a str,
-    pub annotation_type: AnnotationType,
-}
-
-/// An annotation for a `Snippet`.
-#[derive(Debug)]
-pub struct Annotation<'a> {
-    /// Identifier of the annotation. Usually error code like "E0308".
-    pub id: Option<&'a str>,
-    pub label: Option<&'a str>,
-    pub annotation_type: AnnotationType,
+    pub(crate) range: Range<usize>,
+    pub(crate) label: &'a str,
+    pub(crate) annotation_type: AnnotationType,
 }

--- a/tests/fixtures/no-color/issue_52.toml
+++ b/tests/fixtures/no-color/issue_52.toml
@@ -1,5 +1,6 @@
 [snippet.title]
 annotation_type = "Error"
+label = ""
 
 [[snippet.slices]]
 source = """

--- a/tests/fixtures/no-color/multiline_annotation.toml
+++ b/tests/fixtures/no-color/multiline_annotation.toml
@@ -34,7 +34,7 @@ range = [5, 19]
 label = "expected enum `std::option::Option`, found ()"
 annotation_type = "Error"
 range = [22, 766]
-[snippet.title]
-label = "mismatched types"
+
+[snippet]
+title = { annotation_type = "Error", label = "mismatched types" }
 id = "E0308"
-annotation_type =  "Error"

--- a/tests/fixtures/no-color/multiline_annotation2.toml
+++ b/tests/fixtures/no-color/multiline_annotation2.toml
@@ -12,7 +12,6 @@ label = "missing fields `lineno`, `content`"
 annotation_type = "Error"
 range = [31, 128]
 
-[snippet.title]
-label = "pattern does not mention fields `lineno`, `content`"
+[snippet]
+title = { annotation_type = "Error", label = "pattern does not mention fields `lineno`, `content`" }
 id = "E0027"
-annotation_type = "Error"

--- a/tests/fixtures/no-color/multiline_annotation3.toml
+++ b/tests/fixtures/no-color/multiline_annotation3.toml
@@ -12,7 +12,6 @@ label = "this should not be on separate lines"
 annotation_type = "Error"
 range = [11, 18]
 
-[snippet.title]
-label = "spacing error found"
+[snippet]
+title = { annotation_type = "Error", label = "spacing error found" }
 id = "E####"
-annotation_type = "Error"

--- a/tests/fixtures/no-color/multiple_annotations.svg
+++ b/tests/fixtures/no-color/multiple_annotations.svg
@@ -1,4 +1,4 @@
-<svg width="768px" height="272px" xmlns="http://www.w3.org/2000/svg">
+<svg width="768px" height="290px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -16,33 +16,35 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>    |</tspan>
+    <tspan x="10px" y="28px"><tspan>error</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan> 96 | fn add_title_line(result: &amp;mut Vec&lt;String&gt;, main_annotation: Option&lt;&amp;Annotation&gt;) {</tspan>
+    <tspan x="10px" y="46px"><tspan>    |</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan> 97 |     if let Some(annotation) = main_annotation {</tspan>
+    <tspan x="10px" y="64px"><tspan> 96 | fn add_title_line(result: &amp;mut Vec&lt;String&gt;, main_annotation: Option&lt;&amp;Annotation&gt;) {</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>    |                 ^^^^^^^^^^ Variable defined here</tspan>
+    <tspan x="10px" y="82px"><tspan> 97 |     if let Some(annotation) = main_annotation {</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan> 98 |         result.push(format_title_line(</tspan>
+    <tspan x="10px" y="100px"><tspan>    |                 ^^^^^^^^^^ Variable defined here</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan> 99 |             &amp;annotation.annotation_type,</tspan>
+    <tspan x="10px" y="118px"><tspan> 98 |         result.push(format_title_line(</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>    |              ^^^^^^^^^^ Referenced here</tspan>
+    <tspan x="10px" y="136px"><tspan> 99 |             &amp;annotation.annotation_type,</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>100 |             None,</tspan>
+    <tspan x="10px" y="154px"><tspan>    |              ^^^^^^^^^^ Referenced here</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>101 |             &amp;annotation.label,</tspan>
+    <tspan x="10px" y="172px"><tspan>100 |             None,</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>    |              ^^^^^^^^^^ Referenced again here</tspan>
+    <tspan x="10px" y="190px"><tspan>101 |             &amp;annotation.label,</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>102 |         ));</tspan>
+    <tspan x="10px" y="208px"><tspan>    |              ^^^^^^^^^^ Referenced again here</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>103 |     }</tspan>
+    <tspan x="10px" y="226px"><tspan>102 |         ));</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>104 | }</tspan>
+    <tspan x="10px" y="244px"><tspan>103 |     }</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>    |</tspan>
+    <tspan x="10px" y="262px"><tspan>104 | }</tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan>    |</tspan>
 </tspan>
   </text>
 

--- a/tests/fixtures/no-color/multiple_annotations.toml
+++ b/tests/fixtures/no-color/multiple_annotations.toml
@@ -1,3 +1,7 @@
+[snippet.title]
+annotation_type = "Error"
+label = ""
+
 [[snippet.slices]]
 source = """
 fn add_title_line(result: &mut Vec<String>, main_annotation: Option<&Annotation>) {

--- a/tests/fixtures/no-color/strip_line.toml
+++ b/tests/fixtures/no-color/strip_line.toml
@@ -1,7 +1,6 @@
-[snippet.title]
+[snippet]
+title = { annotation_type = "Error", label = "mismatched types" }
 id = "E0308"
-label = "mismatched types"
-annotation_type = "Error"
 
 [[snippet.slices]]
 source = "                                                                                                                                                                                    let _: () = 42;"

--- a/tests/fixtures/no-color/strip_line_char.toml
+++ b/tests/fixtures/no-color/strip_line_char.toml
@@ -1,7 +1,6 @@
-[snippet.title]
+[snippet]
+title = { annotation_type = "Error", label = "mismatched types" }
 id = "E0308"
-label = "mismatched types"
-annotation_type = "Error"
 
 [[snippet.slices]]
 source = "                                                                                                                                                                                    let _: () = 42ñ"

--- a/tests/fixtures/no-color/strip_line_non_ws.toml
+++ b/tests/fixtures/no-color/strip_line_non_ws.toml
@@ -1,7 +1,6 @@
-[snippet.title]
+[snippet]
+title = { annotation_type = "Error", label = "mismatched types" }
 id = "E0308"
-label = "mismatched types"
-annotation_type = "Error"
 
 [[snippet.slices]]
 source = "    let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = 42; let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = ();"

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -1,26 +1,13 @@
-use annotate_snippets::{Annotation, AnnotationType, Renderer, Slice, Snippet, SourceAnnotation};
+use annotate_snippets::{Label, Renderer, Slice, Snippet};
 
 #[test]
 fn test_i_29() {
-    let snippets = Snippet {
-        title: Some(Annotation {
-            id: None,
-            label: Some("oops"),
-            annotation_type: AnnotationType::Error,
-        }),
-        footer: vec![],
-        slices: vec![Slice {
-            source: "First line\r\nSecond oops line",
-            line_start: 1,
-            origin: Some("<current file>"),
-            annotations: vec![SourceAnnotation {
-                range: 19..23,
-                label: "oops",
-                annotation_type: AnnotationType::Error,
-            }],
-            fold: true,
-        }],
-    };
+    let snippets = Snippet::error("oops").slice(
+        Slice::new("First line\r\nSecond oops line", 1)
+            .origin("<current file>")
+            .annotation(Label::error("oops").span(19..23))
+            .fold(true),
+    );
     let expected = r#"error: oops
  --> <current file>:2:8
   |
@@ -35,23 +22,14 @@ fn test_i_29() {
 
 #[test]
 fn test_point_to_double_width_characters() {
-    let snippets = Snippet {
-        slices: vec![Slice {
-            source: "こんにちは、世界",
-            line_start: 1,
-            origin: Some("<current file>"),
-            annotations: vec![SourceAnnotation {
-                range: 12..16,
-                label: "world",
-                annotation_type: AnnotationType::Error,
-            }],
-            fold: false,
-        }],
-        title: None,
-        footer: vec![],
-    };
+    let snippets = Snippet::error("").slice(
+        Slice::new("こんにちは、世界", 1)
+            .origin("<current file>")
+            .annotation(Label::error("world").span(12..16)),
+    );
 
-    let expected = r#" --> <current file>:1:7
+    let expected = r#"error
+ --> <current file>:1:7
   |
 1 | こんにちは、世界
   |             ^^^^ world
@@ -63,23 +41,14 @@ fn test_point_to_double_width_characters() {
 
 #[test]
 fn test_point_to_double_width_characters_across_lines() {
-    let snippets = Snippet {
-        slices: vec![Slice {
-            source: "おはよう\nございます",
-            line_start: 1,
-            origin: Some("<current file>"),
-            annotations: vec![SourceAnnotation {
-                range: 4..15,
-                label: "Good morning",
-                annotation_type: AnnotationType::Error,
-            }],
-            fold: false,
-        }],
-        title: None,
-        footer: vec![],
-    };
+    let snippets = Snippet::error("").slice(
+        Slice::new("おはよう\nございます", 1)
+            .origin("<current file>")
+            .annotation(Label::error("Good morning").span(4..15)),
+    );
 
-    let expected = r#" --> <current file>:1:3
+    let expected = r#"error
+ --> <current file>:1:3
   |
 1 |   おはよう
   |  _____^
@@ -93,30 +62,15 @@ fn test_point_to_double_width_characters_across_lines() {
 
 #[test]
 fn test_point_to_double_width_characters_multiple() {
-    let snippets = Snippet {
-        slices: vec![Slice {
-            source: "お寿司\n食べたい🍣",
-            line_start: 1,
-            origin: Some("<current file>"),
-            annotations: vec![
-                SourceAnnotation {
-                    range: 0..6,
-                    label: "Sushi1",
-                    annotation_type: AnnotationType::Error,
-                },
-                SourceAnnotation {
-                    range: 11..15,
-                    label: "Sushi2",
-                    annotation_type: AnnotationType::Note,
-                },
-            ],
-            fold: false,
-        }],
-        title: None,
-        footer: vec![],
-    };
+    let snippets = Snippet::error("").slice(
+        Slice::new("お寿司\n食べたい🍣", 1)
+            .origin("<current file>")
+            .annotation(Label::error("Sushi1").span(0..6))
+            .annotation(Label::note("Sushi2").span(11..15)),
+    );
 
-    let expected = r#" --> <current file>:1:1
+    let expected = r#"error
+ --> <current file>:1:1
   |
 1 | お寿司
   | ^^^^^^ Sushi1
@@ -130,23 +84,14 @@ fn test_point_to_double_width_characters_multiple() {
 
 #[test]
 fn test_point_to_double_width_characters_mixed() {
-    let snippets = Snippet {
-        slices: vec![Slice {
-            source: "こんにちは、新しいWorld！",
-            line_start: 1,
-            origin: Some("<current file>"),
-            annotations: vec![SourceAnnotation {
-                range: 12..23,
-                label: "New world",
-                annotation_type: AnnotationType::Error,
-            }],
-            fold: false,
-        }],
-        title: None,
-        footer: vec![],
-    };
+    let snippets = Snippet::error("").slice(
+        Slice::new("こんにちは、新しいWorld！", 1)
+            .origin("<current file>")
+            .annotation(Label::error("New world").span(12..23)),
+    );
 
-    let expected = r#" --> <current file>:1:7
+    let expected = r#"error
+ --> <current file>:1:7
   |
 1 | こんにちは、新しいWorld！
   |             ^^^^^^^^^^^ New world


### PR DESCRIPTION
BREAKING CHANGE: Snippets must be created using the builder pattern

This PR makes it so that `Snippet`s must be created via a builder pattern, as described in #87. This should make it easier to change the internal API without making breaking changes. It also appears to help in code readability and size but that is determined by personal preference.

fixes #87 