### PR TITLE
fix: Remove unneeded annotation sorting

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -695,8 +695,7 @@ impl Renderer {
                     if let Some(first_annotation) = primary_line
                         .annotations
                         .iter()
-                        .find(|a| a.is_primary())
-                        .or(primary_line.annotations.first())
+                        .min_by_key(|a| (Reverse(a.is_primary()), a.start.char))
                     {
                         origin.char_column = Some(first_annotation.start.char + 1);
                     }

--- a/src/renderer/source_map.rs
+++ b/src/renderer/source_map.rs
@@ -293,10 +293,6 @@ impl<'a> SourceMap<'a> {
             annotated_line_infos.retain(|l| !l.annotations.is_empty());
         }
 
-        for l in annotated_line_infos.iter_mut() {
-            l.annotations.sort_by(|a, b| a.start.cmp(&b.start));
-        }
-
         (max_depth, annotated_line_infos)
     }
 

--- a/tests/rustc_tests.rs
+++ b/tests/rustc_tests.rs
@@ -2605,7 +2605,7 @@ error[E0532]: expected unit struct, unit variant or constant, found tuple varian
 LL |         E1::Z1 => {} //~ ERROR expected unit struct, unit variant or constant, found tuple variant `E1::Z1`
    |         ^^^^^^
    |
-  ::: $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:11:15
+  ::: $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:11:19
    |
 LL | pub enum E1 { Z0, Z1(), S(u8, u8, u8) }
    |               --  -- `E1::Z1` defined here
@@ -2669,7 +2669,9 @@ LL |   /* //~ ERROR E0758
    | |
 LL | | /* */
 LL | | /*
-   | | -- ...as last nested comment starts here, maybe you want to close this instead?
+   | | --
+   | | |
+   | | ...as last nested comment starts here, maybe you want to close this instead?
 LL | | */
    | |_--^
    |   |


### PR DESCRIPTION
Note: This is another change related to matching rustc's output