### PR TITLE
fix: Remove false positive line trimming

### DIFF
--- a/src/renderer/display_list.rs
+++ b/src/renderer/display_list.rs
@@ -331,28 +331,28 @@ impl DisplaySet<'_> {
 
                     // On long lines, we strip the source line, accounting for unicode.
                     let mut taken = 0;
-                    let code: String = text
-                        .chars()
-                        .skip(left)
-                        .take_while(|ch| {
-                            // Make sure that the trimming on the right will fall within the terminal width.
-                            // FIXME: `unicode_width` sometimes disagrees with terminals on how wide a `char`
-                            // is. For now, just accept that sometimes the code line will be longer than
-                            // desired.
-                            let next = unicode_width::UnicodeWidthChar::width(*ch).unwrap_or(1);
-                            if taken + next > right - left {
-                                return false;
-                            }
-                            taken += next;
-                            true
-                        })
-                        .collect();
+                    let mut was_cut_right = false;
+                    let mut code = String::new();
+                    for ch in text.chars().skip(left) {
+                        // Make sure that the trimming on the right will fall within the terminal width.
+                        // FIXME: `unicode_width` sometimes disagrees with terminals on how wide a `char`
+                        // is. For now, just accept that sometimes the code line will be longer than
+                        // desired.
+                        let next = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(1);
+                        if taken + next > right - left {
+                            was_cut_right = true;
+                            break;
+                        }
+                        taken += next;
+                        code.push(ch);
+                    }
+
                     buffer.puts(line_offset, code_offset, &code, Style::new());
                     if self.margin.was_cut_left() {
                         // We have stripped some code/whitespace from the beginning, make it clear.
                         buffer.puts(line_offset, code_offset, "...", *lineno_color);
                     }
-                    if self.margin.was_cut_right(line_len) {
+                    if was_cut_right {
                         buffer.puts(line_offset, code_offset + taken - 3, "...", *lineno_color);
                     }
 

--- a/src/renderer/margin.rs
+++ b/src/renderer/margin.rs
@@ -58,18 +58,6 @@ impl Margin {
         self.computed_left > 0
     }
 
-    pub(crate) fn was_cut_right(&self, line_len: usize) -> bool {
-        let right =
-            if self.computed_right == self.span_right || self.computed_right == self.label_right {
-                // Account for the "..." padding given above. Otherwise we end up with code lines that
-                // do fit but end in "..." as if they were trimmed.
-                self.computed_right - ELLIPSIS_PASSING
-            } else {
-                self.computed_right
-            };
-        right < line_len && self.computed_left + self.term_width < line_len
-    }
-
     fn compute(&mut self, max_line_len: usize) {
         // When there's a lot of whitespace (>20), we want to trim it as it is useless.
         self.computed_left = if self.whitespace_left > LONG_WHITESPACE {


### PR DESCRIPTION
Previously, it was possible for a `...` to be inserted when no trimming
was actually done. For example:

```
  |
1 |   version = "0.1.0"
2 |   # Ensure that the spans from toml handle utf-8 correctly
3 |   authors = [
  |  ___________^
4 | |     { name = "Z...ALGO", email = 1 }
5 | | ]
  | |_^ RUF200
  |
```

After this fix, the `...` is no longer inserted:

```
  |
1 |   version = "0.1.0"
2 |   # Ensure that the spans from toml handle utf-8 correctly
3 |   authors = [
  |  ___________^
4 | |     { name = "ZALGO", email = 1 }
5 | | ]
  | |_^ RUF200
  |
```

This is another low confidence fix where I'm not sure that it's right.
But the implementation was previously seeming to conflate the line
length (in bytes) versus the actual rendered length. So instead of
trying to do some math to figure out whether an ellipsis should be
inserted, we just keep track of whether the code line we write was
truncated or not.
