### PR TITLE
fix: Match rustc's first group trailing line

### DIFF
--- a/examples/highlight_source.svg
+++ b/examples/highlight_source.svg
@@ -1,4 +1,4 @@
-<svg width="961px" height="146px" xmlns="http://www.w3.org/2000/svg">
+<svg width="961px" height="164px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -29,9 +29,11 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>                       </tspan><tspan class="fg-bright-red bold">^^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-bright-red bold">allocation not allowed in constants</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>   </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="bold">note</tspan><tspan>: The runtime heap is not yet available at compile-time, so no runtime heap allocations can be created.</tspan>
+    <tspan x="10px" y="118px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="136px">
+    <tspan x="10px" y="136px"><tspan>   </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="bold">note</tspan><tspan>: The runtime heap is not yet available at compile-time, so no runtime heap allocations can be created.</tspan>
+</tspan>
+    <tspan x="10px" y="154px">
 </tspan>
   </text>
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -351,23 +351,25 @@ impl Renderer {
                                 peek.is_some() || (g == 0 && group_len > 1),
                             );
 
-                            if g == 0 && group_len > 1 {
+                            if g == 0 {
                                 let current_line = buffer.num_lines();
-                                if matches!(peek, Some(Element::Title(level)) if level.level.name != Some(None))
-                                {
-                                    self.draw_col_separator_no_space(
+                                match peek {
+                                    Some(Element::Title(level))
+                                        if level.level.name != Some(None) =>
+                                    {
+                                        self.draw_col_separator_no_space(
+                                            &mut buffer,
+                                            current_line,
+                                            max_line_num_len + 1,
+                                        );
+                                    }
+
+                                    None if group_len > 1 => self.draw_col_separator_end(
                                         &mut buffer,
                                         current_line,
                                         max_line_num_len + 1,
-                                    );
-                                // We want to draw the separator when it is
-                                // requested, or when it is the last element
-                                } else if peek.is_none() {
-                                    self.draw_col_separator_end(
-                                        &mut buffer,
-                                        current_line,
-                                        max_line_num_len + 1,
-                                    );
+                                    ),
+                                    _ => {}
                                 }
                             }
                         }

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -2021,6 +2021,7 @@ LL │  ┃             Ok("")
 LL │  ┃         ))))))))))))))))))))))))))))))
 LL │  ┃     ))))))))))))))))))))))))))))));
    │  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ expected `Atype<Btype<Ctype<..., i32>, i32>, i32>`, found `Result<Result<Result<..., _>, _>, _>`
+   │
    ├ note: expected struct `Atype<Btype<..., i32>, i32>`
    │            found enum `Result<Result<..., _>, _>`
    ├ note: the full name for the type has been written to '$TEST_BUILD_DIR/$FILE.long-type-hash.txt'
@@ -2180,6 +2181,7 @@ error: expected item, found `?`
   |
 1 | ... 的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。*/?
   |                                                              ^ expected item
+  |
   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 "#]];
 
@@ -2191,6 +2193,7 @@ error: expected item, found `?`
   │
 1 │ … 宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。*/?
   │                                                              ━ expected item
+  │
   ╰ note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 "#]];
     let renderer_unicode = renderer_ascii.theme(OutputTheme::Unicode);
@@ -2217,6 +2220,7 @@ error: expected item, found `?`
   |
 1 | ... 。这是宽的。这是宽的。这是宽的...
   |             ^^ expected item
+  |
   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 "#]];
 
@@ -2228,6 +2232,7 @@ error: expected item, found `?`
   │
 1 │ … 的。这是宽的。这是宽的。这是宽的。…
   │             ━━ expected item
+  │
   ╰ note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 "#]];
     let renderer_unicode = renderer_ascii.theme(OutputTheme::Unicode);
@@ -2254,6 +2259,7 @@ error: expected item, found `?`
   |
 1 | ...aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa*/?
   |                                                             ^ expected item
+  |
   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 "#]];
 
@@ -2265,6 +2271,7 @@ error: expected item, found `?`
   │
 1 │ …aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa*/?
   │                                                             ━ expected item
+  │
   ╰ note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 "#]];
     let renderer_unicode = renderer_ascii.theme(OutputTheme::Unicode);


### PR DESCRIPTION
Note: This is another change related to matching `rustc`'s output

