### PR TITLE
Fix annotating line endings

### DIFF
--- a/tests/fixtures/no-color/ann_multiline2.svg
+++ b/tests/fixtures/no-color/ann_multiline2.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="182px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="164px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -22,17 +22,15 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan>   |</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>26 |   This is an example</tspan>
+    <tspan x="10px" y="82px"><tspan>26 | This is an example</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>   |  ____________^</tspan>
+    <tspan x="10px" y="100px"><tspan>   |            ^^^^^^^ this should not be on separate lines</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>27 | | of an edge case of an annotation overflowing</tspan>
+    <tspan x="10px" y="118px"><tspan>27 | of an edge case of an annotation overflowing</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>   | |_^ this should not be on separate lines</tspan>
+    <tspan x="10px" y="136px"><tspan>28 | to exactly one character on next line.</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>28 |   to exactly one character on next line.</tspan>
-</tspan>
-    <tspan x="10px" y="172px"><tspan>   |</tspan>
+    <tspan x="10px" y="154px"><tspan>   |</tspan>
 </tspan>
   </text>
 

--- a/tests/fixtures/no-color/ann_multiline2.svg
+++ b/tests/fixtures/no-color/ann_multiline2.svg
@@ -22,11 +22,11 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan>   |</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>26 |   This is an exampl</tspan>
+    <tspan x="10px" y="82px"><tspan>26 |   This is an example</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan>   |  ____________^</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>27 | | e of an edge case of an annotation overflowing</tspan>
+    <tspan x="10px" y="118px"><tspan>27 | | of an edge case of an annotation overflowing</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>   | |_^ this should not be on separate lines</tspan>
 </tspan>

--- a/tests/fixtures/no-color/ann_multiline2.toml
+++ b/tests/fixtures/no-color/ann_multiline2.toml
@@ -5,8 +5,8 @@ title = "spacing error found"
 
 [[message.snippets]]
 source = """
-This is an exampl
-e of an edge case of an annotation overflowing
+This is an example
+of an edge case of an annotation overflowing
 to exactly one character on next line.
 """
 line_start = 26
@@ -15,4 +15,4 @@ fold = false
 [[message.snippets.annotations]]
 label = "this should not be on separate lines"
 level = "Error"
-range = [11, 18]
+range = [11, 19]

--- a/tests/fixtures/no-color/fold_ann_multiline.svg
+++ b/tests/fixtures/no-color/fold_ann_multiline.svg
@@ -1,4 +1,4 @@
-<svg width="869px" height="218px" xmlns="http://www.w3.org/2000/svg">
+<svg width="869px" height="236px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -28,15 +28,17 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>52 | /     for ann in annotations {</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>...  |</tspan>
+    <tspan x="10px" y="136px"><tspan>53 | |         match (ann.range.0, ann.range.1) {</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>71 | |         }</tspan>
+    <tspan x="10px" y="154px"><tspan>...  |</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>72 | |     }</tspan>
+    <tspan x="10px" y="172px"><tspan>71 | |         }</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>   | |_____^ expected enum `std::option::Option`, found ()</tspan>
+    <tspan x="10px" y="190px"><tspan>72 | |     }</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>   |</tspan>
+    <tspan x="10px" y="208px"><tspan>   | |_____^ expected enum `std::option::Option`, found ()</tspan>
+</tspan>
+    <tspan x="10px" y="226px"><tspan>   |</tspan>
 </tspan>
   </text>
 


### PR DESCRIPTION
There have been a number of problems recently with annotating line endings:
- #130
- #117

I went ahead and tried my best to fix all of the current problems with annotating line endings, and in doing so, #116 appears to be fixed as well.

The two root problems were that we never really supported highlighting the end of a line in multiline spans, and even in cases where we did support highlighting the end of the line, we only supported highlighting the first of the line endings, if the line ended with `\r\n`.