### PR TITLE
fix: Make spans work with single width emojis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,6 @@ dependencies = [
  "criterion",
  "difference",
  "glob",
- "itertools 0.12.1",
  "serde",
  "snapbox",
  "toml",
@@ -243,7 +242,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools 0.10.5",
+ "itertools",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -264,7 +263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools",
 ]
 
 [[package]]
@@ -445,15 +444,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 anstyle = "1.0.4"
-itertools = "0.12.1"
 unicode-width = "0.1.11"
 
 [dev-dependencies]

--- a/tests/fixtures/no-color/ensure-emoji-highlight-width.svg
+++ b/tests/fixtures/no-color/ensure-emoji-highlight-width.svg
@@ -1,0 +1,33 @@
+<svg width="1356px" height="128px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>error: invalid character ` ` in package name: `haha this isn't a valid name 🐛`, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> --&gt; &lt;file&gt;:7:1</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>  |</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan>7 | "haha this isn't a valid name 🐛" = { package = "libc", version = "0.1" }</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>  |</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/fixtures/no-color/ensure-emoji-highlight-width.toml
+++ b/tests/fixtures/no-color/ensure-emoji-highlight-width.toml
@@ -1,0 +1,15 @@
+[message]
+title = "invalid character ` ` in package name: `haha this isn't a valid name 🐛`, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)"
+level = "Error"
+
+
+[[message.snippets]]
+source = """
+"haha this isn't a valid name 🐛" = { package = "libc", version = "0.1" }
+"""
+line_start = 7
+origin = "<file>"
+[[message.snippets.annotations]]
+label = ""
+level = "Error"
+range = [0, 35]

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -25,7 +25,7 @@ fn test_point_to_double_width_characters() {
     let snippets = Level::Error.title("").snippet(
         Snippet::source("こんにちは、世界")
             .origin("<current file>")
-            .annotation(Level::Error.span(12..16).label("world")),
+            .annotation(Level::Error.span(18..24).label("world")),
     );
 
     let expected = r#"error
@@ -44,7 +44,7 @@ fn test_point_to_double_width_characters_across_lines() {
     let snippets = Level::Error.title("").snippet(
         Snippet::source("おはよう\nございます")
             .origin("<current file>")
-            .annotation(Level::Error.span(4..15).label("Good morning")),
+            .annotation(Level::Error.span(6..22).label("Good morning")),
     );
 
     let expected = r#"error
@@ -65,8 +65,8 @@ fn test_point_to_double_width_characters_multiple() {
     let snippets = Level::Error.title("").snippet(
         Snippet::source("お寿司\n食べたい🍣")
             .origin("<current file>")
-            .annotation(Level::Error.span(0..6).label("Sushi1"))
-            .annotation(Level::Note.span(11..15).label("Sushi2")),
+            .annotation(Level::Error.span(0..9).label("Sushi1"))
+            .annotation(Level::Note.span(16..22).label("Sushi2")),
     );
 
     let expected = r#"error
@@ -87,7 +87,7 @@ fn test_point_to_double_width_characters_mixed() {
     let snippets = Level::Error.title("").snippet(
         Snippet::source("こんにちは、新しいWorld！")
             .origin("<current file>")
-            .annotation(Level::Error.span(12..23).label("New world")),
+            .annotation(Level::Error.span(18..32).label("New world")),
     );
 
     let expected = r#"error


### PR DESCRIPTION
In #90, I made the mistake of thinking bytes and character widths were the same thing, and boy, was I very wrong. This PR addresses this problem and ensures that we are properly dealing with characters with different widths from the number of bytes they are made up of.