### PR TITLE
Add derive debug for public types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![warn(missing_debug_implementations)]
 
 //! A library for formatting of text or programming code snippets.
 //!

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -24,7 +24,7 @@ use stylesheet::Stylesheet;
 pub const DEFAULT_TERM_WIDTH: usize = 140;
 
 /// A renderer for [`Message`]s
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Renderer {
     anonymized_line_numbers: bool,
     term_width: usize,

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -15,6 +15,7 @@ use std::ops::Range;
 /// Primary structure provided for formatting
 ///
 /// See [`Level::title`] to create a [`Message`]
+#[derive(Debug)]
 pub struct Message<'a> {
     pub(crate) level: Level,
     pub(crate) id: Option<&'a str>,
@@ -55,6 +56,7 @@ impl<'a> Message<'a> {
 ///
 /// One `Snippet` is meant to represent a single, continuous,
 /// slice of source code that you want to annotate.
+#[derive(Debug)]
 pub struct Snippet<'a> {
     pub(crate) origin: Option<&'a str>,
     pub(crate) line_start: usize,


### PR DESCRIPTION
While working on some changes for `cargo`, I encountered an issue where `Debug` was not implemented for `Renderer`. To fix this, I derived `Debug` for all public types and set [`missing-debug-implementations`](https://doc.rust-lang.org/stable/rustc/lints/listing/allowed-by-default.html#missing-debug-implementations) to `warn`, so this issue does not pop up again in the future.