### PR TITLE
feat: Add `Level::None` for omitting the header

### DIFF
--- a/src/renderer/display_list.rs
+++ b/src/renderer/display_list.rs
@@ -909,6 +909,7 @@ pub(crate) enum DisplayAnnotationType {
 impl From<snippet::Level> for DisplayAnnotationType {
     fn from(at: snippet::Level) -> Self {
         match at {
+            snippet::Level::None => DisplayAnnotationType::None,
             snippet::Level::Error => DisplayAnnotationType::Error,
             snippet::Level::Warning => DisplayAnnotationType::Warning,
             snippet::Level::Info => DisplayAnnotationType::Info,

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -126,6 +126,8 @@ impl<'a> Annotation<'a> {
 /// Types of annotations.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Level {
+    /// Do not attach any annotation.
+    None,
     /// Error annotations are displayed using red color and "^" character.
     Error,
     /// Warning annotations are displayed using blue color and "-" character.

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -121,6 +121,35 @@ fn test_format_title() {
     assert_data_eq!(renderer.render(input).to_string(), expected);
 }
 
+/// Tests that we can format a message *without* a header.
+///
+/// This uses `Level::None`, which is somewhat of a hacky API addition I made
+/// to our vendored copy of `annotate-snippets` in order to do exactly what
+/// this test asserts: skip the header.
+#[test]
+fn test_format_skip_title() {
+    let source =
+        "# Docstring followed by a newline\n\ndef foobar(foot, bar={}):\n    \"\"\"\n    \"\"\"\n";
+    let src_annotation = Level::Error.span(56..58).label("B006");
+    let snippet = Snippet::source(source)
+        .line_start(1)
+        .annotation(src_annotation)
+        .fold(false);
+    let message = Level::None.title("").snippet(snippet);
+
+    let expected = str![[r#"
+  |
+1 | # Docstring followed by a newline
+2 |
+3 | def foobar(foot, bar={}):
+  |                      ^^ B006
+4 |     """
+5 |     """
+  |
+"#]];
+    assert_data_eq!(Renderer::plain().render(message).to_string(), expected);
+}
+
 #[test]
 fn test_format_snippet_only() {
     let source = "This is line 1\nThis is line 2";


### PR DESCRIPTION
When combined with an empty `title`, this results in the header being
omitted entirely.

This isn't what @epage suggested in #167 since changing our rendering to
pass in a custom header is a bigger refactor than what I've been able to
get to. The goal of this change was to be very small without requiring
bigger code changes on our end. Unfortunately, this is a breaking
change, so I'm not sure what the appetite is for this.

Fixes #167
