### PR TITLE
test: Adjust spans to match original test spans

### DIFF
--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -1519,7 +1519,7 @@ fn main() {}"#;
                 .element(
                     Snippet::source(source)
                         .fold(true)
-                        .patch(Patch::new(52..86, "")),
+                        .patch(Patch::new(52..85, "")),
                 ),
         );
     let expected = str![[r#"
@@ -1537,7 +1537,6 @@ LL -     T
 LL -     :
 LL -     ?
 LL -     Sized
-LL + {
    |
 "#]];
     let renderer = Renderer::plain().anonymized_line_numbers(true);
@@ -1619,8 +1618,8 @@ fn main() {}"#;
         ).element(
             Snippet::source(source)
                 .fold(true)
-                .patch(Patch::new(56..90, ""))
-                .patch(Patch::new(90..90, "+ Send"))
+                .patch(Patch::new(56..89, ""))
+                .patch(Patch::new(89..89, "+ Send"))
                 ,
         ));
     let expected = str![[r#"
@@ -1651,7 +1650,7 @@ LL -     T
 LL -     :
 LL -     ?
 LL -     Sized
-LL + and + Send{
+LL + and + Send
    |
 "#]];
     let renderer = Renderer::plain().anonymized_line_numbers(true);


### PR DESCRIPTION
When working on a fix for an issue, it caused changes to `multiline_removal` and `multiline_replacement`, which I found odd, so I dug into why that was happening and found that the suggestion spans for both were one byte wider (34 vs 33) than the span of the [test they were based on](https://github.com/rust-lang/rust/blob/5de8e6edfcc747930891a0adc8e90608776dbe54/tests/ui/suggestions/removal-of-multiline-trait-bound-in-where-clause.stderr#L1-L28). Removing this extra width makes it so that `multiline_removal`'s suggestion matches the original test.