### PR TITLE
Show fixture test location

### DIFF
--- a/tests/fixtures/main.rs
+++ b/tests/fixtures/main.rs
@@ -14,7 +14,15 @@ fn main() {
 }
 
 fn setup(input_path: std::path::PathBuf) -> tryfn::Case {
-    let name = input_path.file_name().unwrap().to_str().unwrap().to_owned();
+    let parent = input_path
+        .parent()
+        .unwrap()
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap();
+    let file_name = input_path.file_name().unwrap().to_str().unwrap();
+    let name = format!("{}/{}", parent, file_name);
     let expected = Data::read_from(&input_path.with_extension("svg"), None);
     tryfn::Case {
         name,


### PR DESCRIPTION
While working on #143, I noticed that fixture test names were missing the "module" (folder) before the name, which usually gets added for normal tests in folders. While this isn't a big deal now, if other test folders get added in the future, it will make it easier to find the failure.

Before:
![Screenshot from 2024-08-21 15-31-07](https://github.com/user-attachments/assets/7695640f-c351-46ba-8ff6-6a10644640a2)

After:
![Screenshot from 2024-08-21 16-44-56](https://github.com/user-attachments/assets/bb2b5a81-e86b-43f1-8441-c903e6a05bf4)


