### PR TITLE
chore: Make master the allowed release branch

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,2 +1,2 @@
 dependent-version = "fix"
-allow-branch = ["main"]
+allow-branch = ["master"]


### PR DESCRIPTION
#147 changed the branch allowed release branch from `master` to `main`. The allowed release branch should be `master` as that is the default branch.