### PR TITLE
fix: Only bold the first title of a message

### DIFF
--- a/examples/custom_level.svg
+++ b/examples/custom_level.svg
@@ -41,7 +41,7 @@
 </tspan>
     <tspan x="10px" y="190px"><tspan>   </tspan><tspan class="fg-bright-blue bold">╰╴</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan class="fg-bright-cyan bold">suggestion</tspan><tspan class="bold">: use `break` on its own without a value inside this `while` loop</tspan>
+    <tspan x="10px" y="208px"><tspan class="fg-bright-cyan bold">suggestion</tspan><tspan>: use `break` on its own without a value inside this `while` loop</tspan>
 </tspan>
     <tspan x="10px" y="226px"><tspan>   </tspan><tspan class="fg-bright-blue bold">╭╴</tspan>
 </tspan>

--- a/examples/footer.svg
+++ b/examples/footer.svg
@@ -32,9 +32,9 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">: expected type: `snippet::Annotation`</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">note</tspan><tspan>: expected type: `snippet::Annotation`</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="bold">         found type: `__&amp;__snippet::Annotation`</tspan>
+    <tspan x="10px" y="154px"><tspan>         found type: `__&amp;__snippet::Annotation`</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/examples/highlight_title.svg
+++ b/examples/highlight_title.svg
@@ -41,7 +41,7 @@
 </tspan>
     <tspan x="10px" y="190px"><tspan>                 found fn item `fn(Box&lt;</tspan><tspan class="fg-magenta bold">(dyn Any + Send + 'static)</tspan><tspan>&gt;) -&gt; Pin&lt;_&gt; </tspan><tspan class="fg-magenta bold">{wrapped_fn}</tspan><tspan>`</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">: function defined here</tspan>
+    <tspan x="10px" y="208px"><tspan class="fg-bright-green bold">note</tspan><tspan>: function defined here</tspan>
 </tspan>
     <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-blue bold">--&gt; </tspan><tspan>$DIR/highlighting.rs:10:4</tspan>
 </tspan>

--- a/src/level.rs
+++ b/src/level.rs
@@ -78,7 +78,6 @@ impl<'a> Level<'a> {
             groups: vec![Group::new().element(Element::Title(Title {
                 level: self,
                 title: header,
-                primary: true,
             }))],
         }
     }
@@ -92,11 +91,7 @@ impl<'a> Level<'a> {
     ///
     /// </div>
     pub fn title(self, title: &'a str) -> Title<'a> {
-        Title {
-            level: self,
-            title,
-            primary: false,
-        }
+        Title { level: self, title }
     }
 
     pub(crate) fn as_str(&self) -> &'a str {

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -159,14 +159,6 @@ pub struct Padding;
 pub struct Title<'a> {
     pub(crate) level: Level<'a>,
     pub(crate) title: &'a str,
-    pub(crate) primary: bool,
-}
-
-impl Title<'_> {
-    pub fn primary(mut self, primary: bool) -> Self {
-        self.primary = primary;
-        self
-    }
 }
 
 /// A source view [`Element`] in a [`Group`]

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -1663,6 +1663,8 @@ zappy
     let input_new = Level::ERROR
         .header("the size for values of type `T` cannot be known at compilation time")
         .id("E0277")
+        // We need an empty group here to ensure the HELP line is rendered correctly
+        .group(Group::new())
         .group(
             Group::new()
                 .element(Level::HELP.title(


### PR DESCRIPTION
This is another change related to matching `rustc`'s output. In this case, we were giving `ElementStyle::MainHeaderMsg` to the first `Title` of each `Group`, when it should only be applied to the first `Title` of a `Message`.