### PR TITLE
Fix origin position computation

### DIFF
--- a/src/renderer/display_list.rs
+++ b/src/renderer/display_list.rs
@@ -1149,7 +1149,7 @@ fn format_header<'a>(
                 ..
             } = item
             {
-                if main_range >= range.0 && main_range <= range.1 + end_line.len() {
+                if main_range >= range.0 && main_range < range.1 + max(*end_line as usize, 1) {
                     let char_column = text[0..(main_range - range.0).min(text.len())]
                         .chars()
                         .count();

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -905,3 +905,53 @@ error: unused optional dependency
     let renderer = Renderer::plain();
     assert_data_eq!(renderer.render(input).to_string(), expected);
 }
+
+#[test]
+fn origin_correct_start_line() {
+    let source = "aaa\nbbb\nccc\nddd\n";
+    let input = Level::Error.title("title").snippet(
+        Snippet::source(source)
+            .origin("origin.txt")
+            .fold(false)
+            .annotation(Level::Error.span(8..8 + 3).label("annotation")),
+    );
+
+    let expected = str![[r#"
+error: title
+ --> origin.txt:2:4
+  |
+1 | aaa
+2 | bbb
+3 | ccc
+  | ^^^ annotation
+4 | ddd
+  |
+"#]];
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input).to_string(), expected);
+}
+
+#[test]
+fn origin_correct_mid_line() {
+    let source = "aaa\nbbb\nccc\nddd\n";
+    let input = Level::Error.title("title").snippet(
+        Snippet::source(source)
+            .origin("origin.txt")
+            .fold(false)
+            .annotation(Level::Error.span(8 + 1..8 + 3).label("annotation")),
+    );
+
+    let expected = str![[r#"
+error: title
+ --> origin.txt:3:2
+  |
+1 | aaa
+2 | bbb
+3 | ccc
+  |  ^^ annotation
+4 | ddd
+  |
+"#]];
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input).to_string(), expected);
+}

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -918,7 +918,7 @@ fn origin_correct_start_line() {
 
     let expected = str![[r#"
 error: title
- --> origin.txt:2:4
+ --> origin.txt:3:1
   |
 1 | aaa
 2 | bbb


### PR DESCRIPTION
This PR fixes an issue in the computation of the position in the origin file. When a highlighted section starts at the beginning of the line, the origin position used to point to the end of the previous line, instead of the start of the current line. This resulted in outputs like this:

```
error: title
 --> origin.txt:2:4
  |
1 | aaa
2 | bbb
3 | ccc
  | ^^^ annotation
4 | ddd
  |
```

Here `origin.txt:2:4` is wrong, it should be `origin.txt:3:1`, which actually matches the highlighted setting.


As a drive-by fix, 21645ad032dd9117d811db57a5740b6a6406f94a fixes `EndLine`, which was used incorrectly in multiple places that happened to cancel out.
