### PR TITLE
chore: Fix clippy warning

### DIFF
--- a/src/renderer/source_map.rs
+++ b/src/renderer/source_map.rs
@@ -298,9 +298,9 @@ impl<'a> SourceMap<'a> {
             annotated_line_infos.retain(|l| !l.annotations.is_empty());
         }
 
-        annotated_line_infos
-            .iter_mut()
-            .for_each(|l| l.annotations.sort_by(|a, b| a.start.cmp(&b.start)));
+        for l in annotated_line_infos.iter_mut() {
+            l.annotations.sort_by(|a, b| a.start.cmp(&b.start));
+        }
 
         (max_depth, annotated_line_infos)
     }


### PR DESCRIPTION
When updating my nightly Rust version, I ran into `clippy::needless-for-each`