### PR TITLE
docs: Fix and add docs for `Level`

### DIFF
--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -126,12 +126,15 @@ impl<'a> Annotation<'a> {
 /// Types of annotations.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Level {
-    /// Error annotations are displayed using red color and "^" character.
+    /// Error annotations are displayed in red with "^" characters.
     Error,
-    /// Warning annotations are displayed using blue color and "-" character.
+    /// Warning annotations are displayed in yellow with "-" characters.
     Warning,
+    /// Info annotations are displayed in blue with "-" characters and the prefix `info: `.
     Info,
+    /// Note annotations are displayed in green with "-" characters and the prefix `note: `.
     Note,
+    /// Help annotations are displayed in blue with "-" characters and the prefix `help: `.
     Help,
 }
 


### PR DESCRIPTION
Have the documentation for `Level` reflect actual appearance.

---

The output from this file:

<details><summary>(43 lines)</summary>

```rust
//! Provides a user-friendly error if the given file has the string `tab`
//!
//! A silly utility to test annotate_snippets (and anstream)

use annotate_snippets::{Level, Renderer, Snippet};
use clap::Parser;

#[derive(Parser)]
struct Cli {
    file_path: std::path::PathBuf,
}

fn main() {
    let Cli { file_path } = Cli::parse();
    let path_string = file_path.to_string_lossy().to_string();

    // Bad error message; don't do this!
    let contents =
        std::fs::read_to_string(file_path).expect("Should have been able to read the file");

    let renderer = Renderer::styled();
    let message = if let Some(index) = contents.find("tab") {
        Level::Error.title("no tabs allowed!").snippet(
            Snippet::source(&contents)
                .line_start(1)
                .origin(&path_string)
                .fold(true)
                .annotation(
                    Level::Error
                        .span(index..(index + 3))
                        .label("Found `tab` here"),
                )
                .annotation(Level::Warning.span(index..(index + 3)).label("Warning"))
                .annotation(Level::Info.span(index..(index + 3)).label("Info"))
                .annotation(Level::Note.span(index..(index + 3)).label("Note"))
                .annotation(Level::Help.span(index..(index + 3)).label("remove `tab`")),
        )
    } else {
        Level::Info.title("No \"tabs\" found, congrats!")
    };
    anstream::println!("{}", renderer.render(message));
}
```

</details>

Results in this output:
![image](https://github.com/user-attachments/assets/8df89d6b-e03f-4726-b89d-8fcff92297c3)
