### PR TITLE
docs: Shift example code from README to lib.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 name = "annotate-snippets"
 version = "0.10.2"
 dependencies = [
+ "anstream",
  "anstyle",
  "criterion",
  "difference",
@@ -337,6 +338,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "escargot"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f474c6844cbd04e783d0f25757583db4f491770ca618bedf2fb01815fc79939"
+dependencies = [
+ "log",
+ "once_cell",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,6 +556,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "os_pipe"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57119c3b893986491ec9aa85056780d3a0f3cf4da7cc09dd3650dbd6c6738fb9"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "plotters"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,15 +757,20 @@ dependencies = [
  "anstyle-svg",
  "content_inspector",
  "dunce",
+ "escargot",
  "filetime",
  "ignore",
+ "libc",
  "libtest-mimic",
  "normalize-line-endings",
+ "os_pipe",
  "serde_json",
  "similar",
  "snapbox-macros",
  "tempfile",
+ "wait-timeout",
  "walkdir",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -843,6 +871,15 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,12 @@ itertools = "0.12.1"
 unicode-width = "0.1.11"
 
 [dev-dependencies]
+anstream = "0.6.13"
 criterion = "0.5.1"
 difference = "2.0.0"
 glob = "0.3.1"
 serde = { version = "1.0.197", features = ["derive"] }
-snapbox = { version = "0.5.8", features = ["diff", "harness", "path", "term-svg"] }
+snapbox = { version = "0.5.8", features = ["diff", "harness", "path", "term-svg", "cmd", "examples"] }
 toml = "0.5.11"
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -3,73 +3,14 @@
 `annotate-snippets` is a Rust library for annotation of programming code slices.
 
 [![crates.io](https://img.shields.io/crates/v/annotate-snippets.svg)](https://crates.io/crates/annotate-snippets)
+[![documentation](https://img.shields.io/badge/docs-master-blue.svg)][Documentation]
 ![build status](https://github.com/rust-lang/annotate-snippets-rs/actions/workflows/ci.yml/badge.svg)
 
 The library helps visualize meta information annotating source code slices.
 It takes a data structure called `Snippet` on the input and produces a `String`
 which may look like this:
 
-```text
-error[E0308]: mismatched types
-  --> src/format.rs:52:1
-   |
-51 |   ) -> Option<String> {
-   |        -------------- expected `Option<String>` because of return type
-52 | /     for ann in annotations {
-53 | |         match (ann.range.0, ann.range.1) {
-54 | |             (None, None) => continue,
-55 | |             (Some(start), Some(end)) if start > end_index => continue,
-...  |
-71 | |         }
-72 | |     }
-   | |_____^ expected enum `std::option::Option`, found ()
-```
-
-[Documentation][]
-
-[Documentation]: https://docs.rs/annotate-snippets/
-
-Usage
------
-
-```rust
-use annotate_snippets::{Annotation, AnnotationType, Renderer, Slice, Snippet, SourceAnnotation};
-
-fn main() {
-    let snippet = Snippet {
-        title: Some(Annotation {
-            label: Some("expected type, found `22`"),
-            id: None,
-            annotation_type: AnnotationType::Error,
-        }),
-        footer: vec![],
-        slices: vec![Slice {
-            source: r#"                annotations: vec![SourceAnnotation {
-                label: "expected struct `annotate_snippets::snippet::Slice`, found reference"
-                    ,
-                range: <22, 25>,"#,
-            line_start: 26,
-            origin: Some("examples/footer.rs"),
-            fold: true,
-            annotations: vec![
-                SourceAnnotation {
-                    label: "",
-                    annotation_type: AnnotationType::Error,
-                    range: (193, 195),
-                },
-                SourceAnnotation {
-                    label: "while parsing this struct",
-                    annotation_type: AnnotationType::Info,
-                    range: (34, 50),
-                },
-            ],
-        }],
-    };
-
-    let renderer = Renderer::plain();
-    println!("{}", renderer.render(snippet));
-}
-```
+![Screenshot](./examples/expected_type.svg)
 
 Local Development
 -----------------
@@ -80,3 +21,5 @@ Local Development
 When submitting a PR please use  [`cargo fmt`][] (nightly).
 
 [`cargo fmt`]: https://github.com/rust-lang/rustfmt
+
+[Documentation]: https://docs.rs/annotate-snippets/

--- a/examples/expected_type.rs
+++ b/examples/expected_type.rs
@@ -18,6 +18,6 @@ fn main() {
             .annotation(Label::info("while parsing this struct").span(34..50)),
     );
 
-    let renderer = Renderer::plain();
-    println!("{}", renderer.render(snippet));
+    let renderer = Renderer::styled();
+    anstream::println!("{}", renderer.render(snippet));
 }

--- a/examples/expected_type.svg
+++ b/examples/expected_type.svg
@@ -1,0 +1,44 @@
+<svg width="860px" height="200px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: </tspan><tspan class="bold">expected type, found `22`</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-bright-blue bold">--&gt;</tspan><tspan> examples/footer.rs:29:25</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">   |</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">26 |</tspan><tspan>                 annotations: vec![SourceAnnotation {</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-blue bold">   |</tspan><tspan class="fg-bright-blue bold">                                   ----------------</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">info</tspan><tspan class="fg-bright-blue bold">: while parsing this struct</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>...</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-blue bold">29 |</tspan><tspan>                 range: &lt;22, 25&gt;,</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-blue bold">   |</tspan><tspan class="fg-bright-red bold">                         ^^</tspan><tspan> </tspan><tspan class="fg-bright-red bold">expected struct `annotate_snippets::snippet::Slice`, found reference</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-blue bold">   |</tspan>
+</tspan>
+    <tspan x="10px" y="190px">
+</tspan>
+  </text>
+
+</svg>

--- a/examples/footer.rs
+++ b/examples/footer.rs
@@ -17,6 +17,6 @@ fn main() {
             "expected type: `snippet::Annotation`\n   found type: `__&__snippet::Annotation`",
         ));
 
-    let renderer = Renderer::plain();
-    println!("{}", renderer.render(snippet));
+    let renderer = Renderer::styled();
+    anstream::println!("{}", renderer.render(snippet));
 }

--- a/examples/footer.svg
+++ b/examples/footer.svg
@@ -1,0 +1,43 @@
+<svg width="844px" height="182px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error[E0308]</tspan><tspan>: </tspan><tspan class="bold">mismatched types</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-bright-blue bold">--&gt;</tspan><tspan> src/multislice.rs:13:22</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">   |</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">13 |</tspan><tspan>         slices: vec!["A",</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-blue bold">   |</tspan><tspan class="fg-bright-red bold">                      ^^^</tspan><tspan> </tspan><tspan class="fg-bright-red bold">expected struct `annotate_snippets::snippet::Slice`, found reference</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">   |</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>   </tspan><tspan class="fg-bright-blue bold">=</tspan><tspan> </tspan><tspan class="fg-bright-green bold">note</tspan><tspan>: expected type: `snippet::Annotation`</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>              found type: `__&amp;__snippet::Annotation`</tspan>
+</tspan>
+    <tspan x="10px" y="172px">
+</tspan>
+  </text>
+
+</svg>

--- a/examples/format.rs
+++ b/examples/format.rs
@@ -32,6 +32,6 @@ fn main() {
             .annotation(Label::error("expected enum `std::option::Option`").span(26..724)),
     );
 
-    let renderer = Renderer::plain();
-    println!("{}", renderer.render(snippet));
+    let renderer = Renderer::styled();
+    anstream::println!("{}", renderer.render(snippet));
 }

--- a/examples/format.svg
+++ b/examples/format.svg
@@ -1,0 +1,85 @@
+<svg width="740px" height="560px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-red { fill: #FF5555 }
+    .fg-yellow { fill: #AA5500 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error[E0308]</tspan><tspan>: </tspan><tspan class="bold">mismatched types</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-bright-blue bold">--&gt;</tspan><tspan> src/format.rs:51:6</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">   |</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">51 |</tspan><tspan>   ) -&gt; Option&lt;String&gt; {</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-blue bold">   |</tspan><tspan>  </tspan><tspan class="fg-yellow bold">      --------------</tspan><tspan> </tspan><tspan class="fg-yellow bold">expected `Option&lt;String&gt;` because of return type</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">52 |</tspan><tspan>       for ann in annotations {</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-blue bold">   |</tspan><tspan>  </tspan><tspan class="fg-bright-red bold">_____^</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-blue bold">53 |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>         match (ann.range.0, ann.range.1) {</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-blue bold">54 |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>             (None, None) =&gt; continue,</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan class="fg-bright-blue bold">55 |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>             (Some(start), Some(end)) if start &gt; end_index =&gt; continue,</tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan class="fg-bright-blue bold">56 |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>             (Some(start), Some(end)) if start &gt;= start_index =&gt; {</tspan>
+</tspan>
+    <tspan x="10px" y="226px"><tspan class="fg-bright-blue bold">57 |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>                 let label = if let Some(ref label) = ann.label {</tspan>
+</tspan>
+    <tspan x="10px" y="244px"><tspan class="fg-bright-blue bold">58 |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>                     format!(" {}", label)</tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan class="fg-bright-blue bold">59 |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>                 } else {</tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan class="fg-bright-blue bold">60 |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>                     String::from("")</tspan>
+</tspan>
+    <tspan x="10px" y="298px"><tspan class="fg-bright-blue bold">61 |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>                 };</tspan>
+</tspan>
+    <tspan x="10px" y="316px"><tspan class="fg-bright-blue bold">62 |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan> </tspan>
+</tspan>
+    <tspan x="10px" y="334px"><tspan class="fg-bright-blue bold">63 |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>                 return Some(format!(</tspan>
+</tspan>
+    <tspan x="10px" y="352px"><tspan class="fg-bright-blue bold">64 |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>                     "{}{}{}",</tspan>
+</tspan>
+    <tspan x="10px" y="370px"><tspan class="fg-bright-blue bold">65 |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>                     " ".repeat(start - start_index),</tspan>
+</tspan>
+    <tspan x="10px" y="388px"><tspan class="fg-bright-blue bold">66 |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>                     "^".repeat(end - start),</tspan>
+</tspan>
+    <tspan x="10px" y="406px"><tspan class="fg-bright-blue bold">67 |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>                     label</tspan>
+</tspan>
+    <tspan x="10px" y="424px"><tspan class="fg-bright-blue bold">68 |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>                 ));</tspan>
+</tspan>
+    <tspan x="10px" y="442px"><tspan class="fg-bright-blue bold">69 |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>             }</tspan>
+</tspan>
+    <tspan x="10px" y="460px"><tspan class="fg-bright-blue bold">70 |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>             _ =&gt; continue,</tspan>
+</tspan>
+    <tspan x="10px" y="478px"><tspan class="fg-bright-blue bold">71 |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>         }</tspan>
+</tspan>
+    <tspan x="10px" y="496px"><tspan class="fg-bright-blue bold">72 |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>     }</tspan>
+</tspan>
+    <tspan x="10px" y="514px"><tspan class="fg-bright-blue bold">   |</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan class="fg-bright-red bold">____^</tspan><tspan> </tspan><tspan class="fg-bright-red bold">expected enum `std::option::Option`</tspan>
+</tspan>
+    <tspan x="10px" y="532px"><tspan class="fg-bright-blue bold">   |</tspan>
+</tspan>
+    <tspan x="10px" y="550px">
+</tspan>
+  </text>
+
+</svg>

--- a/examples/multislice.rs
+++ b/examples/multislice.rs
@@ -5,6 +5,6 @@ fn main() {
         .slice(Slice::new("Foo", 51).origin("src/format.rs"))
         .slice(Slice::new("Faa", 129).origin("src/display.rs"));
 
-    let renderer = Renderer::plain();
-    println!("{}", renderer.render(snippet));
+    let renderer = Renderer::styled();
+    anstream::println!("{}", renderer.render(snippet));
 }

--- a/examples/multislice.svg
+++ b/examples/multislice.svg
@@ -1,0 +1,44 @@
+<svg width="740px" height="200px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: </tspan><tspan class="bold">mismatched types</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>   </tspan><tspan class="fg-bright-blue bold">--&gt;</tspan><tspan> src/format.rs</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">    |</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold"> 51 |</tspan><tspan> Foo</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-blue bold">    |</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>   </tspan><tspan class="fg-bright-blue bold">:::</tspan><tspan> src/display.rs</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-blue bold">    |</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-blue bold">129 |</tspan><tspan> Faa</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-blue bold">    |</tspan>
+</tspan>
+    <tspan x="10px" y="190px">
+</tspan>
+  </text>
+
+</svg>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,21 +7,11 @@
 //!
 //! # Example
 //!
-//! ```text
-//! error[E0308]: mismatched types
-//!   --> src/format.rs:52:1
-//!    |
-//! 51 |   ) -> Option<String> {
-//!    |        -------------- expected `Option<String>` because of return type
-//! 52 | /     for ann in annotations {
-//! 53 | |         match (ann.range.0, ann.range.1) {
-//! 54 | |             (None, None) => continue,
-//! 55 | |             (Some(start), Some(end)) if start > end_index => continue,
-//! ...  |
-//! 71 | |         }
-//! 72 | |     }
-//!    | |_____^ expected enum `std::option::Option`, found ()
+//! ```rust
+#![doc = include_str!("../examples/expected_type.rs")]
 //! ```
+//!
+#![doc = include_str!("../examples/expected_type.svg")]
 //!
 //! The crate uses a three stage process with two conversions between states:
 //!

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -1,0 +1,37 @@
+#[test]
+fn expected_type() {
+    let target = "expected_type";
+    let expected = snapbox::file!["../examples/expected_type.svg": TermSvg];
+    assert_example(target, expected);
+}
+
+#[test]
+fn footer() {
+    let target = "footer";
+    let expected = snapbox::file!["../examples/footer.svg": TermSvg];
+    assert_example(target, expected);
+}
+
+#[test]
+fn format() {
+    let target = "format";
+    let expected = snapbox::file!["../examples/format.svg": TermSvg];
+    assert_example(target, expected);
+}
+
+#[test]
+fn multislice() {
+    let target = "multislice";
+    let expected = snapbox::file!["../examples/multislice.svg": TermSvg];
+    assert_example(target, expected);
+}
+
+#[track_caller]
+fn assert_example(target: &str, expected: snapbox::Data) {
+    let bin_path = snapbox::cmd::compile_example(target, ["--features=testing-colors"]).unwrap();
+    snapbox::cmd::Command::new(bin_path)
+        .env("CLICOLOR_FORCE", "1")
+        .assert()
+        .success()
+        .stdout_eq(expected);
+}


### PR DESCRIPTION
We now pull from an example
- We verify it builds (wasn't doing that with README)
- We show the output for the actual code (couldn't do that from a
  rustdoc code fence)


![image](https://github.com/rust-lang/annotate-snippets-rs/assets/60961/4eaac01d-c007-4864-9e05-c56de87bad7f)
