### PR TITLE
Fix margin

### DIFF
--- a/src/renderer/margin.rs
+++ b/src/renderer/margin.rs
@@ -17,7 +17,7 @@ pub struct Margin {
     /// The end of the line to be displayed.
     computed_right: usize,
     /// The current width of the terminal. 140 by default and in tests.
-    column_width: usize,
+    term_width: usize,
     /// The end column of a span label, including the span. Doesn't account for labels not in the
     /// same line as the span.
     label_right: usize,
@@ -29,7 +29,7 @@ impl Margin {
         span_left: usize,
         span_right: usize,
         label_right: usize,
-        column_width: usize,
+        term_width: usize,
         max_line_len: usize,
     ) -> Self {
         // The 6 is padding to give a bit of room for `...` when displaying:
@@ -47,7 +47,7 @@ impl Margin {
             span_right: span_right + ELLIPSIS_PASSING,
             computed_left: 0,
             computed_right: 0,
-            column_width,
+            term_width,
             label_right: label_right + ELLIPSIS_PASSING,
         };
         m.compute(max_line_len);
@@ -67,7 +67,7 @@ impl Margin {
             } else {
                 self.computed_right
             };
-        right < line_len && self.computed_left + self.column_width < line_len
+        right < line_len && self.computed_left + self.term_width < line_len
     }
 
     fn compute(&mut self, max_line_len: usize) {
@@ -81,22 +81,22 @@ impl Margin {
         // relevant code.
         self.computed_right = max(max_line_len, self.computed_left);
 
-        if self.computed_right - self.computed_left > self.column_width {
+        if self.computed_right - self.computed_left > self.term_width {
             // Trimming only whitespace isn't enough, let's get craftier.
-            if self.label_right - self.whitespace_left <= self.column_width {
+            if self.label_right - self.whitespace_left <= self.term_width {
                 // Attempt to fit the code window only trimming whitespace.
                 self.computed_left = self.whitespace_left;
-                self.computed_right = self.computed_left + self.column_width;
-            } else if self.label_right - self.span_left <= self.column_width {
+                self.computed_right = self.computed_left + self.term_width;
+            } else if self.label_right - self.span_left <= self.term_width {
                 // Attempt to fit the code window considering only the spans and labels.
-                let padding_left = (self.column_width - (self.label_right - self.span_left)) / 2;
+                let padding_left = (self.term_width - (self.label_right - self.span_left)) / 2;
                 self.computed_left = self.span_left.saturating_sub(padding_left);
-                self.computed_right = self.computed_left + self.column_width;
-            } else if self.span_right - self.span_left <= self.column_width {
+                self.computed_right = self.computed_left + self.term_width;
+            } else if self.span_right - self.span_left <= self.term_width {
                 // Attempt to fit the code window considering the spans and labels plus padding.
-                let padding_left = (self.column_width - (self.span_right - self.span_left)) / 5 * 2;
+                let padding_left = (self.term_width - (self.span_right - self.span_left)) / 5 * 2;
                 self.computed_left = self.span_left.saturating_sub(padding_left);
-                self.computed_right = self.computed_left + self.column_width;
+                self.computed_right = self.computed_left + self.term_width;
             } else {
                 // Mostly give up but still don't show the full line.
                 self.computed_left = self.span_left;
@@ -110,7 +110,7 @@ impl Margin {
     }
 
     pub(crate) fn right(&self, line_len: usize) -> usize {
-        if line_len.saturating_sub(self.computed_left) <= self.column_width {
+        if line_len.saturating_sub(self.computed_left) <= self.term_width {
             line_len
         } else {
             min(line_len, self.computed_right)

--- a/src/renderer/margin.rs
+++ b/src/renderer/margin.rs
@@ -4,7 +4,7 @@ const ELLIPSIS_PASSING: usize = 6;
 const LONG_WHITESPACE: usize = 20;
 const LONG_WHITESPACE_PADDING: usize = 4;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Margin {
     /// The available whitespace in the left that can be consumed when centering.
     whitespace_left: usize,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -21,11 +21,13 @@ pub use margin::Margin;
 use std::fmt::Display;
 use stylesheet::Stylesheet;
 
+pub const DEFAULT_TERM_WIDTH: usize = 140;
+
 /// A renderer for [`Message`]s
 #[derive(Clone)]
 pub struct Renderer {
     anonymized_line_numbers: bool,
-    margin: Option<Margin>,
+    term_width: usize,
     stylesheet: Stylesheet,
 }
 
@@ -34,7 +36,7 @@ impl Renderer {
     pub const fn plain() -> Self {
         Self {
             anonymized_line_numbers: false,
-            margin: None,
+            term_width: DEFAULT_TERM_WIDTH,
             stylesheet: Stylesheet::plain(),
         }
     }
@@ -94,25 +96,9 @@ impl Renderer {
         self
     }
 
-    /// Set the margin for the output
-    ///
-    /// This controls the various margins of the output.
-    ///
-    /// # Example
-    ///
-    /// ```text
-    /// error: expected type, found `22`
-    ///   --> examples/footer.rs:29:25
-    ///    |
-    /// 26 | ...         annotations: vec![SourceAnnotation {
-    ///    |                               ---------------- info: while parsing this struct
-    /// ...
-    /// 29 | ...         range: <22, 25>,
-    ///    |                     ^^
-    ///    |
-    /// ```
-    pub const fn margin(mut self, margin: Option<Margin>) -> Self {
-        self.margin = margin;
+    // Set the terminal width
+    pub const fn term_width(mut self, term_width: usize) -> Self {
+        self.term_width = term_width;
         self
     }
 
@@ -170,7 +156,7 @@ impl Renderer {
             msg,
             &self.stylesheet,
             self.anonymized_line_numbers,
-            self.margin,
+            self.term_width,
         )
     }
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -17,7 +17,7 @@ pub(crate) mod stylesheet;
 use crate::snippet::Message;
 pub use anstyle::*;
 use display_list::DisplayList;
-pub use margin::Margin;
+use margin::Margin;
 use std::fmt::Display;
 use stylesheet::Stylesheet;
 

--- a/tests/fixtures/no-color/strip_line.toml
+++ b/tests/fixtures/no-color/strip_line.toml
@@ -16,10 +16,3 @@ range = [192, 194]
 [renderer]
 color = false
 anonymized_line_numbers = true
-[renderer.margin]
-whitespace_left = 180
-span_left = 192
-span_right = 194
-label_right = 221
-column_width = 140
-max_line_len = 195

--- a/tests/fixtures/no-color/strip_line_char.toml
+++ b/tests/fixtures/no-color/strip_line_char.toml
@@ -16,10 +16,3 @@ range = [192, 194]
 [renderer]
 color = false
 anonymized_line_numbers = true
-[renderer.margin]
-whitespace_left = 180
-span_left = 192
-span_right = 194
-label_right = 221
-column_width = 140
-max_line_len = 195

--- a/tests/fixtures/no-color/strip_line_non_ws.svg
+++ b/tests/fixtures/no-color/strip_line_non_ws.svg
@@ -1,4 +1,4 @@
-<svg width="1238px" height="128px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1196px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -18,15 +18,17 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan>error[E0308]: mismatched types</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>  --&gt; $DIR/non-whitespace-trimming.rs:4:241</tspan>
+    <tspan x="10px" y="46px"><tspan>  --&gt; $DIR/non-whitespace-trimming.rs:4:242</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>   |</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>LL | ... = (); let _: () = (); let _: () = (); let _: () = 42; let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = ();...</tspan>
+    <tspan x="10px" y="82px"><tspan>LL | ... = (); let _: () = (); let _: () = (); let _: () = 42; let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () ...</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>   |                                                       ^^ expected (), found integer</tspan>
+    <tspan x="10px" y="100px"><tspan>   |                                                       ^^ expected `()`, found integer</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>   |</tspan>
+    <tspan x="10px" y="118px"><tspan>   |                                                  ^^ expected due to this</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>   |</tspan>
 </tspan>
   </text>
 

--- a/tests/fixtures/no-color/strip_line_non_ws.toml
+++ b/tests/fixtures/no-color/strip_line_non_ws.toml
@@ -4,21 +4,22 @@ id = "E0308"
 title = "mismatched types"
 
 [[message.snippets]]
-source = "    let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = 42; let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = ();"
+source = """
+	let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = 42; let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = ();
+"""
 line_start = 4
 origin = "$DIR/non-whitespace-trimming.rs"
 
 [[message.snippets.annotations]]
-label = "expected (), found integer"
+label = "expected `()`, found integer"
 level = "Error"
-range = [240, 242]
+range = [241, 243]
+
+[[message.snippets.annotations]]
+label = "expected due to this"
+level = "Error"
+range = [236, 238]
+
 
 [renderer]
 anonymized_line_numbers = true
-[renderer.margin]
-whitespace_left = 4
-span_left = 240
-span_right = 242
-label_right = 271
-column_width = 140
-max_line_len = 371


### PR DESCRIPTION
`Margin` was being utilized for a whole `Message` when it really should be per `Snippet`, since that is what is displayed together. `Margin` should also be calculated by `annotate-snippets` and not passed in, as we know how to figure everything out.

To fix these problems, this PR does the following:
- Grouped a `Snippet`'s `DisplayLine`s together into a `DisplaySet` so all lines to be rendered for a `Snippet` are kept together
- Made annotations be a field in `DisplayLine`, so they can reference information about the line. This will also help us in the future to be able to fold annotations into one line where possible, as well as other future rendering improvements
- Made it so that the `Margin` for each `DisplaySet` is created internally, allowing for better formatting
- Replaced the ability to pass in `Margin` with the ability to pass in only `column_width`, so users can easily specify it without setting all of `Margin`

Breaking changes:
- `Margin` is now private
- You can only pass in `column_width` and not all of `Margin` as we now handle it internally