### PR TITLE
feat: Add `Level::None` for no title prefix

### DIFF
--- a/src/renderer/display_list.rs
+++ b/src/renderer/display_list.rs
@@ -914,6 +914,7 @@ impl From<snippet::Level> for DisplayAnnotationType {
             snippet::Level::Info => DisplayAnnotationType::Info,
             snippet::Level::Note => DisplayAnnotationType::Note,
             snippet::Level::Help => DisplayAnnotationType::Help,
+            snippet::Level::None => DisplayAnnotationType::None,
         }
     }
 }

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -133,6 +133,7 @@ pub enum Level {
     Info,
     Note,
     Help,
+    None,
 }
 
 impl Level {

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -955,3 +955,28 @@ error: title
     let renderer = Renderer::plain();
     assert_data_eq!(renderer.render(input).to_string(), expected);
 }
+
+#[test]
+fn level_none() {
+    let source = "aaa\nbbb\nccc\nddd\n";
+    let input = Level::None.title("title").snippet(
+        Snippet::source(source)
+            .origin("origin.txt")
+            .fold(false)
+            .annotation(Level::Error.span(8 + 1..8 + 3).label("annotation")),
+    );
+
+    let expected = str![[r#"
+title
+ --> origin.txt:3:2
+  |
+1 | aaa
+2 | bbb
+3 | ccc
+  |  ^^ annotation
+4 | ddd
+  |
+"#]];
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input).to_string(), expected);
+}


### PR DESCRIPTION
A part solution to #97, although only really useful for the title. For the inline annotations, this currently gives no underlining.