### PR TITLE
fix!: Clarify Snippet API

### DIFF
--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -4,7 +4,7 @@ extern crate criterion;
 
 use criterion::{black_box, Criterion};
 
-use annotate_snippets::{Label, Message, Renderer, Slice};
+use annotate_snippets::{Label, Message, Renderer, Snippet};
 
 fn create_snippet(renderer: Renderer) {
     let source = r#") -> Option<String> {
@@ -29,8 +29,8 @@ fn create_snippet(renderer: Renderer) {
             _ => continue,
         }
     }"#;
-    let message = Message::error("mismatched types").id("E0308").slice(
-        Slice::new(source, 51)
+    let message = Message::error("mismatched types").id("E0308").snippet(
+        Snippet::new(source, 51)
             .origin("src/format.rs")
             .annotation(
                 Label::warning("expected `Option<String>` because of return type").span(5..19),

--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -4,7 +4,7 @@ extern crate criterion;
 
 use criterion::{black_box, Criterion};
 
-use annotate_snippets::{Label, Level, Renderer, Snippet};
+use annotate_snippets::{Level, Renderer, Snippet};
 
 fn create_snippet(renderer: Renderer) {
     let source = r#") -> Option<String> {
@@ -34,9 +34,15 @@ fn create_snippet(renderer: Renderer) {
             .line_start(51)
             .origin("src/format.rs")
             .annotation(
-                Label::warning("expected `Option<String>` because of return type").span(5..19),
+                Level::Warning
+                    .span(5..19)
+                    .label("expected `Option<String>` because of return type"),
             )
-            .annotation(Label::error("expected enum `std::option::Option`").span(26..724)),
+            .annotation(
+                Level::Error
+                    .span(26..724)
+                    .label("expected enum `std::option::Option`"),
+            ),
     );
 
     let _result = renderer.render(message).to_string();

--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -4,7 +4,7 @@ extern crate criterion;
 
 use criterion::{black_box, Criterion};
 
-use annotate_snippets::{Label, Message, Renderer, Snippet};
+use annotate_snippets::{Label, Level, Renderer, Snippet};
 
 fn create_snippet(renderer: Renderer) {
     let source = r#") -> Option<String> {
@@ -29,7 +29,7 @@ fn create_snippet(renderer: Renderer) {
             _ => continue,
         }
     }"#;
-    let message = Message::error("mismatched types").id("E0308").snippet(
+    let message = Level::Error.title("mismatched types").id("E0308").snippet(
         Snippet::new(source)
             .line_start(51)
             .origin("src/format.rs")

--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -30,7 +30,7 @@ fn create_snippet(renderer: Renderer) {
         }
     }"#;
     let message = Level::Error.title("mismatched types").id("E0308").snippet(
-        Snippet::new(source)
+        Snippet::source(source)
             .line_start(51)
             .origin("src/format.rs")
             .annotation(

--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -30,7 +30,8 @@ fn create_snippet(renderer: Renderer) {
         }
     }"#;
     let message = Message::error("mismatched types").id("E0308").snippet(
-        Snippet::new(source, 51)
+        Snippet::new(source)
+            .line_start(51)
             .origin("src/format.rs")
             .annotation(
                 Label::warning("expected `Option<String>` because of return type").span(5..19),

--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -4,7 +4,7 @@ extern crate criterion;
 
 use criterion::{black_box, Criterion};
 
-use annotate_snippets::{Label, Renderer, Slice, Snippet};
+use annotate_snippets::{Label, Message, Renderer, Slice};
 
 fn create_snippet(renderer: Renderer) {
     let source = r#") -> Option<String> {
@@ -29,7 +29,7 @@ fn create_snippet(renderer: Renderer) {
             _ => continue,
         }
     }"#;
-    let snippet = Snippet::error("mismatched types").id("E0308").slice(
+    let message = Message::error("mismatched types").id("E0308").slice(
         Slice::new(source, 51)
             .origin("src/format.rs")
             .annotation(
@@ -38,7 +38,7 @@ fn create_snippet(renderer: Renderer) {
             .annotation(Label::error("expected enum `std::option::Option`").span(26..724)),
     );
 
-    let _result = renderer.render(snippet).to_string();
+    let _result = renderer.render(message).to_string();
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {

--- a/examples/expected_type.rs
+++ b/examples/expected_type.rs
@@ -6,7 +6,8 @@ fn main() {
                     ,
                 range: <22, 25>,"#;
     let message = Message::error("expected type, found `22`").snippet(
-        Snippet::new(source, 26)
+        Snippet::new(source)
+            .line_start(26)
             .origin("examples/footer.rs")
             .fold(true)
             .annotation(

--- a/examples/expected_type.rs
+++ b/examples/expected_type.rs
@@ -1,12 +1,12 @@
-use annotate_snippets::{Label, Message, Renderer, Slice};
+use annotate_snippets::{Label, Message, Renderer, Snippet};
 
 fn main() {
     let source = r#"                annotations: vec![SourceAnnotation {
                 label: "expected struct `annotate_snippets::snippet::Slice`, found reference"
                     ,
                 range: <22, 25>,"#;
-    let message = Message::error("expected type, found `22`").slice(
-        Slice::new(source, 26)
+    let message = Message::error("expected type, found `22`").snippet(
+        Snippet::new(source, 26)
             .origin("examples/footer.rs")
             .fold(true)
             .annotation(

--- a/examples/expected_type.rs
+++ b/examples/expected_type.rs
@@ -1,11 +1,11 @@
-use annotate_snippets::{Label, Message, Renderer, Snippet};
+use annotate_snippets::{Label, Level, Renderer, Snippet};
 
 fn main() {
     let source = r#"                annotations: vec![SourceAnnotation {
                 label: "expected struct `annotate_snippets::snippet::Slice`, found reference"
                     ,
                 range: <22, 25>,"#;
-    let message = Message::error("expected type, found `22`").snippet(
+    let message = Level::Error.title("expected type, found `22`").snippet(
         Snippet::new(source)
             .line_start(26)
             .origin("examples/footer.rs")

--- a/examples/expected_type.rs
+++ b/examples/expected_type.rs
@@ -1,11 +1,11 @@
-use annotate_snippets::{Label, Renderer, Slice, Snippet};
+use annotate_snippets::{Label, Message, Renderer, Slice};
 
 fn main() {
     let source = r#"                annotations: vec![SourceAnnotation {
                 label: "expected struct `annotate_snippets::snippet::Slice`, found reference"
                     ,
                 range: <22, 25>,"#;
-    let snippet = Snippet::error("expected type, found `22`").slice(
+    let message = Message::error("expected type, found `22`").slice(
         Slice::new(source, 26)
             .origin("examples/footer.rs")
             .fold(true)
@@ -19,5 +19,5 @@ fn main() {
     );
 
     let renderer = Renderer::styled();
-    anstream::println!("{}", renderer.render(snippet));
+    anstream::println!("{}", renderer.render(message));
 }

--- a/examples/expected_type.rs
+++ b/examples/expected_type.rs
@@ -6,7 +6,7 @@ fn main() {
                     ,
                 range: <22, 25>,"#;
     let message = Level::Error.title("expected type, found `22`").snippet(
-        Snippet::new(source)
+        Snippet::source(source)
             .line_start(26)
             .origin("examples/footer.rs")
             .fold(true)

--- a/examples/expected_type.rs
+++ b/examples/expected_type.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{Label, Level, Renderer, Snippet};
+use annotate_snippets::{Level, Renderer, Snippet};
 
 fn main() {
     let source = r#"                annotations: vec![SourceAnnotation {
@@ -11,12 +11,11 @@ fn main() {
             .origin("examples/footer.rs")
             .fold(true)
             .annotation(
-                Label::error(
-                    "expected struct `annotate_snippets::snippet::Slice`, found reference",
-                )
-                .span(193..195),
+                Level::Error
+                    .span(193..195)
+                    .label("expected struct `annotate_snippets::snippet::Slice`, found reference"),
             )
-            .annotation(Label::info("while parsing this struct").span(34..50)),
+            .annotation(Level::Info.span(34..50).label("while parsing this struct")),
     );
 
     let renderer = Renderer::styled();

--- a/examples/footer.rs
+++ b/examples/footer.rs
@@ -5,7 +5,7 @@ fn main() {
         .title("mismatched types")
         .id("E0308")
         .snippet(
-            Snippet::new("        slices: vec![\"A\",")
+            Snippet::source("        slices: vec![\"A\",")
                 .line_start(13)
                 .origin("src/multislice.rs")
                 .annotation(

--- a/examples/footer.rs
+++ b/examples/footer.rs
@@ -1,7 +1,7 @@
-use annotate_snippets::{Label, Renderer, Slice, Snippet};
+use annotate_snippets::{Label, Message, Renderer, Slice};
 
 fn main() {
-    let snippet = Snippet::error("mismatched types")
+    let message = Message::error("mismatched types")
         .id("E0308")
         .slice(
             Slice::new("        slices: vec![\"A\",", 13)
@@ -18,5 +18,5 @@ fn main() {
         ));
 
     let renderer = Renderer::styled();
-    anstream::println!("{}", renderer.render(snippet));
+    anstream::println!("{}", renderer.render(message));
 }

--- a/examples/footer.rs
+++ b/examples/footer.rs
@@ -4,7 +4,8 @@ fn main() {
     let message = Message::error("mismatched types")
         .id("E0308")
         .snippet(
-            Snippet::new("        slices: vec![\"A\",", 13)
+            Snippet::new("        slices: vec![\"A\",")
+                .line_start(13)
                 .origin("src/multislice.rs")
                 .annotation(
                     Label::error(

--- a/examples/footer.rs
+++ b/examples/footer.rs
@@ -1,23 +1,21 @@
 use annotate_snippets::{Label, Level, Renderer, Snippet};
 
 fn main() {
-    let message = Level::Error
-        .title("mismatched types")
-        .id("E0308")
-        .snippet(
-            Snippet::source("        slices: vec![\"A\",")
-                .line_start(13)
-                .origin("src/multislice.rs")
-                .annotation(
-                    Label::error(
+    let message =
+        Level::Error
+            .title("mismatched types")
+            .id("E0308")
+            .snippet(
+                Snippet::source("        slices: vec![\"A\",")
+                    .line_start(13)
+                    .origin("src/multislice.rs")
+                    .annotation(Level::Error.span(21..24).label(
                         "expected struct `annotate_snippets::snippet::Slice`, found reference",
-                    )
-                    .span(21..24),
-                ),
-        )
-        .footer(Label::note(
-            "expected type: `snippet::Annotation`\n   found type: `__&__snippet::Annotation`",
-        ));
+                    )),
+            )
+            .footer(Label::note(
+                "expected type: `snippet::Annotation`\n   found type: `__&__snippet::Annotation`",
+            ));
 
     let renderer = Renderer::styled();
     anstream::println!("{}", renderer.render(message));

--- a/examples/footer.rs
+++ b/examples/footer.rs
@@ -1,7 +1,8 @@
-use annotate_snippets::{Label, Message, Renderer, Snippet};
+use annotate_snippets::{Label, Level, Renderer, Snippet};
 
 fn main() {
-    let message = Message::error("mismatched types")
+    let message = Level::Error
+        .title("mismatched types")
         .id("E0308")
         .snippet(
             Snippet::new("        slices: vec![\"A\",")

--- a/examples/footer.rs
+++ b/examples/footer.rs
@@ -1,10 +1,10 @@
-use annotate_snippets::{Label, Message, Renderer, Slice};
+use annotate_snippets::{Label, Message, Renderer, Snippet};
 
 fn main() {
     let message = Message::error("mismatched types")
         .id("E0308")
-        .slice(
-            Slice::new("        slices: vec![\"A\",", 13)
+        .snippet(
+            Snippet::new("        slices: vec![\"A\",", 13)
                 .origin("src/multislice.rs")
                 .annotation(
                     Label::error(

--- a/examples/format.rs
+++ b/examples/format.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{Label, Renderer, Slice, Snippet};
+use annotate_snippets::{Label, Message, Renderer, Slice};
 
 fn main() {
     let source = r#") -> Option<String> {
@@ -23,7 +23,7 @@ fn main() {
             _ => continue,
         }
     }"#;
-    let snippet = Snippet::error("mismatched types").id("E0308").slice(
+    let message = Message::error("mismatched types").id("E0308").slice(
         Slice::new(source, 51)
             .origin("src/format.rs")
             .annotation(
@@ -33,5 +33,5 @@ fn main() {
     );
 
     let renderer = Renderer::styled();
-    anstream::println!("{}", renderer.render(snippet));
+    anstream::println!("{}", renderer.render(message));
 }

--- a/examples/format.rs
+++ b/examples/format.rs
@@ -24,7 +24,8 @@ fn main() {
         }
     }"#;
     let message = Message::error("mismatched types").id("E0308").snippet(
-        Snippet::new(source, 51)
+        Snippet::new(source)
+            .line_start(51)
             .origin("src/format.rs")
             .annotation(
                 Label::warning("expected `Option<String>` because of return type").span(5..19),

--- a/examples/format.rs
+++ b/examples/format.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{Label, Level, Renderer, Snippet};
+use annotate_snippets::{Level, Renderer, Snippet};
 
 fn main() {
     let source = r#") -> Option<String> {
@@ -28,9 +28,15 @@ fn main() {
             .line_start(51)
             .origin("src/format.rs")
             .annotation(
-                Label::warning("expected `Option<String>` because of return type").span(5..19),
+                Level::Warning
+                    .span(5..19)
+                    .label("expected `Option<String>` because of return type"),
             )
-            .annotation(Label::error("expected enum `std::option::Option`").span(26..724)),
+            .annotation(
+                Level::Error
+                    .span(26..724)
+                    .label("expected enum `std::option::Option`"),
+            ),
     );
 
     let renderer = Renderer::styled();

--- a/examples/format.rs
+++ b/examples/format.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{Label, Message, Renderer, Snippet};
+use annotate_snippets::{Label, Level, Renderer, Snippet};
 
 fn main() {
     let source = r#") -> Option<String> {
@@ -23,7 +23,7 @@ fn main() {
             _ => continue,
         }
     }"#;
-    let message = Message::error("mismatched types").id("E0308").snippet(
+    let message = Level::Error.title("mismatched types").id("E0308").snippet(
         Snippet::new(source)
             .line_start(51)
             .origin("src/format.rs")

--- a/examples/format.rs
+++ b/examples/format.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{Label, Message, Renderer, Slice};
+use annotate_snippets::{Label, Message, Renderer, Snippet};
 
 fn main() {
     let source = r#") -> Option<String> {
@@ -23,8 +23,8 @@ fn main() {
             _ => continue,
         }
     }"#;
-    let message = Message::error("mismatched types").id("E0308").slice(
-        Slice::new(source, 51)
+    let message = Message::error("mismatched types").id("E0308").snippet(
+        Snippet::new(source, 51)
             .origin("src/format.rs")
             .annotation(
                 Label::warning("expected `Option<String>` because of return type").span(5..19),

--- a/examples/format.rs
+++ b/examples/format.rs
@@ -24,7 +24,7 @@ fn main() {
         }
     }"#;
     let message = Level::Error.title("mismatched types").id("E0308").snippet(
-        Snippet::new(source)
+        Snippet::source(source)
             .line_start(51)
             .origin("src/format.rs")
             .annotation(

--- a/examples/multislice.rs
+++ b/examples/multislice.rs
@@ -2,8 +2,8 @@ use annotate_snippets::{Message, Renderer, Snippet};
 
 fn main() {
     let message = Message::error("mismatched types")
-        .snippet(Snippet::new("Foo", 51).origin("src/format.rs"))
-        .snippet(Snippet::new("Faa", 129).origin("src/display.rs"));
+        .snippet(Snippet::new("Foo").line_start(51).origin("src/format.rs"))
+        .snippet(Snippet::new("Faa").line_start(129).origin("src/display.rs"));
 
     let renderer = Renderer::styled();
     anstream::println!("{}", renderer.render(message));

--- a/examples/multislice.rs
+++ b/examples/multislice.rs
@@ -1,10 +1,10 @@
-use annotate_snippets::{Renderer, Slice, Snippet};
+use annotate_snippets::{Message, Renderer, Slice};
 
 fn main() {
-    let snippet = Snippet::error("mismatched types")
+    let message = Message::error("mismatched types")
         .slice(Slice::new("Foo", 51).origin("src/format.rs"))
         .slice(Slice::new("Faa", 129).origin("src/display.rs"));
 
     let renderer = Renderer::styled();
-    anstream::println!("{}", renderer.render(snippet));
+    anstream::println!("{}", renderer.render(message));
 }

--- a/examples/multislice.rs
+++ b/examples/multislice.rs
@@ -1,7 +1,8 @@
-use annotate_snippets::{Message, Renderer, Snippet};
+use annotate_snippets::{Level, Renderer, Snippet};
 
 fn main() {
-    let message = Message::error("mismatched types")
+    let message = Level::Error
+        .title("mismatched types")
         .snippet(Snippet::new("Foo").line_start(51).origin("src/format.rs"))
         .snippet(Snippet::new("Faa").line_start(129).origin("src/display.rs"));
 

--- a/examples/multislice.rs
+++ b/examples/multislice.rs
@@ -3,8 +3,16 @@ use annotate_snippets::{Level, Renderer, Snippet};
 fn main() {
     let message = Level::Error
         .title("mismatched types")
-        .snippet(Snippet::new("Foo").line_start(51).origin("src/format.rs"))
-        .snippet(Snippet::new("Faa").line_start(129).origin("src/display.rs"));
+        .snippet(
+            Snippet::source("Foo")
+                .line_start(51)
+                .origin("src/format.rs"),
+        )
+        .snippet(
+            Snippet::source("Faa")
+                .line_start(129)
+                .origin("src/display.rs"),
+        );
 
     let renderer = Renderer::styled();
     anstream::println!("{}", renderer.render(message));

--- a/examples/multislice.rs
+++ b/examples/multislice.rs
@@ -1,9 +1,9 @@
-use annotate_snippets::{Message, Renderer, Slice};
+use annotate_snippets::{Message, Renderer, Snippet};
 
 fn main() {
     let message = Message::error("mismatched types")
-        .slice(Slice::new("Foo", 51).origin("src/format.rs"))
-        .slice(Slice::new("Faa", 129).origin("src/display.rs"));
+        .snippet(Snippet::new("Foo", 51).origin("src/format.rs"))
+        .snippet(Snippet::new("Faa", 129).origin("src/display.rs"));
 
     let renderer = Renderer::styled();
     anstream::println!("{}", renderer.render(message));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,10 @@
 //! The crate uses a three stage process with two conversions between states:
 //!
 //! ```text
-//! Snippet --> Renderer --> impl Display
+//! Message --> Renderer --> impl Display
 //! ```
 //!
-//! The input type - [Snippet] is a structure designed
+//! The input type - [Message] is a structure designed
 //! to align with likely output from any parser whose code snippet is to be
 //! annotated.
 //!

--- a/src/renderer/display_list.rs
+++ b/src/renderer/display_list.rs
@@ -107,8 +107,9 @@ impl<'a> DisplayList<'a> {
 
     pub(crate) fn new(
         snippet::Message {
-            title,
+            level,
             id,
+            title,
             footer,
             snippets,
         }: snippet::Message<'a>,
@@ -118,7 +119,13 @@ impl<'a> DisplayList<'a> {
     ) -> DisplayList<'a> {
         let mut body = vec![];
 
-        body.push(format_title(title, id));
+        body.push(format_title(
+            snippet::Label {
+                level,
+                label: title,
+            },
+            id,
+        ));
 
         for (idx, snippet) in snippets.into_iter().enumerate() {
             body.append(&mut format_slice(
@@ -1206,7 +1213,7 @@ mod tests {
 
     #[test]
     fn test_format_title() {
-        let input = snippet::Message::error("This is a title").id("E0001");
+        let input = snippet::Level::Error.title("This is a title").id("E0001");
         let output = from_display_lines(vec![DisplayLine::Raw(DisplayRawLine::Annotation {
             annotation: Annotation {
                 annotation_type: DisplayAnnotationType::Error,
@@ -1227,8 +1234,9 @@ mod tests {
         let line_1 = "This is line 1";
         let line_2 = "This is line 2";
         let source = [line_1, line_2].join("\n");
-        let input =
-            snippet::Message::error("").snippet(snippet::Snippet::new(&source).line_start(5402));
+        let input = snippet::Level::Error
+            .title("")
+            .snippet(snippet::Snippet::new(&source).line_start(5402));
         let output = from_display_lines(vec![
             DisplayLine::Raw(DisplayRawLine::Annotation {
                 annotation: Annotation {
@@ -1278,7 +1286,8 @@ mod tests {
         let src_0_len = src_0.len();
         let src_1 = "This is slice 2";
         let src_1_len = src_1.len();
-        let input = snippet::Message::error("")
+        let input = snippet::Level::Error
+            .title("")
             .snippet(
                 snippet::Snippet::new(src_0)
                     .line_start(5402)
@@ -1359,7 +1368,7 @@ mod tests {
         let source = [line_1, line_2].join("\n");
         // In line 2
         let range = 22..24;
-        let input = snippet::Message::error("").snippet(
+        let input = snippet::Level::Error.title("").snippet(
             snippet::Snippet::new(&source)
                 .line_start(5402)
                 .annotation(snippet::Label::info("Test annotation").span(range.clone())),
@@ -1429,8 +1438,9 @@ mod tests {
 
     #[test]
     fn test_format_label() {
-        let input =
-            snippet::Message::error("").footer(snippet::Label::error("This __is__ a title"));
+        let input = snippet::Level::Error
+            .title("")
+            .footer(snippet::Label::error("This __is__ a title"));
         let output = from_display_lines(vec![
             DisplayLine::Raw(DisplayRawLine::Annotation {
                 annotation: Annotation {
@@ -1465,7 +1475,7 @@ mod tests {
     fn test_i26() {
         let source = "short";
         let label = "label";
-        let input = snippet::Message::error("").snippet(
+        let input = snippet::Level::Error.title("").snippet(
             snippet::Snippet::new(source)
                 .line_start(0)
                 .annotation(snippet::Label::error(label).span(0..source.len() + 2)),
@@ -1475,7 +1485,7 @@ mod tests {
 
     #[test]
     fn test_i_29() {
-        let snippets = snippet::Message::error("oops").snippet(
+        let snippets = snippet::Level::Error.title("oops").snippet(
             snippet::Snippet::new("First line\r\nSecond oops line")
                 .line_start(1)
                 .origin("<current file>")

--- a/src/renderer/display_list.rs
+++ b/src/renderer/display_list.rs
@@ -1227,7 +1227,8 @@ mod tests {
         let line_1 = "This is line 1";
         let line_2 = "This is line 2";
         let source = [line_1, line_2].join("\n");
-        let input = snippet::Message::error("").snippet(snippet::Snippet::new(&source, 5402));
+        let input =
+            snippet::Message::error("").snippet(snippet::Snippet::new(&source).line_start(5402));
         let output = from_display_lines(vec![
             DisplayLine::Raw(DisplayRawLine::Annotation {
                 annotation: Annotation {
@@ -1278,8 +1279,16 @@ mod tests {
         let src_1 = "This is slice 2";
         let src_1_len = src_1.len();
         let input = snippet::Message::error("")
-            .snippet(snippet::Snippet::new(src_0, 5402).origin("file1.rs"))
-            .snippet(snippet::Snippet::new(src_1, 2).origin("file2.rs"));
+            .snippet(
+                snippet::Snippet::new(src_0)
+                    .line_start(5402)
+                    .origin("file1.rs"),
+            )
+            .snippet(
+                snippet::Snippet::new(src_1)
+                    .line_start(2)
+                    .origin("file2.rs"),
+            );
         let output = from_display_lines(vec![
             DisplayLine::Raw(DisplayRawLine::Annotation {
                 annotation: Annotation {
@@ -1351,7 +1360,8 @@ mod tests {
         // In line 2
         let range = 22..24;
         let input = snippet::Message::error("").snippet(
-            snippet::Snippet::new(&source, 5402)
+            snippet::Snippet::new(&source)
+                .line_start(5402)
                 .annotation(snippet::Label::info("Test annotation").span(range.clone())),
         );
         let output = from_display_lines(vec![
@@ -1456,7 +1466,8 @@ mod tests {
         let source = "short";
         let label = "label";
         let input = snippet::Message::error("").snippet(
-            snippet::Snippet::new(source, 0)
+            snippet::Snippet::new(source)
+                .line_start(0)
                 .annotation(snippet::Label::error(label).span(0..source.len() + 2)),
         );
         let _ = DisplayList::new(input, &STYLESHEET, false, None);
@@ -1465,7 +1476,8 @@ mod tests {
     #[test]
     fn test_i_29() {
         let snippets = snippet::Message::error("oops").snippet(
-            snippet::Snippet::new("First line\r\nSecond oops line", 1)
+            snippet::Snippet::new("First line\r\nSecond oops line")
+                .line_start(1)
                 .origin("<current file>")
                 .fold(true)
                 .annotation(snippet::Label::error("oops").span(19..23)),

--- a/src/renderer/display_list.rs
+++ b/src/renderer/display_list.rs
@@ -1040,7 +1040,7 @@ fn format_body(
                                 annotation: Annotation {
                                     annotation_type,
                                     id: None,
-                                    label: format_label(Some(annotation.label), None),
+                                    label: format_label(annotation.label, None),
                                 },
                                 range,
                                 annotation_type: DisplayAnnotationType::from(annotation.level),
@@ -1134,7 +1134,7 @@ fn format_body(
                                 annotation: Annotation {
                                     annotation_type,
                                     id: None,
-                                    label: format_label(Some(annotation.label), None),
+                                    label: format_label(annotation.label, None),
                                 },
                                 range,
                                 annotation_type: DisplayAnnotationType::from(annotation.level),
@@ -1371,7 +1371,11 @@ mod tests {
         let input = snippet::Level::Error.title("").snippet(
             snippet::Snippet::source(&source)
                 .line_start(5402)
-                .annotation(snippet::Label::info("Test annotation").span(range.clone())),
+                .annotation(
+                    snippet::Level::Info
+                        .span(range.clone())
+                        .label("Test annotation"),
+                ),
         );
         let output = from_display_lines(vec![
             DisplayLine::Raw(DisplayRawLine::Annotation {
@@ -1478,7 +1482,7 @@ mod tests {
         let input = snippet::Level::Error.title("").snippet(
             snippet::Snippet::source(source)
                 .line_start(0)
-                .annotation(snippet::Label::error(label).span(0..source.len() + 2)),
+                .annotation(snippet::Level::Error.span(0..source.len() + 2).label(label)),
         );
         let _ = DisplayList::new(input, &STYLESHEET, false, None);
     }
@@ -1490,7 +1494,7 @@ mod tests {
                 .line_start(1)
                 .origin("<current file>")
                 .fold(true)
-                .annotation(snippet::Label::error("oops").span(19..23)),
+                .annotation(snippet::Level::Error.span(19..23).label("oops")),
         );
 
         let expected = from_display_lines(vec![

--- a/src/renderer/display_list.rs
+++ b/src/renderer/display_list.rs
@@ -106,12 +106,12 @@ impl<'a> DisplayList<'a> {
     const WARNING_TXT: &'static str = "warning";
 
     pub(crate) fn new(
-        snippet::Snippet {
+        snippet::Message {
             title,
             id,
             footer,
             slices,
-        }: snippet::Snippet<'a>,
+        }: snippet::Message<'a>,
         stylesheet: &'a Stylesheet,
         anonymized_line_numbers: bool,
         margin: Option<Margin>,
@@ -1206,7 +1206,7 @@ mod tests {
 
     #[test]
     fn test_format_title() {
-        let input = snippet::Snippet::error("This is a title").id("E0001");
+        let input = snippet::Message::error("This is a title").id("E0001");
         let output = from_display_lines(vec![DisplayLine::Raw(DisplayRawLine::Annotation {
             annotation: Annotation {
                 annotation_type: DisplayAnnotationType::Error,
@@ -1227,7 +1227,7 @@ mod tests {
         let line_1 = "This is line 1";
         let line_2 = "This is line 2";
         let source = [line_1, line_2].join("\n");
-        let input = snippet::Snippet::error("").slice(snippet::Slice::new(&source, 5402));
+        let input = snippet::Message::error("").slice(snippet::Slice::new(&source, 5402));
         let output = from_display_lines(vec![
             DisplayLine::Raw(DisplayRawLine::Annotation {
                 annotation: Annotation {
@@ -1277,7 +1277,7 @@ mod tests {
         let src_0_len = src_0.len();
         let src_1 = "This is slice 2";
         let src_1_len = src_1.len();
-        let input = snippet::Snippet::error("")
+        let input = snippet::Message::error("")
             .slice(snippet::Slice::new(src_0, 5402).origin("file1.rs"))
             .slice(snippet::Slice::new(src_1, 2).origin("file2.rs"));
         let output = from_display_lines(vec![
@@ -1350,7 +1350,7 @@ mod tests {
         let source = [line_1, line_2].join("\n");
         // In line 2
         let range = 22..24;
-        let input = snippet::Snippet::error("").slice(
+        let input = snippet::Message::error("").slice(
             snippet::Slice::new(&source, 5402)
                 .annotation(snippet::Label::info("Test annotation").span(range.clone())),
         );
@@ -1420,7 +1420,7 @@ mod tests {
     #[test]
     fn test_format_label() {
         let input =
-            snippet::Snippet::error("").footer(snippet::Label::error("This __is__ a title"));
+            snippet::Message::error("").footer(snippet::Label::error("This __is__ a title"));
         let output = from_display_lines(vec![
             DisplayLine::Raw(DisplayRawLine::Annotation {
                 annotation: Annotation {
@@ -1455,7 +1455,7 @@ mod tests {
     fn test_i26() {
         let source = "short";
         let label = "label";
-        let input = snippet::Snippet::error("").slice(
+        let input = snippet::Message::error("").slice(
             snippet::Slice::new(source, 0)
                 .annotation(snippet::Label::error(label).span(0..source.len() + 2)),
         );
@@ -1464,7 +1464,7 @@ mod tests {
 
     #[test]
     fn test_i_29() {
-        let snippets = snippet::Snippet::error("oops").slice(
+        let snippets = snippet::Message::error("oops").slice(
             snippet::Slice::new("First line\r\nSecond oops line", 1)
                 .origin("<current file>")
                 .fold(true)

--- a/src/renderer/display_list.rs
+++ b/src/renderer/display_list.rs
@@ -1236,7 +1236,7 @@ mod tests {
         let source = [line_1, line_2].join("\n");
         let input = snippet::Level::Error
             .title("")
-            .snippet(snippet::Snippet::new(&source).line_start(5402));
+            .snippet(snippet::Snippet::source(&source).line_start(5402));
         let output = from_display_lines(vec![
             DisplayLine::Raw(DisplayRawLine::Annotation {
                 annotation: Annotation {
@@ -1289,12 +1289,12 @@ mod tests {
         let input = snippet::Level::Error
             .title("")
             .snippet(
-                snippet::Snippet::new(src_0)
+                snippet::Snippet::source(src_0)
                     .line_start(5402)
                     .origin("file1.rs"),
             )
             .snippet(
-                snippet::Snippet::new(src_1)
+                snippet::Snippet::source(src_1)
                     .line_start(2)
                     .origin("file2.rs"),
             );
@@ -1369,7 +1369,7 @@ mod tests {
         // In line 2
         let range = 22..24;
         let input = snippet::Level::Error.title("").snippet(
-            snippet::Snippet::new(&source)
+            snippet::Snippet::source(&source)
                 .line_start(5402)
                 .annotation(snippet::Label::info("Test annotation").span(range.clone())),
         );
@@ -1476,7 +1476,7 @@ mod tests {
         let source = "short";
         let label = "label";
         let input = snippet::Level::Error.title("").snippet(
-            snippet::Snippet::new(source)
+            snippet::Snippet::source(source)
                 .line_start(0)
                 .annotation(snippet::Label::error(label).span(0..source.len() + 2)),
         );
@@ -1486,7 +1486,7 @@ mod tests {
     #[test]
     fn test_i_29() {
         let snippets = snippet::Level::Error.title("oops").snippet(
-            snippet::Snippet::new("First line\r\nSecond oops line")
+            snippet::Snippet::source("First line\r\nSecond oops line")
                 .line_start(1)
                 .origin("<current file>")
                 .fold(true)

--- a/src/renderer/display_list.rs
+++ b/src/renderer/display_list.rs
@@ -649,14 +649,14 @@ pub enum DisplayAnnotationType {
     Help,
 }
 
-impl From<snippet::AnnotationType> for DisplayAnnotationType {
-    fn from(at: snippet::AnnotationType) -> Self {
+impl From<snippet::Level> for DisplayAnnotationType {
+    fn from(at: snippet::Level) -> Self {
         match at {
-            snippet::AnnotationType::Error => DisplayAnnotationType::Error,
-            snippet::AnnotationType::Warning => DisplayAnnotationType::Warning,
-            snippet::AnnotationType::Info => DisplayAnnotationType::Info,
-            snippet::AnnotationType::Note => DisplayAnnotationType::Note,
-            snippet::AnnotationType::Help => DisplayAnnotationType::Help,
+            snippet::Level::Error => DisplayAnnotationType::Error,
+            snippet::Level::Warning => DisplayAnnotationType::Warning,
+            snippet::Level::Info => DisplayAnnotationType::Info,
+            snippet::Level::Note => DisplayAnnotationType::Note,
+            snippet::Level::Help => DisplayAnnotationType::Help,
         }
     }
 }
@@ -736,7 +736,7 @@ fn format_label(
 fn format_title<'a>(title: snippet::Label<'a>, id: Option<&'a str>) -> DisplayLine<'a> {
     DisplayLine::Raw(DisplayRawLine::Annotation {
         annotation: Annotation {
-            annotation_type: DisplayAnnotationType::from(title.annotation_type),
+            annotation_type: DisplayAnnotationType::from(title.level),
             id,
             label: format_label(Some(title.label), Some(DisplayTextStyle::Emphasis)),
         },
@@ -750,7 +750,7 @@ fn format_footer(footer: snippet::Label<'_>) -> Vec<DisplayLine<'_>> {
     for (i, line) in footer.label.lines().enumerate() {
         result.push(DisplayLine::Raw(DisplayRawLine::Annotation {
             annotation: Annotation {
-                annotation_type: DisplayAnnotationType::from(footer.annotation_type),
+                annotation_type: DisplayAnnotationType::from(footer.level),
                 id: None,
                 label: format_label(Some(line), None),
             },
@@ -1010,10 +1010,10 @@ fn format_body(
         // It would be nice to use filter_drain here once it's stable.
         annotations.retain(|annotation| {
             let body_idx = idx + annotation_line_count;
-            let annotation_type = match annotation.annotation_type {
-                snippet::AnnotationType::Error => DisplayAnnotationType::None,
-                snippet::AnnotationType::Warning => DisplayAnnotationType::None,
-                _ => DisplayAnnotationType::from(annotation.annotation_type),
+            let annotation_type = match annotation.level {
+                snippet::Level::Error => DisplayAnnotationType::None,
+                snippet::Level::Warning => DisplayAnnotationType::None,
+                _ => DisplayAnnotationType::from(annotation.level),
             };
             match annotation.range {
                 Range { start, .. } if start > line_end_index => true,
@@ -1036,9 +1036,7 @@ fn format_body(
                                     label: format_label(Some(annotation.label), None),
                                 },
                                 range,
-                                annotation_type: DisplayAnnotationType::from(
-                                    annotation.annotation_type,
-                                ),
+                                annotation_type: DisplayAnnotationType::from(annotation.level),
                                 annotation_part: DisplayAnnotationPart::Standalone,
                             },
                         },
@@ -1059,9 +1057,7 @@ fn format_body(
                         {
                             inline_marks.push(DisplayMark {
                                 mark_type: DisplayMarkType::AnnotationStart,
-                                annotation_type: DisplayAnnotationType::from(
-                                    annotation.annotation_type,
-                                ),
+                                annotation_type: DisplayAnnotationType::from(annotation.level),
                             });
                         }
                     } else {
@@ -1079,9 +1075,7 @@ fn format_body(
                                         label: vec![],
                                     },
                                     range,
-                                    annotation_type: DisplayAnnotationType::from(
-                                        annotation.annotation_type,
-                                    ),
+                                    annotation_type: DisplayAnnotationType::from(annotation.level),
                                     annotation_part: DisplayAnnotationPart::MultilineStart,
                                 },
                             },
@@ -1098,9 +1092,7 @@ fn format_body(
                     {
                         inline_marks.push(DisplayMark {
                             mark_type: DisplayMarkType::AnnotationThrough,
-                            annotation_type: DisplayAnnotationType::from(
-                                annotation.annotation_type,
-                            ),
+                            annotation_type: DisplayAnnotationType::from(annotation.level),
                         });
                     }
                     true
@@ -1117,9 +1109,7 @@ fn format_body(
                     {
                         inline_marks.push(DisplayMark {
                             mark_type: DisplayMarkType::AnnotationThrough,
-                            annotation_type: DisplayAnnotationType::from(
-                                annotation.annotation_type,
-                            ),
+                            annotation_type: DisplayAnnotationType::from(annotation.level),
                         });
                     }
 
@@ -1131,9 +1121,7 @@ fn format_body(
                             lineno: None,
                             inline_marks: vec![DisplayMark {
                                 mark_type: DisplayMarkType::AnnotationThrough,
-                                annotation_type: DisplayAnnotationType::from(
-                                    annotation.annotation_type,
-                                ),
+                                annotation_type: DisplayAnnotationType::from(annotation.level),
                             }],
                             line: DisplaySourceLine::Annotation {
                                 annotation: Annotation {
@@ -1142,9 +1130,7 @@ fn format_body(
                                     label: format_label(Some(annotation.label), None),
                                 },
                                 range,
-                                annotation_type: DisplayAnnotationType::from(
-                                    annotation.annotation_type,
-                                ),
+                                annotation_type: DisplayAnnotationType::from(annotation.level),
                                 annotation_part: DisplayAnnotationPart::MultilineEnd,
                             },
                         },

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -4,8 +4,8 @@
 //! ```
 //! use annotate_snippets::{Renderer, Snippet, Level};
 //! let snippet = Level::Error.title("mismatched types")
-//!     .snippet(Snippet::new("Foo").line_start(51).origin("src/format.rs"))
-//!     .snippet(Snippet::new("Faa").line_start(129).origin("src/display.rs"));
+//!     .snippet(Snippet::source("Foo").line_start(51).origin("src/format.rs"))
+//!     .snippet(Snippet::source("Faa").line_start(129).origin("src/display.rs"));
 //!
 //!  let renderer = Renderer::styled();
 //!  println!("{}", renderer.render(snippet));

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1,9 +1,9 @@
-//! The renderer for [`Snippet`]s
+//! The renderer for [`Message`]s
 //!
 //! # Example
 //! ```
-//! use annotate_snippets::{Renderer, Slice, Snippet};
-//! let snippet = Snippet::error("mismatched types")
+//! use annotate_snippets::{Renderer, Slice, Message};
+//! let snippet = Message::error("mismatched types")
 //!     .slice(Slice::new("Foo", 51).origin("src/format.rs"))
 //!     .slice(Slice::new("Faa", 129).origin("src/display.rs"));
 //!
@@ -14,14 +14,14 @@ mod display_list;
 mod margin;
 pub(crate) mod stylesheet;
 
-use crate::snippet::Snippet;
+use crate::snippet::Message;
 pub use anstyle::*;
 use display_list::DisplayList;
 pub use margin::Margin;
 use std::fmt::Display;
 use stylesheet::Stylesheet;
 
-/// A renderer for [`Snippet`]s
+/// A renderer for [`Message`]s
 #[derive(Clone)]
 pub struct Renderer {
     anonymized_line_numbers: bool,
@@ -165,9 +165,9 @@ impl Renderer {
     }
 
     /// Render a snippet into a `Display`able object
-    pub fn render<'a>(&'a self, snippet: Snippet<'a>) -> impl Display + 'a {
+    pub fn render<'a>(&'a self, msg: Message<'a>) -> impl Display + 'a {
         DisplayList::new(
-            snippet,
+            msg,
             &self.stylesheet,
             self.anonymized_line_numbers,
             self.margin,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -4,8 +4,8 @@
 //! ```
 //! use annotate_snippets::{Renderer, Snippet, Message};
 //! let snippet = Message::error("mismatched types")
-//!     .snippet(Snippet::new("Foo", 51).origin("src/format.rs"))
-//!     .snippet(Snippet::new("Faa", 129).origin("src/display.rs"));
+//!     .snippet(Snippet::new("Foo").line_start(51).origin("src/format.rs"))
+//!     .snippet(Snippet::new("Faa").line_start(129).origin("src/display.rs"));
 //!
 //!  let renderer = Renderer::styled();
 //!  println!("{}", renderer.render(snippet));

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -2,10 +2,10 @@
 //!
 //! # Example
 //! ```
-//! use annotate_snippets::{Renderer, Slice, Message};
+//! use annotate_snippets::{Renderer, Snippet, Message};
 //! let snippet = Message::error("mismatched types")
-//!     .slice(Slice::new("Foo", 51).origin("src/format.rs"))
-//!     .slice(Slice::new("Faa", 129).origin("src/display.rs"));
+//!     .snippet(Snippet::new("Foo", 51).origin("src/format.rs"))
+//!     .snippet(Snippet::new("Faa", 129).origin("src/display.rs"));
 //!
 //!  let renderer = Renderer::styled();
 //!  println!("{}", renderer.render(snippet));

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! # Example
 //! ```
-//! use annotate_snippets::{Renderer, Snippet, Message};
-//! let snippet = Message::error("mismatched types")
+//! use annotate_snippets::{Renderer, Snippet, Level};
+//! let snippet = Level::Error.title("mismatched types")
 //!     .snippet(Snippet::new("Foo").line_start(51).origin("src/format.rs"))
 //!     .snippet(Snippet::new("Faa").line_start(129).origin("src/display.rs"));
 //!

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -152,6 +152,17 @@ impl<'a> Snippet<'a> {
     }
 }
 
+/// An annotation for a [`Snippet`].
+///
+/// This gets created by [`Label::span`].
+#[derive(Debug)]
+pub struct Annotation<'a> {
+    /// The byte range of the annotation in the `source` string
+    pub(crate) range: Range<usize>,
+    pub(crate) label: &'a str,
+    pub(crate) level: Level,
+}
+
 /// Types of annotations.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Level {
@@ -162,15 +173,4 @@ pub enum Level {
     Info,
     Note,
     Help,
-}
-
-/// An annotation for a [`Snippet`].
-///
-/// This gets created by [`Label::span`].
-#[derive(Debug)]
-pub struct Annotation<'a> {
-    /// The byte range of the annotation in the `source` string
-    pub(crate) range: Range<usize>,
-    pub(crate) label: &'a str,
-    pub(crate) level: Level,
 }

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -116,19 +116,21 @@ impl<'a> Label<'a> {
 /// One `Snippet` is meant to represent a single, continuous,
 /// slice of source code that you want to annotate.
 pub struct Snippet<'a> {
-    pub(crate) source: &'a str,
-    pub(crate) line_start: usize,
     pub(crate) origin: Option<&'a str>,
+    pub(crate) line_start: usize,
+
+    pub(crate) source: &'a str,
     pub(crate) annotations: Vec<Annotation<'a>>,
+
     pub(crate) fold: bool,
 }
 
 impl<'a> Snippet<'a> {
     pub fn new(source: &'a str, line_start: usize) -> Self {
         Self {
-            source,
-            line_start,
             origin: None,
+            line_start,
+            source,
             annotations: vec![],
             fold: false,
         }

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -113,15 +113,6 @@ impl<'a> Label<'a> {
     }
 }
 
-impl From<AnnotationType> for Label<'_> {
-    fn from(annotation_type: AnnotationType) -> Self {
-        Label {
-            annotation_type,
-            label: "",
-        }
-    }
-}
-
 /// Structure containing the slice of text to be annotated and
 /// basic information about the location of the slice.
 ///

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -5,7 +5,7 @@
 //! ```
 //! use annotate_snippets::*;
 //!
-//! Message::error("mismatched types")
+//! Level::Error.title("mismatched types")
 //!     .snippet(Snippet::new("Foo").line_start(51).origin("src/format.rs"))
 //!     .snippet(Snippet::new("Faa").line_start(129).origin("src/display.rs"));
 //! ```
@@ -13,43 +13,17 @@
 use std::ops::Range;
 
 /// Primary structure provided for formatting
+///
+/// See [`Level::title`] to create a [`Message`]
 pub struct Message<'a> {
-    pub(crate) title: Label<'a>,
+    pub(crate) level: Level,
     pub(crate) id: Option<&'a str>,
+    pub(crate) title: &'a str,
     pub(crate) snippets: Vec<Snippet<'a>>,
     pub(crate) footer: Vec<Label<'a>>,
 }
 
 impl<'a> Message<'a> {
-    pub fn title(title: Label<'a>) -> Self {
-        Self {
-            title,
-            id: None,
-            snippets: vec![],
-            footer: vec![],
-        }
-    }
-
-    pub fn error(title: &'a str) -> Self {
-        Self::title(Label::error(title))
-    }
-
-    pub fn warning(title: &'a str) -> Self {
-        Self::title(Label::warning(title))
-    }
-
-    pub fn info(title: &'a str) -> Self {
-        Self::title(Label::info(title))
-    }
-
-    pub fn note(title: &'a str) -> Self {
-        Self::title(Label::note(title))
-    }
-
-    pub fn help(title: &'a str) -> Self {
-        Self::title(Label::help(title))
-    }
-
     pub fn id(mut self, id: &'a str) -> Self {
         self.id = Some(id);
         self
@@ -178,4 +152,16 @@ pub enum Level {
     Info,
     Note,
     Help,
+}
+
+impl Level {
+    pub fn title(self, title: &str) -> Message<'_> {
+        Message {
+            level: self,
+            id: None,
+            title,
+            snippets: vec![],
+            footer: vec![],
+        }
+    }
 }

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -34,8 +34,18 @@ impl<'a> Message<'a> {
         self
     }
 
+    pub fn snippets(mut self, slice: impl IntoIterator<Item = Snippet<'a>>) -> Self {
+        self.snippets.extend(slice);
+        self
+    }
+
     pub fn footer(mut self, footer: Label<'a>) -> Self {
         self.footer.push(footer);
+        self
+    }
+
+    pub fn footers(mut self, footer: impl IntoIterator<Item = Label<'a>>) -> Self {
+        self.footer.extend(footer);
         self
     }
 }
@@ -113,6 +123,11 @@ impl<'a> Snippet<'a> {
 
     pub fn annotation(mut self, annotation: Annotation<'a>) -> Self {
         self.annotations.push(annotation);
+        self
+    }
+
+    pub fn annotations(mut self, annotation: impl IntoIterator<Item = Annotation<'a>>) -> Self {
+        self.annotations.extend(annotation);
         self
     }
 

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -100,9 +100,9 @@ impl<'a> Label<'a> {
         self
     }
 
-    /// Create a [`SourceAnnotation`] with the given span for a [`Slice`]
-    pub fn span(&self, span: Range<usize>) -> SourceAnnotation<'a> {
-        SourceAnnotation {
+    /// Create a [`Annotation`] with the given span for a [`Slice`]
+    pub fn span(&self, span: Range<usize>) -> Annotation<'a> {
+        Annotation {
             range: span,
             label: self.label,
             level: self.level,
@@ -119,7 +119,7 @@ pub struct Slice<'a> {
     pub(crate) source: &'a str,
     pub(crate) line_start: usize,
     pub(crate) origin: Option<&'a str>,
-    pub(crate) annotations: Vec<SourceAnnotation<'a>>,
+    pub(crate) annotations: Vec<Annotation<'a>>,
     pub(crate) fold: bool,
 }
 
@@ -139,7 +139,7 @@ impl<'a> Slice<'a> {
         self
     }
 
-    pub fn annotation(mut self, annotation: SourceAnnotation<'a>) -> Self {
+    pub fn annotation(mut self, annotation: Annotation<'a>) -> Self {
         self.annotations.push(annotation);
         self
     }
@@ -166,7 +166,7 @@ pub enum Level {
 ///
 /// This gets created by [`Label::span`].
 #[derive(Debug)]
-pub struct SourceAnnotation<'a> {
+pub struct Annotation<'a> {
     /// The byte range of the annotation in the `source` string
     pub(crate) range: Range<usize>,
     pub(crate) label: &'a str,

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -73,15 +73,6 @@ impl<'a> Label<'a> {
         self.label = label;
         self
     }
-
-    /// Create a [`Annotation`] with the given span for a [`Snippet`]
-    pub fn span(&self, span: Range<usize>) -> Annotation<'a> {
-        Annotation {
-            range: span,
-            label: self.label,
-            level: self.level,
-        }
-    }
 }
 
 /// Structure containing the slice of text to be annotated and
@@ -133,13 +124,20 @@ impl<'a> Snippet<'a> {
 
 /// An annotation for a [`Snippet`].
 ///
-/// This gets created by [`Label::span`].
+/// See [`Level::span`] to create a [`Annotation`]
 #[derive(Debug)]
 pub struct Annotation<'a> {
     /// The byte range of the annotation in the `source` string
     pub(crate) range: Range<usize>,
-    pub(crate) label: &'a str,
+    pub(crate) label: Option<&'a str>,
     pub(crate) level: Level,
+}
+
+impl<'a> Annotation<'a> {
+    pub fn label(mut self, label: &'a str) -> Self {
+        self.label = Some(label);
+        self
+    }
 }
 
 /// Types of annotations.
@@ -162,6 +160,15 @@ impl Level {
             title,
             snippets: vec![],
             footer: vec![],
+        }
+    }
+
+    /// Create a [`Annotation`] with the given span for a [`Snippet`]
+    pub fn span<'a>(self, span: Range<usize>) -> Annotation<'a> {
+        Annotation {
+            range: span,
+            label: None,
+            level: self,
         }
     }
 }

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -131,6 +131,7 @@ impl<'a> Snippet<'a> {
         self
     }
 
+    /// Hide lines without [`Annotation`]s
     pub fn fold(mut self, fold: bool) -> Self {
         self.fold = fold;
         self

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -67,35 +67,32 @@ impl<'a> Snippet<'a> {
 }
 
 pub struct Label<'a> {
-    pub(crate) annotation_type: AnnotationType,
+    pub(crate) level: Level,
     pub(crate) label: &'a str,
 }
 
 impl<'a> Label<'a> {
-    pub fn new(annotation_type: AnnotationType, label: &'a str) -> Self {
-        Self {
-            annotation_type,
-            label,
-        }
+    pub fn new(level: Level, label: &'a str) -> Self {
+        Self { level, label }
     }
     pub fn error(label: &'a str) -> Self {
-        Self::new(AnnotationType::Error, label)
+        Self::new(Level::Error, label)
     }
 
     pub fn warning(label: &'a str) -> Self {
-        Self::new(AnnotationType::Warning, label)
+        Self::new(Level::Warning, label)
     }
 
     pub fn info(label: &'a str) -> Self {
-        Self::new(AnnotationType::Info, label)
+        Self::new(Level::Info, label)
     }
 
     pub fn note(label: &'a str) -> Self {
-        Self::new(AnnotationType::Note, label)
+        Self::new(Level::Note, label)
     }
 
     pub fn help(label: &'a str) -> Self {
-        Self::new(AnnotationType::Help, label)
+        Self::new(Level::Help, label)
     }
 
     pub fn label(mut self, label: &'a str) -> Self {
@@ -108,7 +105,7 @@ impl<'a> Label<'a> {
         SourceAnnotation {
             range: span,
             label: self.label,
-            annotation_type: self.annotation_type,
+            level: self.level,
         }
     }
 }
@@ -155,7 +152,7 @@ impl<'a> Slice<'a> {
 
 /// Types of annotations.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum AnnotationType {
+pub enum Level {
     /// Error annotations are displayed using red color and "^" character.
     Error,
     /// Warning annotations are displayed using blue color and "-" character.
@@ -173,5 +170,5 @@ pub struct SourceAnnotation<'a> {
     /// The byte range of the annotation in the `source` string
     pub(crate) range: Range<usize>,
     pub(crate) label: &'a str,
-    pub(crate) annotation_type: AnnotationType,
+    pub(crate) level: Level,
 }

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -6,8 +6,8 @@
 //! use annotate_snippets::*;
 //!
 //! Message::error("mismatched types")
-//!     .slice(Slice::new("Foo", 51).origin("src/format.rs"))
-//!     .slice(Slice::new("Faa", 129).origin("src/display.rs"));
+//!     .snippet(Snippet::new("Foo", 51).origin("src/format.rs"))
+//!     .snippet(Snippet::new("Faa", 129).origin("src/display.rs"));
 //! ```
 
 use std::ops::Range;
@@ -16,7 +16,7 @@ use std::ops::Range;
 pub struct Message<'a> {
     pub(crate) title: Label<'a>,
     pub(crate) id: Option<&'a str>,
-    pub(crate) slices: Vec<Slice<'a>>,
+    pub(crate) snippets: Vec<Snippet<'a>>,
     pub(crate) footer: Vec<Label<'a>>,
 }
 
@@ -25,7 +25,7 @@ impl<'a> Message<'a> {
         Self {
             title,
             id: None,
-            slices: vec![],
+            snippets: vec![],
             footer: vec![],
         }
     }
@@ -55,8 +55,8 @@ impl<'a> Message<'a> {
         self
     }
 
-    pub fn slice(mut self, slice: Slice<'a>) -> Self {
-        self.slices.push(slice);
+    pub fn snippet(mut self, slice: Snippet<'a>) -> Self {
+        self.snippets.push(slice);
         self
     }
 
@@ -100,7 +100,7 @@ impl<'a> Label<'a> {
         self
     }
 
-    /// Create a [`Annotation`] with the given span for a [`Slice`]
+    /// Create a [`Annotation`] with the given span for a [`Snippet`]
     pub fn span(&self, span: Range<usize>) -> Annotation<'a> {
         Annotation {
             range: span,
@@ -113,9 +113,9 @@ impl<'a> Label<'a> {
 /// Structure containing the slice of text to be annotated and
 /// basic information about the location of the slice.
 ///
-/// One `Slice` is meant to represent a single, continuous,
+/// One `Snippet` is meant to represent a single, continuous,
 /// slice of source code that you want to annotate.
-pub struct Slice<'a> {
+pub struct Snippet<'a> {
     pub(crate) source: &'a str,
     pub(crate) line_start: usize,
     pub(crate) origin: Option<&'a str>,
@@ -123,7 +123,7 @@ pub struct Slice<'a> {
     pub(crate) fold: bool,
 }
 
-impl<'a> Slice<'a> {
+impl<'a> Snippet<'a> {
     pub fn new(source: &'a str, line_start: usize) -> Self {
         Self {
             source,
@@ -162,7 +162,7 @@ pub enum Level {
     Help,
 }
 
-/// An annotation for a [`Slice`].
+/// An annotation for a [`Snippet`].
 ///
 /// This gets created by [`Label::span`].
 #[derive(Debug)]

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -5,7 +5,7 @@
 //! ```
 //! use annotate_snippets::*;
 //!
-//! Snippet::error("mismatched types")
+//! Message::error("mismatched types")
 //!     .slice(Slice::new("Foo", 51).origin("src/format.rs"))
 //!     .slice(Slice::new("Faa", 129).origin("src/display.rs"));
 //! ```
@@ -13,14 +13,14 @@
 use std::ops::Range;
 
 /// Primary structure provided for formatting
-pub struct Snippet<'a> {
+pub struct Message<'a> {
     pub(crate) title: Label<'a>,
     pub(crate) id: Option<&'a str>,
     pub(crate) slices: Vec<Slice<'a>>,
     pub(crate) footer: Vec<Label<'a>>,
 }
 
-impl<'a> Snippet<'a> {
+impl<'a> Message<'a> {
     pub fn title(title: Label<'a>) -> Self {
         Self {
             title,

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -6,8 +6,8 @@
 //! use annotate_snippets::*;
 //!
 //! Level::Error.title("mismatched types")
-//!     .snippet(Snippet::new("Foo").line_start(51).origin("src/format.rs"))
-//!     .snippet(Snippet::new("Faa").line_start(129).origin("src/display.rs"));
+//!     .snippet(Snippet::source("Foo").line_start(51).origin("src/format.rs"))
+//!     .snippet(Snippet::source("Faa").line_start(129).origin("src/display.rs"));
 //! ```
 
 use std::ops::Range;
@@ -100,7 +100,7 @@ pub struct Snippet<'a> {
 }
 
 impl<'a> Snippet<'a> {
-    pub fn new(source: &'a str) -> Self {
+    pub fn source(source: &'a str) -> Self {
         Self {
             origin: None,
             line_start: 1,

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -6,8 +6,8 @@
 //! use annotate_snippets::*;
 //!
 //! Message::error("mismatched types")
-//!     .snippet(Snippet::new("Foo", 51).origin("src/format.rs"))
-//!     .snippet(Snippet::new("Faa", 129).origin("src/display.rs"));
+//!     .snippet(Snippet::new("Foo").line_start(51).origin("src/format.rs"))
+//!     .snippet(Snippet::new("Faa").line_start(129).origin("src/display.rs"));
 //! ```
 
 use std::ops::Range;
@@ -126,14 +126,19 @@ pub struct Snippet<'a> {
 }
 
 impl<'a> Snippet<'a> {
-    pub fn new(source: &'a str, line_start: usize) -> Self {
+    pub fn new(source: &'a str) -> Self {
         Self {
             origin: None,
-            line_start,
+            line_start: 1,
             source,
             annotations: vec![],
             fold: false,
         }
+    }
+
+    pub fn line_start(mut self, line_start: usize) -> Self {
+        self.line_start = line_start;
+        self
     }
 
     pub fn origin(mut self, origin: &'a str) -> Self {

--- a/tests/fixtures/deserialize.rs
+++ b/tests/fixtures/deserialize.rs
@@ -1,18 +1,18 @@
 use serde::{Deserialize, Deserializer, Serialize};
 use std::ops::Range;
 
-use annotate_snippets::{renderer::Margin, Annotation, Label, Level, Renderer, Slice, Snippet};
+use annotate_snippets::{renderer::Margin, Annotation, Label, Level, Message, Renderer, Slice};
 
 #[derive(Deserialize)]
 pub struct Fixture<'a> {
     #[serde(default)]
     pub renderer: RendererDef,
     #[serde(borrow)]
-    pub snippet: SnippetDef<'a>,
+    pub message: MessageDef<'a>,
 }
 
 #[derive(Deserialize)]
-pub struct SnippetDef<'a> {
+pub struct MessageDef<'a> {
     #[serde(deserialize_with = "deserialize_label")]
     #[serde(borrow)]
     pub title: Label<'a>,
@@ -28,25 +28,25 @@ pub struct SnippetDef<'a> {
     pub slices: Vec<Slice<'a>>,
 }
 
-impl<'a> From<SnippetDef<'a>> for Snippet<'a> {
-    fn from(val: SnippetDef<'a>) -> Self {
-        let SnippetDef {
+impl<'a> From<MessageDef<'a>> for Message<'a> {
+    fn from(val: MessageDef<'a>) -> Self {
+        let MessageDef {
             title,
             id,
             footer,
             slices,
         } = val;
-        let mut snippet = Snippet::title(title);
+        let mut message = Message::title(title);
         if let Some(id) = id {
-            snippet = snippet.id(id);
+            message = message.id(id);
         }
-        snippet = slices
+        message = slices
             .into_iter()
-            .fold(snippet, |snippet, slice| snippet.slice(slice));
-        snippet = footer
+            .fold(message, |message, slice| message.slice(slice));
+        message = footer
             .into_iter()
-            .fold(snippet, |snippet, label| snippet.footer(label));
-        snippet
+            .fold(message, |message, label| message.footer(label));
+        message
     }
 }
 

--- a/tests/fixtures/deserialize.rs
+++ b/tests/fixtures/deserialize.rs
@@ -147,7 +147,7 @@ impl<'a> From<AnnotationDef<'a>> for Annotation<'a> {
             label,
             level,
         } = val;
-        Label::new(level, label).span(range)
+        level.span(range).label(label)
     }
 }
 

--- a/tests/fixtures/deserialize.rs
+++ b/tests/fixtures/deserialize.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::ops::Range;
 
 use annotate_snippets::{
-    renderer::Margin, AnnotationType, Label, Renderer, Slice, Snippet, SourceAnnotation,
+    renderer::Margin, Label, Level, Renderer, Slice, Snippet, SourceAnnotation,
 };
 
 #[derive(Deserialize)]
@@ -63,8 +63,7 @@ where
         LabelDef<'a>,
     );
 
-    Wrapper::deserialize(deserializer)
-        .map(|Wrapper(label)| Label::new(label.annotation_type, label.label))
+    Wrapper::deserialize(deserializer).map(|Wrapper(label)| Label::new(label.level, label.label))
 }
 
 fn deserialize_labels<'de, D>(deserializer: D) -> Result<Vec<Label<'de>>, D::Error>
@@ -80,7 +79,7 @@ where
 
     let v = Vec::deserialize(deserializer)?;
     Ok(v.into_iter()
-        .map(|Wrapper(a)| Label::new(a.annotation_type, a.label))
+        .map(|Wrapper(a)| Label::new(a.level, a.label))
         .collect())
 }
 
@@ -151,8 +150,8 @@ pub struct SourceAnnotationDef<'a> {
     pub range: Range<usize>,
     #[serde(borrow)]
     pub label: &'a str,
-    #[serde(with = "AnnotationTypeDef")]
-    pub annotation_type: AnnotationType,
+    #[serde(with = "LevelDef")]
+    pub level: Level,
 }
 
 impl<'a> From<SourceAnnotationDef<'a>> for SourceAnnotation<'a> {
@@ -160,24 +159,24 @@ impl<'a> From<SourceAnnotationDef<'a>> for SourceAnnotation<'a> {
         let SourceAnnotationDef {
             range,
             label,
-            annotation_type,
+            level,
         } = val;
-        Label::new(annotation_type, label).span(range)
+        Label::new(level, label).span(range)
     }
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct LabelDef<'a> {
-    #[serde(with = "AnnotationTypeDef")]
-    pub annotation_type: AnnotationType,
+    #[serde(with = "LevelDef")]
+    pub level: Level,
     #[serde(borrow)]
     pub label: &'a str,
 }
 
 #[allow(dead_code)]
 #[derive(Serialize, Deserialize)]
-#[serde(remote = "AnnotationType")]
-enum AnnotationTypeDef {
+#[serde(remote = "Level")]
+enum LevelDef {
     Error,
     Warning,
     Info,

--- a/tests/fixtures/deserialize.rs
+++ b/tests/fixtures/deserialize.rs
@@ -107,7 +107,7 @@ impl<'a> From<SnippetDef<'a>> for Snippet<'a> {
             annotations,
             fold,
         } = val;
-        let mut snippet = Snippet::new(source).line_start(line_start).fold(fold);
+        let mut snippet = Snippet::source(source).line_start(line_start).fold(fold);
         if let Some(origin) = origin {
             snippet = snippet.origin(origin)
         }

--- a/tests/fixtures/deserialize.rs
+++ b/tests/fixtures/deserialize.rs
@@ -42,12 +42,8 @@ impl<'a> From<MessageDef<'a>> for Message<'a> {
         if let Some(id) = id {
             message = message.id(id);
         }
-        message = snippets
-            .into_iter()
-            .fold(message, |message, snippet| message.snippet(snippet));
-        message = footer
-            .into_iter()
-            .fold(message, |message, label| message.footer(label));
+        message = message.snippets(snippets);
+        message = message.footers(footer);
         message
     }
 }
@@ -111,11 +107,7 @@ impl<'a> From<SnippetDef<'a>> for Snippet<'a> {
         if let Some(origin) = origin {
             snippet = snippet.origin(origin)
         }
-        snippet = annotations
-            .into_iter()
-            .fold(snippet, |snippet, annotation| {
-                snippet.annotation(annotation)
-            });
+        snippet = snippet.annotations(annotations);
         snippet
     }
 }

--- a/tests/fixtures/deserialize.rs
+++ b/tests/fixtures/deserialize.rs
@@ -119,7 +119,7 @@ impl<'a> From<SnippetDef<'a>> for Snippet<'a> {
             annotations,
             fold,
         } = val;
-        let mut snippet = Snippet::new(source, line_start).fold(fold);
+        let mut snippet = Snippet::new(source).line_start(line_start).fold(fold);
         if let Some(origin) = origin {
             snippet = snippet.origin(origin)
         }

--- a/tests/fixtures/main.rs
+++ b/tests/fixtures/main.rs
@@ -1,7 +1,7 @@
 mod deserialize;
 
 use crate::deserialize::Fixture;
-use annotate_snippets::{Renderer, Snippet};
+use annotate_snippets::{Message, Renderer};
 use snapbox::data::DataFormat;
 use snapbox::Data;
 use std::error::Error;
@@ -26,8 +26,8 @@ fn setup(input_path: std::path::PathBuf) -> snapbox::harness::Case {
 
 fn test(input_path: &std::path::Path) -> Result<Data, Box<dyn Error>> {
     let src = std::fs::read_to_string(input_path)?;
-    let (renderer, snippet): (Renderer, Snippet<'_>) =
-        toml::from_str(&src).map(|a: Fixture| (a.renderer.into(), a.snippet.into()))?;
-    let actual = renderer.render(snippet).to_string();
+    let (renderer, message): (Renderer, Message<'_>) =
+        toml::from_str(&src).map(|a: Fixture| (a.renderer.into(), a.message.into()))?;
+    let actual = renderer.render(message).to_string();
     Ok(Data::from(actual).coerce_to(DataFormat::TermSvg))
 }

--- a/tests/fixtures/no-color/issue_52.toml
+++ b/tests/fixtures/no-color/issue_52.toml
@@ -2,7 +2,7 @@
 level = "Error"
 label = ""
 
-[[message.slices]]
+[[message.snippets]]
 source = """
 
 
@@ -11,7 +11,7 @@ invalid syntax
 line_start = 1
 origin = "path/to/error.rs"
 fold = true
-[[message.slices.annotations]]
+[[message.snippets.annotations]]
 label = "error here"
 level = "Warning"
 range = [2,16]

--- a/tests/fixtures/no-color/issue_52.toml
+++ b/tests/fixtures/no-color/issue_52.toml
@@ -1,8 +1,8 @@
-[snippet.title]
+[message.title]
 level = "Error"
 label = ""
 
-[[snippet.slices]]
+[[message.slices]]
 source = """
 
 
@@ -11,7 +11,7 @@ invalid syntax
 line_start = 1
 origin = "path/to/error.rs"
 fold = true
-[[snippet.slices.annotations]]
+[[message.slices.annotations]]
 label = "error here"
 level = "Warning"
 range = [2,16]

--- a/tests/fixtures/no-color/issue_52.toml
+++ b/tests/fixtures/no-color/issue_52.toml
@@ -1,5 +1,5 @@
 [snippet.title]
-annotation_type = "Error"
+level = "Error"
 label = ""
 
 [[snippet.slices]]
@@ -13,5 +13,5 @@ origin = "path/to/error.rs"
 fold = true
 [[snippet.slices.annotations]]
 label = "error here"
-annotation_type = "Warning"
+level = "Warning"
 range = [2,16]

--- a/tests/fixtures/no-color/issue_52.toml
+++ b/tests/fixtures/no-color/issue_52.toml
@@ -1,6 +1,6 @@
-[message.title]
+[message]
 level = "Error"
-label = ""
+title = ""
 
 [[message.snippets]]
 source = """

--- a/tests/fixtures/no-color/issue_9.toml
+++ b/tests/fixtures/no-color/issue_9.toml
@@ -1,28 +1,28 @@
-[snippet.title]
+[message.title]
 label = "expected one of `.`, `;`, `?`, or an operator, found `for`"
 level = "Error"
 
-[[snippet.slices]]
+[[message.slices]]
 source = "let x = vec![1];"
 line_start = 4
 origin = "/code/rust/src/test/ui/annotate-snippet/suggestion.rs"
-[[snippet.slices.annotations]]
+[[message.slices.annotations]]
 label = "move occurs because `x` has type `std::vec::Vec<i32>`, which does not implement the `Copy` trait"
 level = "Warning"
 range = [4, 5]
 
-[[snippet.slices]]
+[[message.slices]]
 source = "let y = x;"
 line_start = 7
-[[snippet.slices.annotations]]
+[[message.slices.annotations]]
 label = "value moved here"
 level = "Warning"
 range = [8, 9]
 
-[[snippet.slices]]
+[[message.slices]]
 source = "x;"
 line_start = 9
-[[snippet.slices.annotations]]
+[[message.slices.annotations]]
 label = "value used here after move"
 level = "Error"
 range = [0, 1]

--- a/tests/fixtures/no-color/issue_9.toml
+++ b/tests/fixtures/no-color/issue_9.toml
@@ -1,6 +1,6 @@
 [snippet.title]
 label = "expected one of `.`, `;`, `?`, or an operator, found `for`"
-annotation_type = "Error"
+level = "Error"
 
 [[snippet.slices]]
 source = "let x = vec![1];"
@@ -8,7 +8,7 @@ line_start = 4
 origin = "/code/rust/src/test/ui/annotate-snippet/suggestion.rs"
 [[snippet.slices.annotations]]
 label = "move occurs because `x` has type `std::vec::Vec<i32>`, which does not implement the `Copy` trait"
-annotation_type = "Warning"
+level = "Warning"
 range = [4, 5]
 
 [[snippet.slices]]
@@ -16,7 +16,7 @@ source = "let y = x;"
 line_start = 7
 [[snippet.slices.annotations]]
 label = "value moved here"
-annotation_type = "Warning"
+level = "Warning"
 range = [8, 9]
 
 [[snippet.slices]]
@@ -24,5 +24,5 @@ source = "x;"
 line_start = 9
 [[snippet.slices.annotations]]
 label = "value used here after move"
-annotation_type = "Error"
+level = "Error"
 range = [0, 1]

--- a/tests/fixtures/no-color/issue_9.toml
+++ b/tests/fixtures/no-color/issue_9.toml
@@ -2,27 +2,27 @@
 label = "expected one of `.`, `;`, `?`, or an operator, found `for`"
 level = "Error"
 
-[[message.slices]]
+[[message.snippets]]
 source = "let x = vec![1];"
 line_start = 4
 origin = "/code/rust/src/test/ui/annotate-snippet/suggestion.rs"
-[[message.slices.annotations]]
+[[message.snippets.annotations]]
 label = "move occurs because `x` has type `std::vec::Vec<i32>`, which does not implement the `Copy` trait"
 level = "Warning"
 range = [4, 5]
 
-[[message.slices]]
+[[message.snippets]]
 source = "let y = x;"
 line_start = 7
-[[message.slices.annotations]]
+[[message.snippets.annotations]]
 label = "value moved here"
 level = "Warning"
 range = [8, 9]
 
-[[message.slices]]
+[[message.snippets]]
 source = "x;"
 line_start = 9
-[[message.slices.annotations]]
+[[message.snippets.annotations]]
 label = "value used here after move"
 level = "Error"
 range = [0, 1]

--- a/tests/fixtures/no-color/issue_9.toml
+++ b/tests/fixtures/no-color/issue_9.toml
@@ -1,6 +1,6 @@
-[message.title]
-label = "expected one of `.`, `;`, `?`, or an operator, found `for`"
+[message]
 level = "Error"
+title = "expected one of `.`, `;`, `?`, or an operator, found `for`"
 
 [[message.snippets]]
 source = "let x = vec![1];"

--- a/tests/fixtures/no-color/multiline_annotation.toml
+++ b/tests/fixtures/no-color/multiline_annotation.toml
@@ -1,3 +1,8 @@
+[message]
+level = "Error"
+id = "E0308"
+title = "mismatched types"
+
 [[message.snippets]]
 source = """
 ) -> Option<String> {
@@ -34,7 +39,3 @@ range = [5, 19]
 label = "expected enum `std::option::Option`, found ()"
 level = "Error"
 range = [22, 766]
-
-[message]
-title = { level = "Error", label = "mismatched types" }
-id = "E0308"

--- a/tests/fixtures/no-color/multiline_annotation.toml
+++ b/tests/fixtures/no-color/multiline_annotation.toml
@@ -1,4 +1,4 @@
-[[message.slices]]
+[[message.snippets]]
 source = """
 ) -> Option<String> {
     for ann in annotations {
@@ -26,11 +26,11 @@ source = """
 line_start = 51
 origin = "src/format.rs"
 fold = true
-[[message.slices.annotations]]
+[[message.snippets.annotations]]
 label = "expected `std::option::Option<std::string::String>` because of return type"
 level = "Warning"
 range = [5, 19]
-[[message.slices.annotations]]
+[[message.snippets.annotations]]
 label = "expected enum `std::option::Option`, found ()"
 level = "Error"
 range = [22, 766]

--- a/tests/fixtures/no-color/multiline_annotation.toml
+++ b/tests/fixtures/no-color/multiline_annotation.toml
@@ -28,13 +28,13 @@ origin = "src/format.rs"
 fold = true
 [[snippet.slices.annotations]]
 label = "expected `std::option::Option<std::string::String>` because of return type"
-annotation_type = "Warning"
+level = "Warning"
 range = [5, 19]
 [[snippet.slices.annotations]]
 label = "expected enum `std::option::Option`, found ()"
-annotation_type = "Error"
+level = "Error"
 range = [22, 766]
 
 [snippet]
-title = { annotation_type = "Error", label = "mismatched types" }
+title = { level = "Error", label = "mismatched types" }
 id = "E0308"

--- a/tests/fixtures/no-color/multiline_annotation.toml
+++ b/tests/fixtures/no-color/multiline_annotation.toml
@@ -1,4 +1,4 @@
-[[snippet.slices]]
+[[message.slices]]
 source = """
 ) -> Option<String> {
     for ann in annotations {
@@ -26,15 +26,15 @@ source = """
 line_start = 51
 origin = "src/format.rs"
 fold = true
-[[snippet.slices.annotations]]
+[[message.slices.annotations]]
 label = "expected `std::option::Option<std::string::String>` because of return type"
 level = "Warning"
 range = [5, 19]
-[[snippet.slices.annotations]]
+[[message.slices.annotations]]
 label = "expected enum `std::option::Option`, found ()"
 level = "Error"
 range = [22, 766]
 
-[snippet]
+[message]
 title = { level = "Error", label = "mismatched types" }
 id = "E0308"

--- a/tests/fixtures/no-color/multiline_annotation2.toml
+++ b/tests/fixtures/no-color/multiline_annotation2.toml
@@ -1,4 +1,4 @@
-[[message.slices]]
+[[message.snippets]]
 source = """
                         if let DisplayLine::Source {
                             ref mut inline_marks,
@@ -7,7 +7,7 @@ source = """
 line_start = 139
 origin = "src/display_list.rs"
 fold = false
-[[message.slices.annotations]]
+[[message.snippets.annotations]]
 label = "missing fields `lineno`, `content`"
 level = "Error"
 range = [31, 128]

--- a/tests/fixtures/no-color/multiline_annotation2.toml
+++ b/tests/fixtures/no-color/multiline_annotation2.toml
@@ -1,4 +1,4 @@
-[[snippet.slices]]
+[[message.slices]]
 source = """
                         if let DisplayLine::Source {
                             ref mut inline_marks,
@@ -7,11 +7,11 @@ source = """
 line_start = 139
 origin = "src/display_list.rs"
 fold = false
-[[snippet.slices.annotations]]
+[[message.slices.annotations]]
 label = "missing fields `lineno`, `content`"
 level = "Error"
 range = [31, 128]
 
-[snippet]
+[message]
 title = { level = "Error", label = "pattern does not mention fields `lineno`, `content`" }
 id = "E0027"

--- a/tests/fixtures/no-color/multiline_annotation2.toml
+++ b/tests/fixtures/no-color/multiline_annotation2.toml
@@ -9,9 +9,9 @@ origin = "src/display_list.rs"
 fold = false
 [[snippet.slices.annotations]]
 label = "missing fields `lineno`, `content`"
-annotation_type = "Error"
+level = "Error"
 range = [31, 128]
 
 [snippet]
-title = { annotation_type = "Error", label = "pattern does not mention fields `lineno`, `content`" }
+title = { level = "Error", label = "pattern does not mention fields `lineno`, `content`" }
 id = "E0027"

--- a/tests/fixtures/no-color/multiline_annotation2.toml
+++ b/tests/fixtures/no-color/multiline_annotation2.toml
@@ -1,3 +1,8 @@
+[message]
+level = "Error"
+id = "E0027"
+title = "pattern does not mention fields `lineno`, `content`"
+
 [[message.snippets]]
 source = """
                         if let DisplayLine::Source {
@@ -11,7 +16,3 @@ fold = false
 label = "missing fields `lineno`, `content`"
 level = "Error"
 range = [31, 128]
-
-[message]
-title = { level = "Error", label = "pattern does not mention fields `lineno`, `content`" }
-id = "E0027"

--- a/tests/fixtures/no-color/multiline_annotation3.toml
+++ b/tests/fixtures/no-color/multiline_annotation3.toml
@@ -1,4 +1,4 @@
-[[snippet.slices]]
+[[message.slices]]
 source = """
 This is an exampl
 e of an edge case of an annotation overflowing
@@ -7,11 +7,11 @@ to exactly one character on next line.
 line_start = 26
 origin = "foo.txt"
 fold = false
-[[snippet.slices.annotations]]
+[[message.slices.annotations]]
 label = "this should not be on separate lines"
 level = "Error"
 range = [11, 18]
 
-[snippet]
+[message]
 title = { level = "Error", label = "spacing error found" }
 id = "E####"

--- a/tests/fixtures/no-color/multiline_annotation3.toml
+++ b/tests/fixtures/no-color/multiline_annotation3.toml
@@ -1,4 +1,4 @@
-[[message.slices]]
+[[message.snippets]]
 source = """
 This is an exampl
 e of an edge case of an annotation overflowing
@@ -7,7 +7,7 @@ to exactly one character on next line.
 line_start = 26
 origin = "foo.txt"
 fold = false
-[[message.slices.annotations]]
+[[message.snippets.annotations]]
 label = "this should not be on separate lines"
 level = "Error"
 range = [11, 18]

--- a/tests/fixtures/no-color/multiline_annotation3.toml
+++ b/tests/fixtures/no-color/multiline_annotation3.toml
@@ -9,9 +9,9 @@ origin = "foo.txt"
 fold = false
 [[snippet.slices.annotations]]
 label = "this should not be on separate lines"
-annotation_type = "Error"
+level = "Error"
 range = [11, 18]
 
 [snippet]
-title = { annotation_type = "Error", label = "spacing error found" }
+title = { level = "Error", label = "spacing error found" }
 id = "E####"

--- a/tests/fixtures/no-color/multiline_annotation3.toml
+++ b/tests/fixtures/no-color/multiline_annotation3.toml
@@ -1,3 +1,8 @@
+[message]
+level = "Error"
+id = "E####"
+title = "spacing error found"
+
 [[message.snippets]]
 source = """
 This is an exampl
@@ -11,7 +16,3 @@ fold = false
 label = "this should not be on separate lines"
 level = "Error"
 range = [11, 18]
-
-[message]
-title = { level = "Error", label = "spacing error found" }
-id = "E####"

--- a/tests/fixtures/no-color/multiple_annotations.toml
+++ b/tests/fixtures/no-color/multiple_annotations.toml
@@ -2,7 +2,7 @@
 level = "Error"
 label = ""
 
-[[message.slices]]
+[[message.snippets]]
 source = """
 fn add_title_line(result: &mut Vec<String>, main_annotation: Option<&Annotation>) {
     if let Some(annotation) = main_annotation {
@@ -15,15 +15,15 @@ fn add_title_line(result: &mut Vec<String>, main_annotation: Option<&Annotation>
 }
 """
 line_start = 96
-[[message.slices.annotations]]
+[[message.snippets.annotations]]
 label = "Variable defined here"
 level = "Error"
 range = [100, 110]
-[[message.slices.annotations]]
+[[message.snippets.annotations]]
 label = "Referenced here"
 level = "Error"
 range = [184, 194]
-[[message.slices.annotations]]
+[[message.snippets.annotations]]
 label = "Referenced again here"
 level = "Error"
 range = [243, 253]

--- a/tests/fixtures/no-color/multiple_annotations.toml
+++ b/tests/fixtures/no-color/multiple_annotations.toml
@@ -1,8 +1,8 @@
-[snippet.title]
+[message.title]
 level = "Error"
 label = ""
 
-[[snippet.slices]]
+[[message.slices]]
 source = """
 fn add_title_line(result: &mut Vec<String>, main_annotation: Option<&Annotation>) {
     if let Some(annotation) = main_annotation {
@@ -15,15 +15,15 @@ fn add_title_line(result: &mut Vec<String>, main_annotation: Option<&Annotation>
 }
 """
 line_start = 96
-[[snippet.slices.annotations]]
+[[message.slices.annotations]]
 label = "Variable defined here"
 level = "Error"
 range = [100, 110]
-[[snippet.slices.annotations]]
+[[message.slices.annotations]]
 label = "Referenced here"
 level = "Error"
 range = [184, 194]
-[[snippet.slices.annotations]]
+[[message.slices.annotations]]
 label = "Referenced again here"
 level = "Error"
 range = [243, 253]

--- a/tests/fixtures/no-color/multiple_annotations.toml
+++ b/tests/fixtures/no-color/multiple_annotations.toml
@@ -1,5 +1,5 @@
 [snippet.title]
-annotation_type = "Error"
+level = "Error"
 label = ""
 
 [[snippet.slices]]
@@ -17,13 +17,13 @@ fn add_title_line(result: &mut Vec<String>, main_annotation: Option<&Annotation>
 line_start = 96
 [[snippet.slices.annotations]]
 label = "Variable defined here"
-annotation_type = "Error"
+level = "Error"
 range = [100, 110]
 [[snippet.slices.annotations]]
 label = "Referenced here"
-annotation_type = "Error"
+level = "Error"
 range = [184, 194]
 [[snippet.slices.annotations]]
 label = "Referenced again here"
-annotation_type = "Error"
+level = "Error"
 range = [243, 253]

--- a/tests/fixtures/no-color/multiple_annotations.toml
+++ b/tests/fixtures/no-color/multiple_annotations.toml
@@ -1,6 +1,6 @@
-[message.title]
+[message]
 level = "Error"
-label = ""
+title = ""
 
 [[message.snippets]]
 source = """

--- a/tests/fixtures/no-color/one_past.toml
+++ b/tests/fixtures/no-color/one_past.toml
@@ -1,6 +1,6 @@
-[message.title]
-label = "expected `.`, `=`"
+[message]
 level = "Error"
+title = "expected `.`, `=`"
 
 [[message.snippets]]
 source = "asdf"

--- a/tests/fixtures/no-color/one_past.toml
+++ b/tests/fixtures/no-color/one_past.toml
@@ -1,6 +1,6 @@
 [snippet.title]
 label = "expected `.`, `=`"
-annotation_type = "Error"
+level = "Error"
 
 [[snippet.slices]]
 source = "asdf"
@@ -8,5 +8,5 @@ line_start = 1
 origin = "Cargo.toml"
 [[snippet.slices.annotations]]
 label = ""
-annotation_type = "Error"
+level = "Error"
 range = [4, 5]

--- a/tests/fixtures/no-color/one_past.toml
+++ b/tests/fixtures/no-color/one_past.toml
@@ -2,11 +2,11 @@
 label = "expected `.`, `=`"
 level = "Error"
 
-[[message.slices]]
+[[message.snippets]]
 source = "asdf"
 line_start = 1
 origin = "Cargo.toml"
-[[message.slices.annotations]]
+[[message.snippets.annotations]]
 label = ""
 level = "Error"
 range = [4, 5]

--- a/tests/fixtures/no-color/one_past.toml
+++ b/tests/fixtures/no-color/one_past.toml
@@ -1,12 +1,12 @@
-[snippet.title]
+[message.title]
 label = "expected `.`, `=`"
 level = "Error"
 
-[[snippet.slices]]
+[[message.slices]]
 source = "asdf"
 line_start = 1
 origin = "Cargo.toml"
-[[snippet.slices.annotations]]
+[[message.slices.annotations]]
 label = ""
 level = "Error"
 range = [4, 5]

--- a/tests/fixtures/no-color/simple.toml
+++ b/tests/fixtures/no-color/simple.toml
@@ -1,3 +1,7 @@
+[message]
+level = "Error"
+title = "expected one of `.`, `;`, `?`, or an operator, found `for`"
+
 [[message.snippets]]
 source = """
         })
@@ -13,6 +17,3 @@ range = [20, 23]
 label = "expected one of `.`, `;`, `?`, or an operator here"
 level = "Warning"
 range = [10, 11]
-[message.title]
-label = "expected one of `.`, `;`, `?`, or an operator, found `for`"
-level = "Error"

--- a/tests/fixtures/no-color/simple.toml
+++ b/tests/fixtures/no-color/simple.toml
@@ -1,15 +1,15 @@
-[[message.slices]]
+[[message.snippets]]
 source = """
         })
 
         for line in &self.body {"""
 line_start = 169
 origin = "src/format_color.rs"
-[[message.slices.annotations]]
+[[message.snippets.annotations]]
 label = "unexpected token"
 level = "Error"
 range = [20, 23]
-[[message.slices.annotations]]
+[[message.snippets.annotations]]
 label = "expected one of `.`, `;`, `?`, or an operator here"
 level = "Warning"
 range = [10, 11]

--- a/tests/fixtures/no-color/simple.toml
+++ b/tests/fixtures/no-color/simple.toml
@@ -1,18 +1,18 @@
-[[snippet.slices]]
+[[message.slices]]
 source = """
         })
 
         for line in &self.body {"""
 line_start = 169
 origin = "src/format_color.rs"
-[[snippet.slices.annotations]]
+[[message.slices.annotations]]
 label = "unexpected token"
 level = "Error"
 range = [20, 23]
-[[snippet.slices.annotations]]
+[[message.slices.annotations]]
 label = "expected one of `.`, `;`, `?`, or an operator here"
 level = "Warning"
 range = [10, 11]
-[snippet.title]
+[message.title]
 label = "expected one of `.`, `;`, `?`, or an operator, found `for`"
 level = "Error"

--- a/tests/fixtures/no-color/simple.toml
+++ b/tests/fixtures/no-color/simple.toml
@@ -7,12 +7,12 @@ line_start = 169
 origin = "src/format_color.rs"
 [[snippet.slices.annotations]]
 label = "unexpected token"
-annotation_type = "Error"
+level = "Error"
 range = [20, 23]
 [[snippet.slices.annotations]]
 label = "expected one of `.`, `;`, `?`, or an operator here"
-annotation_type = "Warning"
+level = "Warning"
 range = [10, 11]
 [snippet.title]
 label = "expected one of `.`, `;`, `?`, or an operator, found `for`"
-annotation_type = "Error"
+level = "Error"

--- a/tests/fixtures/no-color/strip_line.toml
+++ b/tests/fixtures/no-color/strip_line.toml
@@ -1,5 +1,5 @@
 [snippet]
-title = { annotation_type = "Error", label = "mismatched types" }
+title = { level = "Error", label = "mismatched types" }
 id = "E0308"
 
 [[snippet.slices]]
@@ -9,7 +9,7 @@ origin = "$DIR/whitespace-trimming.rs"
 
 [[snippet.slices.annotations]]
 label = "expected (), found integer"
-annotation_type = "Error"
+level = "Error"
 range = [192, 194]
 
 [renderer]

--- a/tests/fixtures/no-color/strip_line.toml
+++ b/tests/fixtures/no-color/strip_line.toml
@@ -1,13 +1,13 @@
-[snippet]
+[message]
 title = { level = "Error", label = "mismatched types" }
 id = "E0308"
 
-[[snippet.slices]]
+[[message.slices]]
 source = "                                                                                                                                                                                    let _: () = 42;"
 line_start = 4
 origin = "$DIR/whitespace-trimming.rs"
 
-[[snippet.slices.annotations]]
+[[message.slices.annotations]]
 label = "expected (), found integer"
 level = "Error"
 range = [192, 194]

--- a/tests/fixtures/no-color/strip_line.toml
+++ b/tests/fixtures/no-color/strip_line.toml
@@ -2,12 +2,12 @@
 title = { level = "Error", label = "mismatched types" }
 id = "E0308"
 
-[[message.slices]]
+[[message.snippets]]
 source = "                                                                                                                                                                                    let _: () = 42;"
 line_start = 4
 origin = "$DIR/whitespace-trimming.rs"
 
-[[message.slices.annotations]]
+[[message.snippets.annotations]]
 label = "expected (), found integer"
 level = "Error"
 range = [192, 194]

--- a/tests/fixtures/no-color/strip_line.toml
+++ b/tests/fixtures/no-color/strip_line.toml
@@ -1,6 +1,7 @@
 [message]
-title = { level = "Error", label = "mismatched types" }
+level = "Error"
 id = "E0308"
+title = "mismatched types"
 
 [[message.snippets]]
 source = "                                                                                                                                                                                    let _: () = 42;"

--- a/tests/fixtures/no-color/strip_line_char.toml
+++ b/tests/fixtures/no-color/strip_line_char.toml
@@ -1,13 +1,13 @@
-[snippet]
+[message]
 title = { level = "Error", label = "mismatched types" }
 id = "E0308"
 
-[[snippet.slices]]
+[[message.slices]]
 source = "                                                                                                                                                                                    let _: () = 42ñ"
 line_start = 4
 origin = "$DIR/whitespace-trimming.rs"
 
-[[snippet.slices.annotations]]
+[[message.slices.annotations]]
 label = "expected (), found integer"
 level = "Error"
 range = [192, 194]

--- a/tests/fixtures/no-color/strip_line_char.toml
+++ b/tests/fixtures/no-color/strip_line_char.toml
@@ -1,6 +1,7 @@
 [message]
-title = { level = "Error", label = "mismatched types" }
+level = "Error"
 id = "E0308"
+title = "mismatched types" 
 
 [[message.snippets]]
 source = "                                                                                                                                                                                    let _: () = 42ñ"

--- a/tests/fixtures/no-color/strip_line_char.toml
+++ b/tests/fixtures/no-color/strip_line_char.toml
@@ -1,5 +1,5 @@
 [snippet]
-title = { annotation_type = "Error", label = "mismatched types" }
+title = { level = "Error", label = "mismatched types" }
 id = "E0308"
 
 [[snippet.slices]]
@@ -9,7 +9,7 @@ origin = "$DIR/whitespace-trimming.rs"
 
 [[snippet.slices.annotations]]
 label = "expected (), found integer"
-annotation_type = "Error"
+level = "Error"
 range = [192, 194]
 
 [renderer]

--- a/tests/fixtures/no-color/strip_line_char.toml
+++ b/tests/fixtures/no-color/strip_line_char.toml
@@ -2,12 +2,12 @@
 title = { level = "Error", label = "mismatched types" }
 id = "E0308"
 
-[[message.slices]]
+[[message.snippets]]
 source = "                                                                                                                                                                                    let _: () = 42ñ"
 line_start = 4
 origin = "$DIR/whitespace-trimming.rs"
 
-[[message.slices.annotations]]
+[[message.snippets.annotations]]
 label = "expected (), found integer"
 level = "Error"
 range = [192, 194]

--- a/tests/fixtures/no-color/strip_line_non_ws.toml
+++ b/tests/fixtures/no-color/strip_line_non_ws.toml
@@ -1,6 +1,7 @@
 [message]
-title = { level = "Error", label = "mismatched types" }
+level = "Error"
 id = "E0308"
+title = "mismatched types"
 
 [[message.snippets]]
 source = "    let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = 42; let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = ();"

--- a/tests/fixtures/no-color/strip_line_non_ws.toml
+++ b/tests/fixtures/no-color/strip_line_non_ws.toml
@@ -1,5 +1,5 @@
 [snippet]
-title = { annotation_type = "Error", label = "mismatched types" }
+title = { level = "Error", label = "mismatched types" }
 id = "E0308"
 
 [[snippet.slices]]
@@ -9,7 +9,7 @@ origin = "$DIR/non-whitespace-trimming.rs"
 
 [[snippet.slices.annotations]]
 label = "expected (), found integer"
-annotation_type = "Error"
+level = "Error"
 range = [240, 242]
 
 [renderer]

--- a/tests/fixtures/no-color/strip_line_non_ws.toml
+++ b/tests/fixtures/no-color/strip_line_non_ws.toml
@@ -2,12 +2,12 @@
 title = { level = "Error", label = "mismatched types" }
 id = "E0308"
 
-[[message.slices]]
+[[message.snippets]]
 source = "    let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = 42; let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = ();"
 line_start = 4
 origin = "$DIR/non-whitespace-trimming.rs"
 
-[[message.slices.annotations]]
+[[message.snippets.annotations]]
 label = "expected (), found integer"
 level = "Error"
 range = [240, 242]

--- a/tests/fixtures/no-color/strip_line_non_ws.toml
+++ b/tests/fixtures/no-color/strip_line_non_ws.toml
@@ -1,13 +1,13 @@
-[snippet]
+[message]
 title = { level = "Error", label = "mismatched types" }
 id = "E0308"
 
-[[snippet.slices]]
+[[message.slices]]
 source = "    let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = 42; let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = ();"
 line_start = 4
 origin = "$DIR/non-whitespace-trimming.rs"
 
-[[snippet.slices.annotations]]
+[[message.slices.annotations]]
 label = "expected (), found integer"
 level = "Error"
 range = [240, 242]

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -1,8 +1,8 @@
-use annotate_snippets::{Label, Message, Renderer, Snippet};
+use annotate_snippets::{Label, Level, Renderer, Snippet};
 
 #[test]
 fn test_i_29() {
-    let snippets = Message::error("oops").snippet(
+    let snippets = Level::Error.title("oops").snippet(
         Snippet::new("First line\r\nSecond oops line")
             .origin("<current file>")
             .annotation(Label::error("oops").span(19..23))
@@ -22,7 +22,7 @@ fn test_i_29() {
 
 #[test]
 fn test_point_to_double_width_characters() {
-    let snippets = Message::error("").snippet(
+    let snippets = Level::Error.title("").snippet(
         Snippet::new("こんにちは、世界")
             .origin("<current file>")
             .annotation(Label::error("world").span(12..16)),
@@ -41,7 +41,7 @@ fn test_point_to_double_width_characters() {
 
 #[test]
 fn test_point_to_double_width_characters_across_lines() {
-    let snippets = Message::error("").snippet(
+    let snippets = Level::Error.title("").snippet(
         Snippet::new("おはよう\nございます")
             .origin("<current file>")
             .annotation(Label::error("Good morning").span(4..15)),
@@ -62,7 +62,7 @@ fn test_point_to_double_width_characters_across_lines() {
 
 #[test]
 fn test_point_to_double_width_characters_multiple() {
-    let snippets = Message::error("").snippet(
+    let snippets = Level::Error.title("").snippet(
         Snippet::new("お寿司\n食べたい🍣")
             .origin("<current file>")
             .annotation(Label::error("Sushi1").span(0..6))
@@ -84,7 +84,7 @@ fn test_point_to_double_width_characters_multiple() {
 
 #[test]
 fn test_point_to_double_width_characters_mixed() {
-    let snippets = Message::error("").snippet(
+    let snippets = Level::Error.title("").snippet(
         Snippet::new("こんにちは、新しいWorld！")
             .origin("<current file>")
             .annotation(Label::error("New world").span(12..23)),

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -3,7 +3,7 @@ use annotate_snippets::{Label, Message, Renderer, Snippet};
 #[test]
 fn test_i_29() {
     let snippets = Message::error("oops").snippet(
-        Snippet::new("First line\r\nSecond oops line", 1)
+        Snippet::new("First line\r\nSecond oops line")
             .origin("<current file>")
             .annotation(Label::error("oops").span(19..23))
             .fold(true),
@@ -23,7 +23,7 @@ fn test_i_29() {
 #[test]
 fn test_point_to_double_width_characters() {
     let snippets = Message::error("").snippet(
-        Snippet::new("こんにちは、世界", 1)
+        Snippet::new("こんにちは、世界")
             .origin("<current file>")
             .annotation(Label::error("world").span(12..16)),
     );
@@ -42,7 +42,7 @@ fn test_point_to_double_width_characters() {
 #[test]
 fn test_point_to_double_width_characters_across_lines() {
     let snippets = Message::error("").snippet(
-        Snippet::new("おはよう\nございます", 1)
+        Snippet::new("おはよう\nございます")
             .origin("<current file>")
             .annotation(Label::error("Good morning").span(4..15)),
     );
@@ -63,7 +63,7 @@ fn test_point_to_double_width_characters_across_lines() {
 #[test]
 fn test_point_to_double_width_characters_multiple() {
     let snippets = Message::error("").snippet(
-        Snippet::new("お寿司\n食べたい🍣", 1)
+        Snippet::new("お寿司\n食べたい🍣")
             .origin("<current file>")
             .annotation(Label::error("Sushi1").span(0..6))
             .annotation(Label::note("Sushi2").span(11..15)),
@@ -85,7 +85,7 @@ fn test_point_to_double_width_characters_multiple() {
 #[test]
 fn test_point_to_double_width_characters_mixed() {
     let snippets = Message::error("").snippet(
-        Snippet::new("こんにちは、新しいWorld！", 1)
+        Snippet::new("こんにちは、新しいWorld！")
             .origin("<current file>")
             .annotation(Label::error("New world").span(12..23)),
     );

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -3,7 +3,7 @@ use annotate_snippets::{Label, Level, Renderer, Snippet};
 #[test]
 fn test_i_29() {
     let snippets = Level::Error.title("oops").snippet(
-        Snippet::new("First line\r\nSecond oops line")
+        Snippet::source("First line\r\nSecond oops line")
             .origin("<current file>")
             .annotation(Label::error("oops").span(19..23))
             .fold(true),
@@ -23,7 +23,7 @@ fn test_i_29() {
 #[test]
 fn test_point_to_double_width_characters() {
     let snippets = Level::Error.title("").snippet(
-        Snippet::new("こんにちは、世界")
+        Snippet::source("こんにちは、世界")
             .origin("<current file>")
             .annotation(Label::error("world").span(12..16)),
     );
@@ -42,7 +42,7 @@ fn test_point_to_double_width_characters() {
 #[test]
 fn test_point_to_double_width_characters_across_lines() {
     let snippets = Level::Error.title("").snippet(
-        Snippet::new("おはよう\nございます")
+        Snippet::source("おはよう\nございます")
             .origin("<current file>")
             .annotation(Label::error("Good morning").span(4..15)),
     );
@@ -63,7 +63,7 @@ fn test_point_to_double_width_characters_across_lines() {
 #[test]
 fn test_point_to_double_width_characters_multiple() {
     let snippets = Level::Error.title("").snippet(
-        Snippet::new("お寿司\n食べたい🍣")
+        Snippet::source("お寿司\n食べたい🍣")
             .origin("<current file>")
             .annotation(Label::error("Sushi1").span(0..6))
             .annotation(Label::note("Sushi2").span(11..15)),
@@ -85,7 +85,7 @@ fn test_point_to_double_width_characters_multiple() {
 #[test]
 fn test_point_to_double_width_characters_mixed() {
     let snippets = Level::Error.title("").snippet(
-        Snippet::new("こんにちは、新しいWorld！")
+        Snippet::source("こんにちは、新しいWorld！")
             .origin("<current file>")
             .annotation(Label::error("New world").span(12..23)),
     );

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -1,11 +1,11 @@
-use annotate_snippets::{Label, Level, Renderer, Snippet};
+use annotate_snippets::{Level, Renderer, Snippet};
 
 #[test]
 fn test_i_29() {
     let snippets = Level::Error.title("oops").snippet(
         Snippet::source("First line\r\nSecond oops line")
             .origin("<current file>")
-            .annotation(Label::error("oops").span(19..23))
+            .annotation(Level::Error.span(19..23).label("oops"))
             .fold(true),
     );
     let expected = r#"error: oops
@@ -25,7 +25,7 @@ fn test_point_to_double_width_characters() {
     let snippets = Level::Error.title("").snippet(
         Snippet::source("こんにちは、世界")
             .origin("<current file>")
-            .annotation(Label::error("world").span(12..16)),
+            .annotation(Level::Error.span(12..16).label("world")),
     );
 
     let expected = r#"error
@@ -44,7 +44,7 @@ fn test_point_to_double_width_characters_across_lines() {
     let snippets = Level::Error.title("").snippet(
         Snippet::source("おはよう\nございます")
             .origin("<current file>")
-            .annotation(Label::error("Good morning").span(4..15)),
+            .annotation(Level::Error.span(4..15).label("Good morning")),
     );
 
     let expected = r#"error
@@ -65,8 +65,8 @@ fn test_point_to_double_width_characters_multiple() {
     let snippets = Level::Error.title("").snippet(
         Snippet::source("お寿司\n食べたい🍣")
             .origin("<current file>")
-            .annotation(Label::error("Sushi1").span(0..6))
-            .annotation(Label::note("Sushi2").span(11..15)),
+            .annotation(Level::Error.span(0..6).label("Sushi1"))
+            .annotation(Level::Note.span(11..15).label("Sushi2")),
     );
 
     let expected = r#"error
@@ -87,7 +87,7 @@ fn test_point_to_double_width_characters_mixed() {
     let snippets = Level::Error.title("").snippet(
         Snippet::source("こんにちは、新しいWorld！")
             .origin("<current file>")
-            .annotation(Label::error("New world").span(12..23)),
+            .annotation(Level::Error.span(12..23).label("New world")),
     );
 
     let expected = r#"error

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -1,8 +1,8 @@
-use annotate_snippets::{Label, Renderer, Slice, Snippet};
+use annotate_snippets::{Label, Message, Renderer, Slice};
 
 #[test]
 fn test_i_29() {
-    let snippets = Snippet::error("oops").slice(
+    let snippets = Message::error("oops").slice(
         Slice::new("First line\r\nSecond oops line", 1)
             .origin("<current file>")
             .annotation(Label::error("oops").span(19..23))
@@ -22,7 +22,7 @@ fn test_i_29() {
 
 #[test]
 fn test_point_to_double_width_characters() {
-    let snippets = Snippet::error("").slice(
+    let snippets = Message::error("").slice(
         Slice::new("こんにちは、世界", 1)
             .origin("<current file>")
             .annotation(Label::error("world").span(12..16)),
@@ -41,7 +41,7 @@ fn test_point_to_double_width_characters() {
 
 #[test]
 fn test_point_to_double_width_characters_across_lines() {
-    let snippets = Snippet::error("").slice(
+    let snippets = Message::error("").slice(
         Slice::new("おはよう\nございます", 1)
             .origin("<current file>")
             .annotation(Label::error("Good morning").span(4..15)),
@@ -62,7 +62,7 @@ fn test_point_to_double_width_characters_across_lines() {
 
 #[test]
 fn test_point_to_double_width_characters_multiple() {
-    let snippets = Snippet::error("").slice(
+    let snippets = Message::error("").slice(
         Slice::new("お寿司\n食べたい🍣", 1)
             .origin("<current file>")
             .annotation(Label::error("Sushi1").span(0..6))
@@ -84,7 +84,7 @@ fn test_point_to_double_width_characters_multiple() {
 
 #[test]
 fn test_point_to_double_width_characters_mixed() {
-    let snippets = Snippet::error("").slice(
+    let snippets = Message::error("").slice(
         Slice::new("こんにちは、新しいWorld！", 1)
             .origin("<current file>")
             .annotation(Label::error("New world").span(12..23)),

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -1,9 +1,9 @@
-use annotate_snippets::{Label, Message, Renderer, Slice};
+use annotate_snippets::{Label, Message, Renderer, Snippet};
 
 #[test]
 fn test_i_29() {
-    let snippets = Message::error("oops").slice(
-        Slice::new("First line\r\nSecond oops line", 1)
+    let snippets = Message::error("oops").snippet(
+        Snippet::new("First line\r\nSecond oops line", 1)
             .origin("<current file>")
             .annotation(Label::error("oops").span(19..23))
             .fold(true),
@@ -22,8 +22,8 @@ fn test_i_29() {
 
 #[test]
 fn test_point_to_double_width_characters() {
-    let snippets = Message::error("").slice(
-        Slice::new("こんにちは、世界", 1)
+    let snippets = Message::error("").snippet(
+        Snippet::new("こんにちは、世界", 1)
             .origin("<current file>")
             .annotation(Label::error("world").span(12..16)),
     );
@@ -41,8 +41,8 @@ fn test_point_to_double_width_characters() {
 
 #[test]
 fn test_point_to_double_width_characters_across_lines() {
-    let snippets = Message::error("").slice(
-        Slice::new("おはよう\nございます", 1)
+    let snippets = Message::error("").snippet(
+        Snippet::new("おはよう\nございます", 1)
             .origin("<current file>")
             .annotation(Label::error("Good morning").span(4..15)),
     );
@@ -62,8 +62,8 @@ fn test_point_to_double_width_characters_across_lines() {
 
 #[test]
 fn test_point_to_double_width_characters_multiple() {
-    let snippets = Message::error("").slice(
-        Slice::new("お寿司\n食べたい🍣", 1)
+    let snippets = Message::error("").snippet(
+        Snippet::new("お寿司\n食べたい🍣", 1)
             .origin("<current file>")
             .annotation(Label::error("Sushi1").span(0..6))
             .annotation(Label::note("Sushi2").span(11..15)),
@@ -84,8 +84,8 @@ fn test_point_to_double_width_characters_multiple() {
 
 #[test]
 fn test_point_to_double_width_characters_mixed() {
-    let snippets = Message::error("").slice(
-        Slice::new("こんにちは、新しいWorld！", 1)
+    let snippets = Message::error("").snippet(
+        Snippet::new("こんにちは、新しいWorld！", 1)
             .origin("<current file>")
             .annotation(Label::error("New world").span(12..23)),
     );


### PR DESCRIPTION
This is a batch API change from talking to @Muscraft about what would make the clearer, what will make it more easily adapt to rustc, and what will make it better encoded the design in the type system.

Renames:
- `Snippet` -> `Message`
- `Slice` -> `Snippet`
  - `Slice::new` to `Snippet::source`
- `SourceAnnotation` -> `Annotation`
- `AnnotationType` -> `Level`

Other breaking changes:
- `Snippet::line_start` is now defaulted to `1`  instead of required
- Create `Message` from `Level`
- Create `Annotation` from `Level`
  - `Annotation::label` is now optional

New:
- Bulk-add functions to make it simpler to use builder API for automated conversion

What wasn't done:
- Deferred: Switch `Annotation` from using `Level` to a `Style { Level, Neutral, Added, Removed }`
- Deferred: Remove `footer` or convert it from `Vec<Label>` to `Vec<Message>`
- Deferred: Switching fields that are `Option` to have constructor methods that are `Option`
  - A little messy for people directly making a `Message`
  - Simplifies use with automated conversion
  - Alts
    - Leave as-is
    - Switch to `&mut` builder which gets messy with the nesting builder API
- `Message::id` to `Message::code`.  I feel like the former is more semantically meaningful