### PR TITLE
Color Primary annotations by their group level

### DIFF
--- a/examples/highlight_title.rs
+++ b/examples/highlight_title.rs
@@ -5,7 +5,6 @@ fn main() {
     let source = r#"// Make sure "highlighted" code is colored purple
 
 //@ compile-flags: --error-format=human --color=always
-//@ error-pattern:[35mfor<'a> [0m
 //@ edition:2018
 
 use core::pin::Pin;
@@ -24,8 +23,7 @@ fn wrapped_fn<'a>(_: Box<(dyn Any + Send)>) -> Pin<Box<(
 
 fn main() {
     query(wrapped_fn);
-}
-"#;
+}"#;
 
     let magenta = annotate_snippets::renderer::AnsiColor::Magenta
         .on_default()
@@ -43,25 +41,39 @@ fn main() {
         magenta.render_reset()
     );
 
-    let message = Level::ERROR.header("mismatched types").id("E0308").group(
-        Group::new()
-            .element(
-                Snippet::source(source)
-                    .fold(true)
-                    .origin("$DIR/highlighting.rs")
-                    .annotation(
-                        AnnotationKind::Primary
-                            .span(589..599)
-                            .label("one type is more general than the other"),
-                    )
-                    .annotation(
-                        AnnotationKind::Context
-                            .span(583..588)
-                            .label("arguments to this function are incorrect"),
-                    ),
-            )
-            .element(Level::NOTE.title(&title)),
-    );
+    let message = Level::ERROR
+        .header("mismatched types")
+        .id("E0308")
+        .group(
+            Group::new()
+                .element(
+                    Snippet::source(source)
+                        .fold(true)
+                        .origin("$DIR/highlighting.rs")
+                        .annotation(
+                            AnnotationKind::Primary
+                                .span(553..563)
+                                .label("one type is more general than the other"),
+                        )
+                        .annotation(
+                            AnnotationKind::Context
+                                .span(547..552)
+                                .label("arguments to this function are incorrect"),
+                        ),
+                )
+                .element(Level::NOTE.title(&title)),
+        )
+        .group(
+            Group::new()
+                .element(Level::NOTE.title("function defined here"))
+                .element(
+                    Snippet::source(source)
+                        .fold(true)
+                        .origin("$DIR/highlighting.rs")
+                        .annotation(AnnotationKind::Context.span(200..333).label(""))
+                        .annotation(AnnotationKind::Primary.span(194..199)),
+                ),
+        );
 
     let renderer = Renderer::styled().anonymized_line_numbers(true);
     anstream::println!("{}", renderer.render(message));

--- a/examples/highlight_title.svg
+++ b/examples/highlight_title.svg
@@ -1,8 +1,9 @@
-<svg width="785px" height="200px" xmlns="http://www.w3.org/2000/svg">
+<svg width="785px" height="362px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
     .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-bright-red { fill: #FF5555 }
     .fg-magenta { fill: #AA00AA }
     .container {
@@ -22,7 +23,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error[E0308]</tspan><tspan class="bold">: mismatched types</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-bright-blue bold">--&gt; </tspan><tspan>$DIR/highlighting.rs:22:11</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-bright-blue bold">--&gt; </tspan><tspan>$DIR/highlighting.rs:21:11</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>
@@ -34,11 +35,29 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>     </tspan><tspan class="fg-bright-blue bold">arguments to this function are incorrect</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>   </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="bold">note</tspan><tspan>: expected fn pointer `</tspan><tspan class="fg-magenta bold">for&lt;'a&gt;</tspan><tspan> fn(Box&lt;</tspan><tspan class="fg-magenta bold">(dyn Any + Send + 'a)</tspan><tspan>&gt;) -&gt; Pin&lt;_&gt;`</tspan>
+    <tspan x="10px" y="154px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>                 found fn item `fn(Box&lt;</tspan><tspan class="fg-magenta bold">(dyn Any + Send + 'static)</tspan><tspan>&gt;) -&gt; Pin&lt;_&gt; </tspan><tspan class="fg-magenta bold">{wrapped_fn}</tspan><tspan>`</tspan>
+    <tspan x="10px" y="172px"><tspan>   </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="bold">note</tspan><tspan>: expected fn pointer `</tspan><tspan class="fg-magenta bold">for&lt;'a&gt;</tspan><tspan> fn(Box&lt;</tspan><tspan class="fg-magenta bold">(dyn Any + Send + 'a)</tspan><tspan>&gt;) -&gt; Pin&lt;_&gt;`</tspan>
 </tspan>
-    <tspan x="10px" y="190px">
+    <tspan x="10px" y="190px"><tspan>                 found fn item `fn(Box&lt;</tspan><tspan class="fg-magenta bold">(dyn Any + Send + 'static)</tspan><tspan>&gt;) -&gt; Pin&lt;_&gt; </tspan><tspan class="fg-magenta bold">{wrapped_fn}</tspan><tspan>`</tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">: function defined here</tspan>
+</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-blue bold">--&gt; </tspan><tspan>$DIR/highlighting.rs:10:4</tspan>
+</tspan>
+    <tspan x="10px" y="244px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan class="fg-bright-blue bold">LL</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>   fn query(_: fn(Box&lt;(dyn Any + Send + '_)&gt;) -&gt; Pin&lt;Box&lt;(</tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-blue bold"> ____</tspan><tspan class="fg-bright-red bold">^^^^^</tspan><tspan class="fg-bright-blue bold">_-</tspan>
+</tspan>
+    <tspan x="10px" y="298px"><tspan class="fg-bright-blue bold">LL</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>     dyn Future&lt;Output = Result&lt;Box&lt;(dyn Any + 'static)&gt;, String&gt;&gt; + Send + 'static</tspan>
+</tspan>
+    <tspan x="10px" y="316px"><tspan class="fg-bright-blue bold">LL</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> )&gt;&gt;) {}</tspan>
+</tspan>
+    <tspan x="10px" y="334px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|___-</tspan>
+</tspan>
+    <tspan x="10px" y="352px">
 </tspan>
   </text>
 

--- a/examples/highlight_title.svg
+++ b/examples/highlight_title.svg
@@ -49,7 +49,7 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan class="fg-bright-blue bold">LL</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>   fn query(_: fn(Box&lt;(dyn Any + Send + '_)&gt;) -&gt; Pin&lt;Box&lt;(</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-blue bold"> ____</tspan><tspan class="fg-bright-red bold">^^^^^</tspan><tspan class="fg-bright-blue bold">_-</tspan>
+    <tspan x="10px" y="280px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-blue bold"> ____</tspan><tspan class="fg-bright-green bold">^^^^^</tspan><tspan class="fg-bright-blue bold">_-</tspan>
 </tspan>
     <tspan x="10px" y="298px"><tspan class="fg-bright-blue bold">LL</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>     dyn Future&lt;Output = Result&lt;Box&lt;(dyn Any + 'static)&gt;, String&gt;&gt; + Send + 'static</tspan>
 </tspan>

--- a/src/renderer/styled_buffer.rs
+++ b/src/renderer/styled_buffer.rs
@@ -43,8 +43,8 @@ impl StyledBuffer {
         &self,
         level: Level<'_>,
         stylesheet: &Stylesheet,
-    ) -> Result<String, fmt::Error> {
-        let mut str = String::new();
+        str: &mut String,
+    ) -> Result<(), fmt::Error> {
         for (i, line) in self.lines.iter().enumerate() {
             let mut current_style = stylesheet.none;
             for StyledChar { ch, style } in line {
@@ -63,7 +63,7 @@ impl StyledBuffer {
                 writeln!(str)?;
             }
         }
-        Ok(str)
+        Ok(())
     }
 
     /// Sets `chr` with `style` for given `line`, `col`.


### PR DESCRIPTION
While working on matching `rustc`'s output, I noticed that we were coloring all `AnnotationKind::Primary` (`^`) based on the first `Level` of a `Message`, not the `Level` for its `Group`. This was caused by us using one `StyledBuffer` for a whole `Message`, instead of using one per `Group`.