### PR TITLE
fix: Make span_to_lines return at least one line

### DIFF
--- a/src/renderer/source_map.rs
+++ b/src/renderer/source_map.rs
@@ -124,7 +124,7 @@ impl<'a> SourceMap<'a> {
             if start >= line_info.end_byte {
                 continue;
             }
-            if end <= line_info.start_byte {
+            if end < line_info.start_byte {
                 break;
             }
             lines.push(line_info);

--- a/tests/rustc_tests.rs
+++ b/tests/rustc_tests.rs
@@ -2966,7 +2966,6 @@ LL | /// This is a long line that contains a <http://link.com>
 }
 
 #[test]
-#[should_panic = "attempt to subtract with overflow"]
 fn array_into_iter() {
     let source1 = r#"#![allow(unused)]
 fn main() {


### PR DESCRIPTION
While running `rustc`'s lintdoc tests, I encountered a corner case with `SourceMap::span_to_lines`, where it would return no `LineInfo` when it was passed the range `0..0`, which ultimately caused a panic down the line. To address this, I made it so `span_to_lines` would only stop including lines when the range end was less than a `LineInfo`'s start_byte (`end < line_info.start_byte`). This seems to be the correct fix, as we use its negation (`end >= line_info.start_byte`) when [determining what line a byte falls on](https://github.com/rust-lang/annotate-snippets-rs/blob/88829299193b7602434fbdf818c856914a753a96/src/renderer/source_map.rs#L91).