### PR TITLE
fix(render): Fold like rustc

### DIFF
--- a/examples/expected_type.svg
+++ b/examples/expected_type.svg
@@ -1,4 +1,4 @@
-<svg width="860px" height="200px" xmlns="http://www.w3.org/2000/svg">
+<svg width="860px" height="218px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -29,15 +29,17 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-blue bold">   |</tspan><tspan class="fg-bright-blue bold">                                   ----------------</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">info</tspan><tspan class="fg-bright-blue bold">: while parsing this struct</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>...</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">27 |</tspan><tspan>                 label: "expected struct `annotate_snippets::snippet::Slice`, found reference"</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-bright-blue bold">29 |</tspan><tspan>                 range: &lt;22, 25&gt;,</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-blue bold">28 |</tspan><tspan>                     ,</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-bright-blue bold">   |</tspan><tspan class="fg-bright-red bold">                         ^^</tspan><tspan> </tspan><tspan class="fg-bright-red bold">expected struct `annotate_snippets::snippet::Slice`, found reference</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-blue bold">29 |</tspan><tspan>                 range: &lt;22, 25&gt;,</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-bright-blue bold">   |</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-blue bold">   |</tspan><tspan class="fg-bright-red bold">                         ^^</tspan><tspan> </tspan><tspan class="fg-bright-red bold">expected struct `annotate_snippets::snippet::Slice`, found reference</tspan>
 </tspan>
-    <tspan x="10px" y="190px">
+    <tspan x="10px" y="190px"><tspan class="fg-bright-blue bold">   |</tspan>
+</tspan>
+    <tspan x="10px" y="208px">
 </tspan>
   </text>
 

--- a/tests/fixtures/no-color/fold_ann_multiline.svg
+++ b/tests/fixtures/no-color/fold_ann_multiline.svg
@@ -1,4 +1,4 @@
-<svg width="869px" height="272px" xmlns="http://www.w3.org/2000/svg">
+<svg width="869px" height="218px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -28,21 +28,15 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>52 | /     for ann in annotations {</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>53 | |         match (ann.range.0, ann.range.1) {</tspan>
+    <tspan x="10px" y="136px"><tspan>...  |</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>54 | |             (None, None) =&gt; continue,</tspan>
+    <tspan x="10px" y="154px"><tspan>71 | |         }</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>55 | |             (Some(start), Some(end)) if start &gt; end_index || end &lt; start_index =&gt; continue,</tspan>
+    <tspan x="10px" y="172px"><tspan>72 | |     }</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>...  |</tspan>
+    <tspan x="10px" y="190px"><tspan>   | |_____^ expected enum `std::option::Option`, found ()</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>71 | |         }</tspan>
-</tspan>
-    <tspan x="10px" y="226px"><tspan>72 | |     }</tspan>
-</tspan>
-    <tspan x="10px" y="244px"><tspan>   | |_____^ expected enum `std::option::Option`, found ()</tspan>
-</tspan>
-    <tspan x="10px" y="262px"><tspan>   |</tspan>
+    <tspan x="10px" y="208px"><tspan>   |</tspan>
 </tspan>
   </text>
 


### PR DESCRIPTION
Before, we elided all small sets of unhighlighted lines and then partially elided large sets of unhighlighted lines (favoring the start).

In contrast, rustc shows 2 lines of context, split between the start and end of the fold.
If there are 3 unhighlighted lines, it just skips folding. This makes a lot more sense.
See https://github.com/rust-lang/rust/blob/2627e9f3012a97d3136b3e11bf6bd0853c38a534/compiler/rustc_errors/src/emitter.rs#L1878C17-L1939C18

In contrast to rustc, I made the amount of context a variable to make the intent clearer and to open the door to it being configurable.