### PR TITLE
Improve clarity arount Origin and Snippet

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -28,7 +28,7 @@ fn simple() -> String {
         Group::new().element(
             Snippet::source(source)
                 .line_start(51)
-                .origin("src/format.rs")
+                .path("src/format.rs")
                 .annotation(
                     AnnotationKind::Context
                         .span(5..19)
@@ -73,7 +73,7 @@ fn fold(bencher: divan::Bencher<'_, '_>, context: usize) {
                 Group::new().element(
                     Snippet::source(&input)
                         .fold(true)
-                        .origin("src/format.rs")
+                        .path("src/format.rs")
                         .annotation(
                             AnnotationKind::Context
                                 .span(span)

--- a/examples/custom_error.rs
+++ b/examples/custom_error.rs
@@ -22,7 +22,7 @@ pub static C: u32 = 0 - 1;
         .group(
             Group::new().element(
                 Snippet::source(source)
-                    .origin("$DIR/err.rs")
+                    .path("$DIR/err.rs")
                     .fold(true)
                     .annotation(
                         AnnotationKind::Primary

--- a/examples/custom_level.rs
+++ b/examples/custom_level.rs
@@ -36,7 +36,7 @@ fn main() {
             Group::new().element(
                 Snippet::source(source)
                     .line_start(1)
-                    .origin("$DIR/issue-114529-illegal-break-with-value.rs")
+                    .path("$DIR/issue-114529-illegal-break-with-value.rs")
                     .fold(true)
                     .annotation(
                         AnnotationKind::Primary
@@ -60,7 +60,7 @@ fn main() {
                 .element(
                     Snippet::source(source)
                         .line_start(1)
-                        .origin("$DIR/issue-114529-illegal-break-with-value.rs")
+                        .path("$DIR/issue-114529-illegal-break-with-value.rs")
                         .fold(true)
                         .patch(Patch::new(483..581, "break")),
                 ),

--- a/examples/expected_type.rs
+++ b/examples/expected_type.rs
@@ -10,7 +10,7 @@ fn main() {
             Group::new().element(
                 Snippet::source(source)
                     .line_start(26)
-                    .origin("examples/footer.rs")
+                    .path("examples/footer.rs")
                     .fold(true)
                     .annotation(AnnotationKind::Primary.span(193..195).label(
                         "expected struct `annotate_snippets::snippet::Slice`, found reference",

--- a/examples/footer.rs
+++ b/examples/footer.rs
@@ -8,7 +8,7 @@ fn main() {
             Group::new().element(
                 Snippet::source("        slices: vec![\"A\",")
                     .line_start(13)
-                    .origin("src/multislice.rs")
+                    .path("src/multislice.rs")
                     .annotation(AnnotationKind::Primary.span(21..24).label(
                         "expected struct `annotate_snippets::snippet::Slice`, found reference",
                     )),

--- a/examples/format.rs
+++ b/examples/format.rs
@@ -27,7 +27,7 @@ fn main() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(51)
-                .origin("src/format.rs")
+                .path("src/format.rs")
                 .annotation(
                     AnnotationKind::Context
                         .span(5..19)

--- a/examples/highlight_source.rs
+++ b/examples/highlight_source.rs
@@ -17,7 +17,7 @@ fn main() {}
                 .element(
                     Snippet::source(source)
                         .fold(true)
-                        .origin("$DIR/E0010-teach.rs")
+                        .path("$DIR/E0010-teach.rs")
                         .annotation(
                             AnnotationKind::Primary
                                 .span(72..85)

--- a/examples/highlight_title.rs
+++ b/examples/highlight_title.rs
@@ -49,7 +49,7 @@ fn main() {
                 .element(
                     Snippet::source(source)
                         .fold(true)
-                        .origin("$DIR/highlighting.rs")
+                        .path("$DIR/highlighting.rs")
                         .annotation(
                             AnnotationKind::Primary
                                 .span(553..563)
@@ -69,7 +69,7 @@ fn main() {
                 .element(
                     Snippet::source(source)
                         .fold(true)
-                        .origin("$DIR/highlighting.rs")
+                        .path("$DIR/highlighting.rs")
                         .annotation(AnnotationKind::Context.span(200..333).label(""))
                         .annotation(AnnotationKind::Primary.span(194..199)),
                 ),

--- a/examples/multislice.rs
+++ b/examples/multislice.rs
@@ -6,12 +6,12 @@ fn main() {
             .element(
                 Snippet::<Annotation<'_>>::source("Foo")
                     .line_start(51)
-                    .origin("src/format.rs"),
+                    .path("src/format.rs"),
             )
             .element(
                 Snippet::<Annotation<'_>>::source("Faa")
                     .line_start(129)
-                    .origin("src/display.rs"),
+                    .path("src/display.rs"),
             ),
     );
 

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -162,6 +162,8 @@ pub struct Title<'a> {
 }
 
 /// A source view [`Element`] in a [`Group`]
+///
+/// If you do not have [source][Snippet::source] available, see instead [`Origin`]
 #[derive(Clone, Debug)]
 pub struct Snippet<'a, T> {
     pub(crate) path: Option<&'a str>,
@@ -375,7 +377,9 @@ impl<'a> Patch<'a> {
     }
 }
 
-/// The location of the [`Snippet`] (e.g. a path)
+/// The referenced location (e.g. a path)
+///
+/// If you have source available, see instead [`Snippet`]
 #[derive(Clone, Debug)]
 pub struct Origin<'a> {
     pub(crate) path: &'a str,
@@ -412,6 +416,12 @@ impl<'a> Origin<'a> {
     /// Set the default column to display
     ///
     /// Otherwise this will be inferred from the primary [`Annotation`]
+    ///
+    /// <div class="warning">
+    ///
+    /// `char_column` is only be respected if [`Origin::line`] is also set.
+    ///
+    /// </div>
     pub fn char_column(mut self, char_column: usize) -> Self {
         self.char_column = Some(char_column);
         self

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -164,7 +164,7 @@ pub struct Title<'a> {
 /// A source view [`Element`] in a [`Group`]
 #[derive(Clone, Debug)]
 pub struct Snippet<'a, T> {
-    pub(crate) origin: Option<&'a str>,
+    pub(crate) path: Option<&'a str>,
     pub(crate) line_start: usize,
     pub(crate) source: &'a str,
     pub(crate) markers: Vec<T>,
@@ -183,7 +183,7 @@ impl<'a, T: Clone> Snippet<'a, T> {
     /// </div>
     pub fn source(source: &'a str) -> Self {
         Self {
-            origin: None,
+            path: None,
             line_start: 1,
             source,
             markers: vec![],
@@ -207,8 +207,8 @@ impl<'a, T: Clone> Snippet<'a, T> {
     /// not allowed to be passed to this function.
     ///
     /// </div>
-    pub fn origin(mut self, origin: &'a str) -> Self {
-        self.origin = Some(origin);
+    pub fn path(mut self, path: &'a str) -> Self {
+        self.path = Some(path);
         self
     }
 
@@ -378,7 +378,7 @@ impl<'a> Patch<'a> {
 /// The location of the [`Snippet`] (e.g. a path)
 #[derive(Clone, Debug)]
 pub struct Origin<'a> {
-    pub(crate) origin: &'a str,
+    pub(crate) path: &'a str,
     pub(crate) line: Option<usize>,
     pub(crate) char_column: Option<usize>,
     pub(crate) primary: bool,
@@ -392,9 +392,9 @@ impl<'a> Origin<'a> {
     /// not allowed to be passed to this function.
     ///
     /// </div>
-    pub fn new(origin: &'a str) -> Self {
+    pub fn new(path: &'a str) -> Self {
         Self {
-            origin,
+            path,
             line: None,
             char_column: None,
             primary: false,

--- a/tests/color/ann_eof.rs
+++ b/tests/color/ann_eof.rs
@@ -7,7 +7,7 @@ fn case() {
     let input = Level::ERROR.header("expected `.`, `=`").group(
         Group::new().element(
             Snippet::source("asdf")
-                .origin("Cargo.toml")
+                .path("Cargo.toml")
                 .line_start(1)
                 .annotation(AnnotationKind::Primary.span(4..4).label("")),
         ),

--- a/tests/color/ann_insertion.rs
+++ b/tests/color/ann_insertion.rs
@@ -7,7 +7,7 @@ fn case() {
     let input = Level::ERROR.header("expected `.`, `=`").group(
         Group::new().element(
             Snippet::source("asf")
-                .origin("Cargo.toml")
+                .path("Cargo.toml")
                 .line_start(1)
                 .annotation(AnnotationKind::Primary.span(2..2).label("'d' belongs here")),
         ),

--- a/tests/color/ann_multiline.rs
+++ b/tests/color/ann_multiline.rs
@@ -15,7 +15,7 @@ fn case() {
         .group(
             Group::new().element(
                 Snippet::source(source)
-                    .origin("src/display_list.rs")
+                    .path("src/display_list.rs")
                     .line_start(139)
                     .fold(false)
                     .annotation(

--- a/tests/color/ann_multiline2.rs
+++ b/tests/color/ann_multiline2.rs
@@ -15,7 +15,7 @@ to exactly one character on next line.
         .group(
             Group::new().element(
                 Snippet::source(source)
-                    .origin("foo.txt")
+                    .path("foo.txt")
                     .line_start(26)
                     .fold(false)
                     .annotation(

--- a/tests/color/ann_removed_nl.rs
+++ b/tests/color/ann_removed_nl.rs
@@ -7,7 +7,7 @@ fn case() {
     let input = Level::ERROR.header("expected `.`, `=`").group(
         Group::new().element(
             Snippet::source("asdf")
-                .origin("Cargo.toml")
+                .path("Cargo.toml")
                 .line_start(1)
                 .annotation(AnnotationKind::Primary.span(4..5).label("")),
         ),

--- a/tests/color/ensure_emoji_highlight_width.rs
+++ b/tests/color/ensure_emoji_highlight_width.rs
@@ -12,7 +12,7 @@ fn case() {
             Group::new()
                 .element(
                     Snippet::source(source)
-                        .origin("<file>")
+                        .path("<file>")
                         .line_start(7)
                         .annotation(AnnotationKind::Primary.span(0..35).label(""))
                 )

--- a/tests/color/fold_ann_multiline.rs
+++ b/tests/color/fold_ann_multiline.rs
@@ -31,7 +31,7 @@ fn case() {
     let input = Level::ERROR.header("mismatched types").id("E0308").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("src/format.rs")
+                .path("src/format.rs")
                 .line_start(51)
                 .fold(true)
                 .annotation(AnnotationKind::Context.span(5..19).label(

--- a/tests/color/fold_bad_origin_line.rs
+++ b/tests/color/fold_bad_origin_line.rs
@@ -12,7 +12,7 @@ invalid syntax
     let input = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("path/to/error.rs")
+                .path("path/to/error.rs")
                 .line_start(1)
                 .fold(true)
                 .annotation(AnnotationKind::Context.span(2..16).label("error here")),

--- a/tests/color/fold_leading.rs
+++ b/tests/color/fold_leading.rs
@@ -23,7 +23,7 @@ workspace = 20
         .group(
             Group::new().element(
                 Snippet::source(source)
-                    .origin("Cargo.toml")
+                    .path("Cargo.toml")
                     .line_start(1)
                     .fold(true)
                     .annotation(AnnotationKind::Primary.span(132..134).label("")),

--- a/tests/color/fold_trailing.rs
+++ b/tests/color/fold_trailing.rs
@@ -22,7 +22,7 @@ edition = "2021"
         .group(
             Group::new().element(
                 Snippet::source(source)
-                    .origin("Cargo.toml")
+                    .path("Cargo.toml")
                     .line_start(1)
                     .fold(true)
                     .annotation(AnnotationKind::Primary.span(8..10).label("")),

--- a/tests/color/issue_9.rs
+++ b/tests/color/issue_9.rs
@@ -9,7 +9,7 @@ fn case() {
             Group::new()
                 .element(
                     Snippet::source("let x = vec![1];")
-                        .origin("/code/rust/src/test/ui/annotate-snippet/suggestion.rs")
+                        .path("/code/rust/src/test/ui/annotate-snippet/suggestion.rs")
                         .line_start(4)
                         .annotation(AnnotationKind::Context.span(4..5).label("move occurs because `x` has type `std::vec::Vec<i32>`, which does not implement the `Copy` trait"))
                 )

--- a/tests/color/multiline_removal_suggestion.rs
+++ b/tests/color/multiline_removal_suggestion.rs
@@ -71,7 +71,7 @@ fn main() {}
             Group::new()
                 .element(
                     Snippet::source(source)
-                        .origin("$DIR/multiline-removal-suggestion.rs")
+                        .path("$DIR/multiline-removal-suggestion.rs")
                         .fold(true)
                         .annotation(
                             AnnotationKind::Primary
@@ -102,7 +102,7 @@ fn main() {}
                 .element(Level::HELP.title("consider removing this method call, as the receiver has type `std::vec::IntoIter<HashSet<u8>>` and `std::vec::IntoIter<HashSet<u8>>: Iterator` trivially holds"))
                 .element(
                     Snippet::source(source)
-                        .origin("$DIR/multiline-removal-suggestion.rs")
+                        .path("$DIR/multiline-removal-suggestion.rs")
                         .fold(true)
                         .patch(Patch::new(708..768, "")),
                 ),

--- a/tests/color/simple.rs
+++ b/tests/color/simple.rs
@@ -14,7 +14,7 @@ fn case() {
         .group(
             Group::new().element(
                 Snippet::source(source)
-                    .origin("src/format_color.rs")
+                    .path("src/format_color.rs")
                     .line_start(169)
                     .annotation(
                         AnnotationKind::Primary

--- a/tests/color/strip_line.rs
+++ b/tests/color/strip_line.rs
@@ -9,7 +9,7 @@ fn case() {
     let input = Level::ERROR.header("mismatched types").id("E0308").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("$DIR/whitespace-trimming.rs")
+                .path("$DIR/whitespace-trimming.rs")
                 .line_start(4)
                 .annotation(
                     AnnotationKind::Primary

--- a/tests/color/strip_line_char.rs
+++ b/tests/color/strip_line_char.rs
@@ -9,7 +9,7 @@ fn case() {
     let input = Level::ERROR.header("mismatched types").id("E0308").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("$DIR/whitespace-trimming.rs")
+                .path("$DIR/whitespace-trimming.rs")
                 .line_start(4)
                 .annotation(
                     AnnotationKind::Primary

--- a/tests/color/strip_line_non_ws.rs
+++ b/tests/color/strip_line_non_ws.rs
@@ -10,7 +10,7 @@ fn case() {
     let input = Level::ERROR.header("mismatched types").id("E0308").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("$DIR/non-whitespace-trimming.rs")
+                .path("$DIR/non-whitespace-trimming.rs")
                 .line_start(4)
                 .annotation(
                     AnnotationKind::Primary

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -8,7 +8,7 @@ fn test_i_29() {
     let snippets = Level::ERROR.header("oops").group(
         Group::new().element(
             Snippet::source("First line\r\nSecond oops line")
-                .origin("<current file>")
+                .path("<current file>")
                 .annotation(AnnotationKind::Primary.span(19..23).label("oops"))
                 .fold(true),
         ),
@@ -30,7 +30,7 @@ fn test_point_to_double_width_characters() {
     let snippets = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source("こんにちは、世界")
-                .origin("<current file>")
+                .path("<current file>")
                 .annotation(AnnotationKind::Primary.span(18..24).label("world")),
         ),
     );
@@ -52,7 +52,7 @@ fn test_point_to_double_width_characters_across_lines() {
     let snippets = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source("おはよう\nございます")
-                .origin("<current file>")
+                .path("<current file>")
                 .annotation(AnnotationKind::Primary.span(6..22).label("Good morning")),
         ),
     );
@@ -76,7 +76,7 @@ fn test_point_to_double_width_characters_multiple() {
     let snippets = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source("お寿司\n食べたい🍣")
-                .origin("<current file>")
+                .path("<current file>")
                 .annotation(AnnotationKind::Primary.span(0..9).label("Sushi1"))
                 .annotation(AnnotationKind::Context.span(16..22).label("Sushi2")),
         ),
@@ -101,7 +101,7 @@ fn test_point_to_double_width_characters_mixed() {
     let snippets = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source("こんにちは、新しいWorld！")
-                .origin("<current file>")
+                .path("<current file>")
                 .annotation(AnnotationKind::Primary.span(18..32).label("New world")),
         ),
     );
@@ -153,12 +153,12 @@ fn test_format_snippets_continuation() {
             .element(
                 Snippet::<Annotation<'_>>::source(src_0)
                     .line_start(5402)
-                    .origin("file1.rs"),
+                    .path("file1.rs"),
             )
             .element(
                 Snippet::<Annotation<'_>>::source(src_1)
                     .line_start(2)
-                    .origin("file2.rs"),
+                    .path("file2.rs"),
             ),
     );
     let expected = str![[r#"
@@ -298,7 +298,7 @@ error:
 fn test_only_source() {
     let input = Level::ERROR
         .header("")
-        .group(Group::new().element(Snippet::<Annotation<'_>>::source("").origin("file.rs")));
+        .group(Group::new().element(Snippet::<Annotation<'_>>::source("").path("file.rs")));
     let expected = str![[r#"
 error: 
  --> file.rs
@@ -332,7 +332,7 @@ fn issue_130() {
     let input = Level::ERROR.header("dummy").group(
         Group::new().element(
             Snippet::source("foo\nbar\nbaz")
-                .origin("file/path")
+                .path("file/path")
                 .line_start(3)
                 .fold(true)
                 .annotation(AnnotationKind::Primary.span(4..11)),
@@ -360,7 +360,7 @@ a\"
     let input = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("file/path")
+                .path("file/path")
                 .line_start(3)
                 .fold(true)
                 .annotation(AnnotationKind::Primary.span(0..10)),
@@ -384,7 +384,7 @@ fn char_and_nl_annotate_char() {
     let input = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("file/path")
+                .path("file/path")
                 .line_start(3)
                 .annotation(AnnotationKind::Primary.span(0..2)),
         ), // a\r
@@ -407,7 +407,7 @@ fn char_eol_annotate_char() {
     let input = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("file/path")
+                .path("file/path")
                 .line_start(3)
                 .annotation(AnnotationKind::Primary.span(0..3)),
         ), // a\r\n
@@ -429,7 +429,7 @@ fn char_eol_annotate_char_double_width() {
     let snippets = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source("こん\r\nにちは\r\n世界")
-                .origin("<current file>")
+                .path("<current file>")
                 .annotation(AnnotationKind::Primary.span(3..8)),
         ), // ん\r\n
     );
@@ -455,7 +455,7 @@ fn annotate_eol() {
     let input = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("file/path")
+                .path("file/path")
                 .line_start(3)
                 .annotation(AnnotationKind::Primary.span(1..2)),
         ), // \r
@@ -478,7 +478,7 @@ fn annotate_eol2() {
     let input = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("file/path")
+                .path("file/path")
                 .line_start(3)
                 .annotation(AnnotationKind::Primary.span(1..3)),
         ), // \r\n
@@ -502,7 +502,7 @@ fn annotate_eol3() {
     let input = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("file/path")
+                .path("file/path")
                 .line_start(3)
                 .annotation(AnnotationKind::Primary.span(2..3)),
         ), // \n
@@ -526,7 +526,7 @@ fn annotate_eol4() {
     let input = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("file/path")
+                .path("file/path")
                 .line_start(3)
                 .annotation(AnnotationKind::Primary.span(2..2)),
         ), // \n
@@ -548,7 +548,7 @@ fn annotate_eol_double_width() {
     let snippets = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source("こん\r\nにちは\r\n世界")
-                .origin("<current file>")
+                .path("<current file>")
                 .annotation(AnnotationKind::Primary.span(7..8)),
         ), // \n
     );
@@ -574,7 +574,7 @@ fn multiline_eol_start() {
     let input = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("file/path")
+                .path("file/path")
                 .line_start(3)
                 .annotation(AnnotationKind::Primary.span(1..4)),
         ), // \r\nb
@@ -598,7 +598,7 @@ fn multiline_eol_start2() {
     let input = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("file/path")
+                .path("file/path")
                 .line_start(3)
                 .annotation(AnnotationKind::Primary.span(2..4)),
         ), // \nb
@@ -622,7 +622,7 @@ fn multiline_eol_start3() {
     let input = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("file/path")
+                .path("file/path")
                 .line_start(3)
                 .annotation(AnnotationKind::Primary.span(1..3)),
         ), // \nb
@@ -645,7 +645,7 @@ fn multiline_eol_start_double_width() {
     let snippets = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source("こん\r\nにちは\r\n世界")
-                .origin("<current file>")
+                .path("<current file>")
                 .annotation(AnnotationKind::Primary.span(7..11)),
         ), // \r\nに
     );
@@ -671,7 +671,7 @@ fn multiline_eol_start_eol_end() {
     let input = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("file/path")
+                .path("file/path")
                 .line_start(3)
                 .annotation(AnnotationKind::Primary.span(1..4)),
         ), // \nb\n
@@ -696,7 +696,7 @@ fn multiline_eol_start_eol_end2() {
     let input = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("file/path")
+                .path("file/path")
                 .line_start(3)
                 .annotation(AnnotationKind::Primary.span(2..5)),
         ), // \nb\r
@@ -721,7 +721,7 @@ fn multiline_eol_start_eol_end3() {
     let input = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("file/path")
+                .path("file/path")
                 .line_start(3)
                 .annotation(AnnotationKind::Primary.span(2..6)),
         ), // \nb\r\n
@@ -746,7 +746,7 @@ fn multiline_eol_start_eof_end() {
     let input = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("file/path")
+                .path("file/path")
                 .line_start(3)
                 .annotation(AnnotationKind::Primary.span(1..5)),
         ), // \r\nb(EOF)
@@ -770,7 +770,7 @@ fn multiline_eol_start_eof_end_double_width() {
     let input = Level::ERROR.header("").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("file/path")
+                .path("file/path")
                 .line_start(3)
                 .annotation(AnnotationKind::Primary.span(3..9)),
         ), // \r\nに(EOF)
@@ -794,7 +794,7 @@ fn two_single_line_same_line() {
     let input = Level::ERROR.header("unused optional dependency").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("Cargo.toml")
+                .path("Cargo.toml")
                 .line_start(4)
                 .annotation(
                     AnnotationKind::Primary
@@ -969,7 +969,7 @@ fn origin_correct_start_line() {
     let input = Level::ERROR.header("title").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("origin.txt")
+                .path("origin.txt")
                 .fold(false)
                 .annotation(AnnotationKind::Primary.span(8..8 + 3).label("annotation")),
         ),
@@ -995,7 +995,7 @@ fn origin_correct_mid_line() {
     let input = Level::ERROR.header("title").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("origin.txt")
+                .path("origin.txt")
                 .fold(false)
                 .annotation(
                     AnnotationKind::Primary
@@ -1565,7 +1565,7 @@ fn main() {}"#;
         .id("E0277")
         .group(Group::new().element(Snippet::source(source)
             .line_start(1)
-            .origin("$DIR/removal-of-multiline-trait-bound-in-where-clause.rs")
+            .path("$DIR/removal-of-multiline-trait-bound-in-where-clause.rs")
             .fold(true)
             .annotation(
                 AnnotationKind::Primary
@@ -1583,7 +1583,7 @@ fn main() {}"#;
         ).element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("$DIR/removal-of-multiline-trait-bound-in-where-clause.rs")
+                .path("$DIR/removal-of-multiline-trait-bound-in-where-clause.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -1598,7 +1598,7 @@ fn main() {}"#;
             .element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("$DIR/removal-of-multiline-trait-bound-in-where-clause.rs")
+                .path("$DIR/removal-of-multiline-trait-bound-in-where-clause.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -1744,7 +1744,7 @@ fn main() {
         .id("E0271")
         .group(Group::new().element(Snippet::source(source)
             .line_start(4)
-            .origin("$DIR/E0271.rs")
+            .path("$DIR/E0271.rs")
             .fold(true)
             .annotation(
                 AnnotationKind::Primary
@@ -1756,7 +1756,7 @@ fn main() {
         ).element(
             Snippet::source(source)
                 .line_start(4)
-                .origin("$DIR/E0271.rs")
+                .path("$DIR/E0271.rs")
                 .fold(true)
                 .annotation(AnnotationKind::Primary.span(89..90))
         ).element(
@@ -1832,7 +1832,7 @@ fn main() {
         .id("E0271")
         .group(Group::new().element(Snippet::source(source)
             .line_start(4)
-            .origin("$DIR/E0271.rs")
+            .path("$DIR/E0271.rs")
             .fold(true)
             .annotation(
                 AnnotationKind::Primary
@@ -1844,7 +1844,7 @@ fn main() {
         ).element(
             Snippet::source(source)
                 .line_start(4)
-                .origin("$DIR/E0271.rs")
+                .path("$DIR/E0271.rs")
                 .fold(true)
                 .annotation(AnnotationKind::Primary.span(89..90))
         ).element(
@@ -1986,7 +1986,7 @@ fn main() {
         .group(Group::new().element(
             Snippet::source(source)
                 .line_start(7)
-                .origin("$DIR/long-E0308.rs")
+                .path("$DIR/long-E0308.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -2071,7 +2071,7 @@ fn main() {
         .group(Group::new().element(
             Snippet::source(source)
                 .line_start(7)
-                .origin("$DIR/unicode-output.rs")
+                .path("$DIR/unicode-output.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -2093,7 +2093,7 @@ fn main() {
         ).element(
             Snippet::source(source)
                 .line_start(7)
-                .origin("$DIR/unicode-output.rs")
+                .path("$DIR/unicode-output.rs")
                 .fold(true)
                 .annotation(AnnotationKind::Primary.span(77..210))
                 .annotation(AnnotationKind::Context.span(71..76)),
@@ -2299,7 +2299,7 @@ fn main() {
     let input = Level::ERROR.header("mismatched types").id("E0308").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("$DIR/non-whitespace-trimming-unicode.rs")
+                .path("$DIR/non-whitespace-trimming-unicode.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -2359,7 +2359,7 @@ fn main() {
             Group::new()
                 .element(
                     Snippet::source(source)
-                        .origin("$DIR/non-1-width-unicode-multiline-label.rs")
+                        .path("$DIR/non-1-width-unicode-multiline-label.rs")
                         .fold(true)
                         .annotation(AnnotationKind::Context.span(970..984).label("&str"))
                         .annotation(AnnotationKind::Context.span(987..1001).label("&str"))
@@ -2379,7 +2379,7 @@ fn main() {
                 .element(Level::HELP.title("create an owned `String` from a string reference"))
                 .element(
                     Snippet::source(source)
-                        .origin("$DIR/non-1-width-unicode-multiline-label.rs")
+                        .path("$DIR/non-1-width-unicode-multiline-label.rs")
                         .fold(true)
                         .patch(Patch::new(984..984, ".to_owned()")),
                 ),
@@ -2442,7 +2442,7 @@ fn foo() {
         .group(
             Group::new().element(
                 Snippet::source(source)
-                    .origin("$DIR/not-utf8.rs")
+                    .path("$DIR/not-utf8.rs")
                     .fold(true)
                     .annotation(AnnotationKind::Primary.span(136..160)),
             ),
@@ -2452,7 +2452,7 @@ fn foo() {
                 .element(Level::NOTE.title("byte `193` is not valid utf-8"))
                 .element(
                     Snippet::source(bin_source)
-                        .origin("$DIR/not-utf8.bin")
+                        .path("$DIR/not-utf8.bin")
                         .fold(true)
                         .annotation(AnnotationKind::Primary.span(0..0)),
                 )

--- a/tests/rustc_tests.rs
+++ b/tests/rustc_tests.rs
@@ -17,7 +17,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(AnnotationKind::Primary.span(10..13).label("test")),
         ),
@@ -47,7 +47,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(AnnotationKind::Primary.span(10..17).label("test")),
         ),
@@ -79,7 +79,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -122,7 +122,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -166,7 +166,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -210,7 +210,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -257,7 +257,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -305,7 +305,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -355,7 +355,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -399,7 +399,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -442,7 +442,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(AnnotationKind::Primary.span(18..25).label(""))
                 .annotation(
@@ -475,7 +475,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -507,7 +507,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -542,7 +542,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(AnnotationKind::Primary.span(14..27).label(""))
                 .annotation(
@@ -576,7 +576,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -610,7 +610,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(AnnotationKind::Primary.span(14..27).label(""))
                 .annotation(AnnotationKind::Context.span(18..25).label("")),
@@ -638,7 +638,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(AnnotationKind::Primary.span(18..25).label(""))
                 .annotation(AnnotationKind::Context.span(14..27).label(""))
@@ -667,7 +667,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -706,7 +706,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -737,7 +737,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(AnnotationKind::Primary.span(14..27).label("")),
         ),
@@ -777,7 +777,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -837,7 +837,7 @@ fn foo() {
         Group::new().element(
             Snippet::source(source)
                 .line_start(1)
-                .origin("test.rs")
+                .path("test.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -893,7 +893,7 @@ fn f(){||yield(((){),
             Group::new().element(
                 Snippet::source(source)
                     .line_start(1)
-                    .origin("$DIR/issue-91334.rs")
+                    .path("$DIR/issue-91334.rs")
                     .fold(true)
                     .annotation(
                         AnnotationKind::Context
@@ -965,7 +965,7 @@ fn main() {
             Group::new().element(
                 Snippet::source(source)
                     .line_start(1)
-                    .origin("$DIR/issue-114529-illegal-break-with-value.rs")
+                    .path("$DIR/issue-114529-illegal-break-with-value.rs")
                     .fold(true)
                     .annotation(
                         AnnotationKind::Primary
@@ -988,7 +988,7 @@ fn main() {
                 .element(
                     Snippet::source(source)
                         .line_start(1)
-                        .origin("$DIR/issue-114529-illegal-break-with-value.rs")
+                        .path("$DIR/issue-114529-illegal-break-with-value.rs")
                         .fold(true)
                         .annotation(AnnotationKind::Context.span(483..581).label("break")),
                 ),
@@ -1175,7 +1175,7 @@ fn nsize() {
                 Group::new().element(
                     Snippet::source(source)
                         .line_start(1)
-                        .origin("$DIR/primitive_reprs_should_have_correct_length.rs")
+                        .path("$DIR/primitive_reprs_should_have_correct_length.rs")
                         .fold(true)
                         .annotation(AnnotationKind::Primary.span(4375..4381).label(
                             "the size of `V0usize` is smaller than the size of `[usize; 2]`",
@@ -1188,7 +1188,7 @@ fn nsize() {
                     .element(
                         Snippet::source(source)
                             .line_start(1)
-                            .origin("$DIR/primitive_reprs_should_have_correct_length.rs")
+                            .path("$DIR/primitive_reprs_should_have_correct_length.rs")
                             .fold(true)
                             .annotation(
                                 AnnotationKind::Context
@@ -1262,7 +1262,7 @@ fn main() {
                 Snippet::source(source)
                     .line_start(1)
                     .fold(true)
-                    .origin("$DIR/align-fail.rs")
+                    .path("$DIR/align-fail.rs")
                     .annotation(
                         AnnotationKind::Primary
                             .span(442..459)
@@ -1330,7 +1330,7 @@ fn main() {}
             Group::new().element(
                 Snippet::source(source)
                     .line_start(1)
-                    .origin("$DIR/missing-semicolon.rs")
+                    .path("$DIR/missing-semicolon.rs")
                     .fold(true)
                     .annotation(
                         AnnotationKind::Context
@@ -1421,7 +1421,7 @@ outer_macro!(FirstStruct, FirstAttrStruct);
                 .element(
                     Snippet::source(aux_source)
                         .line_start(1)
-                        .origin("$DIR/auxiliary/nested-macro-rules.rs")
+                        .path("$DIR/auxiliary/nested-macro-rules.rs")
                         .fold(true)
                         .annotation(
                             AnnotationKind::Context
@@ -1433,7 +1433,7 @@ outer_macro!(FirstStruct, FirstAttrStruct);
                 .element(
                     Snippet::source(source)
                         .line_start(1)
-                        .origin("$DIR/nested-macro-rules.rs")
+                        .path("$DIR/nested-macro-rules.rs")
                         .fold(true)
                         .annotation(
                             AnnotationKind::Context
@@ -1456,7 +1456,7 @@ outer_macro!(FirstStruct, FirstAttrStruct);
                 .element(
                     Snippet::source(source)
                         .line_start(1)
-                        .origin("$DIR/nested-macro-rules.rs")
+                        .path("$DIR/nested-macro-rules.rs")
                         .fold(true)
                         .annotation(AnnotationKind::Primary.span(224..245)),
                 ),
@@ -1554,7 +1554,7 @@ macro_rules! inline {
             Group::new().element(
                 Snippet::source(source)
                     .line_start(1)
-                    .origin("$DIR/method-on-ambiguous-numeric-type.rs")
+                    .path("$DIR/method-on-ambiguous-numeric-type.rs")
                     .fold(true)
                     .annotation(AnnotationKind::Primary.span(916..919)),
             ),
@@ -1565,7 +1565,7 @@ macro_rules! inline {
                 .element(
                     Snippet::source(aux_source)
                         .line_start(1)
-                        .origin("$DIR/auxiliary/macro-in-other-crate.rs")
+                        .path("$DIR/auxiliary/macro-in-other-crate.rs")
                         .fold(true)
                         .annotation(AnnotationKind::Context.span(69..69).label(": i32")),
                 ),
@@ -1618,7 +1618,7 @@ fn main() {}
             Group::new().element(
                 Snippet::source(source)
                     .line_start(1)
-                    .origin("$DIR/issue-42234-unknown-receiver-type.rs")
+                    .path("$DIR/issue-42234-unknown-receiver-type.rs")
                     .fold(true)
                     .annotation(AnnotationKind::Primary.span(536..539).label(
                         "cannot infer type of the type parameter `S` declared on the method `sum`",
@@ -1726,7 +1726,7 @@ fn main() {}
             Group::new().element(
                 Snippet::source(source)
                     .line_start(1)
-                    .origin("$DIR/empty-match.rs")
+                    .path("$DIR/empty-match.rs")
                     .fold(true)
                     .annotation(
                         AnnotationKind::Primary
@@ -1741,7 +1741,7 @@ fn main() {}
                 .element(
                     Snippet::source(source)
                         .line_start(1)
-                        .origin("$DIR/empty-match.rs")
+                        .path("$DIR/empty-match.rs")
                         .fold(true)
                         .annotation(AnnotationKind::Primary.span(818..831))
                         .annotation(AnnotationKind::Context.span(842..844).label("not covered"))
@@ -1762,7 +1762,7 @@ fn main() {}
                 .element(
                     Snippet::source(source)
                         .line_start(1)
-                        .origin("$DIR/empty-match.rs")
+                        .path("$DIR/empty-match.rs")
                         .fold(true)
                         .annotation(AnnotationKind::Context.span(485..485).label(",\n                _ => todo!()"))
                 )
@@ -1826,7 +1826,7 @@ fn main() {
             Group::new().element(
                 Snippet::source(source)
                     .line_start(1)
-                    .origin("$DIR/object-fail.rs")
+                    .path("$DIR/object-fail.rs")
                     .fold(true)
                     .annotation(
                         AnnotationKind::Primary
@@ -1851,7 +1851,7 @@ fn main() {
                 .element(
                     Snippet::source(source)
                         .line_start(1)
-                        .origin("$DIR/object-fail.rs")
+                        .path("$DIR/object-fail.rs")
                         .fold(true)
                         .annotation(
                             AnnotationKind::Context
@@ -1894,7 +1894,7 @@ fn main() {}
     let input = Level::ERROR.header("mismatched types").id("E0038").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("$DIR/long-span.rs")
+                .path("$DIR/long-span.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -1928,7 +1928,7 @@ fn main() {}
     let input = Level::ERROR.header("mismatched types").id("E0038").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("$DIR/long-span.rs")
+                .path("$DIR/long-span.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -1963,7 +1963,7 @@ fn main() {}
     let input = Level::ERROR.header("mismatched types").id("E0038").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("$DIR/long-span.rs")
+                .path("$DIR/long-span.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -1998,7 +1998,7 @@ fn main() {}
     let input = Level::ERROR.header("mismatched types").id("E0038").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("$DIR/long-span.rs")
+                .path("$DIR/long-span.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Primary
@@ -2052,7 +2052,7 @@ fn main() {
             Group::new()
                 .element(
                     Snippet::source(source)
-                        .origin("$DIR/lint_map_unit_fn.rs")
+                        .path("$DIR/lint_map_unit_fn.rs")
                         .fold(true)
                         .annotation(AnnotationKind::Context.span(271..278).label(
                             "this function returns `()`, which is likely not what you wanted",
@@ -2077,7 +2077,7 @@ fn main() {
                 .element(Level::HELP.title("you might have meant to use `Iterator::for_each`"))
                 .element(
                     Snippet::source(source)
-                        .origin("$DIR/lint_map_unit_fn.rs")
+                        .path("$DIR/lint_map_unit_fn.rs")
                         .fold(true)
                         .patch(Patch::new(267..270, r#"for_each"#)),
                 ),
@@ -2146,7 +2146,7 @@ fn main() {
         .group(
             Group::new().element(
                 Snippet::source(source)
-                    .origin("$DIR/bad-char-literals.rs")
+                    .path("$DIR/bad-char-literals.rs")
                     .fold(true)
                     .annotation(AnnotationKind::Primary.span(204..205)),
             ),
@@ -2156,7 +2156,7 @@ fn main() {
                 .element(Level::HELP.title("escape the character"))
                 .element(
                     Snippet::source(source)
-                        .origin("$DIR/bad-char-literals.rs")
+                        .path("$DIR/bad-char-literals.rs")
                         .line_start(1)
                         .fold(true)
                         .patch(Patch::new(204..205, r#"\n"#)),
@@ -2201,7 +2201,7 @@ fn main() {}
         .group(
             Group::new().element(
                 Snippet::source(source)
-                    .origin("$DIR/unclosed-1.rs")
+                    .path("$DIR/unclosed-1.rs")
                     .fold(true)
                     .annotation(AnnotationKind::Primary.span(0..221)),
             ),
@@ -2211,7 +2211,7 @@ fn main() {}
                 .element(Level::NOTE.title("frontmatter opening here was not closed"))
                 .element(
                     Snippet::source(source)
-                        .origin("$DIR/unclosed-1.rs")
+                        .path("$DIR/unclosed-1.rs")
                         .fold(true)
                         .annotation(AnnotationKind::Primary.span(0..4)),
                 ),
@@ -2261,7 +2261,7 @@ fn foo() -> &str {
         .group(
             Group::new().element(
                 Snippet::source(source)
-                    .origin("$DIR/unclosed-2.rs")
+                    .path("$DIR/unclosed-2.rs")
                     .fold(true)
                     .annotation(AnnotationKind::Primary.span(0..377)),
             ),
@@ -2271,7 +2271,7 @@ fn foo() -> &str {
                 .element(Level::NOTE.title("frontmatter opening here was not closed"))
                 .element(
                     Snippet::source(source)
-                        .origin("$DIR/unclosed-2.rs")
+                        .path("$DIR/unclosed-2.rs")
                         .fold(true)
                         .annotation(AnnotationKind::Primary.span(0..4)),
                 ),
@@ -2323,7 +2323,7 @@ fn foo(x: i32) -> i32 {
         .group(
             Group::new().element(
                 Snippet::source(source)
-                    .origin("$DIR/unclosed-3.rs")
+                    .path("$DIR/unclosed-3.rs")
                     .fold(true)
                     .annotation(AnnotationKind::Primary.span(302..310)),
             ),
@@ -2335,7 +2335,7 @@ fn foo(x: i32) -> i32 {
                 )
                 .element(
                     Snippet::source(source)
-                        .origin("$DIR/unclosed-3.rs")
+                        .path("$DIR/unclosed-3.rs")
                         .fold(true)
                         .annotation(AnnotationKind::Primary.span(302..306)),
                 ),
@@ -2377,7 +2377,7 @@ fn main() {}
         .group(
             Group::new().element(
                 Snippet::source(source)
-                    .origin("$DIR/unclosed-4.rs")
+                    .path("$DIR/unclosed-4.rs")
                     .fold(true)
                     .annotation(AnnotationKind::Primary.span(0..43)),
             ),
@@ -2387,7 +2387,7 @@ fn main() {}
                 .element(Level::NOTE.title("frontmatter opening here was not closed"))
                 .element(
                     Snippet::source(source)
-                        .origin("$DIR/unclosed-4.rs")
+                        .path("$DIR/unclosed-4.rs")
                         .fold(true)
                         .annotation(AnnotationKind::Primary.span(0..4)),
                 ),
@@ -2432,7 +2432,7 @@ fn main() {}
         .group(
             Group::new().element(
                 Snippet::source(source)
-                    .origin("$DIR/unclosed-5.rs")
+                    .path("$DIR/unclosed-5.rs")
                     .fold(true)
                     .annotation(AnnotationKind::Primary.span(0..176)),
             ),
@@ -2442,7 +2442,7 @@ fn main() {}
                 .element(Level::NOTE.title("frontmatter opening here was not closed"))
                 .element(
                     Snippet::source(source)
-                        .origin("$DIR/unclosed-5.rs")
+                        .path("$DIR/unclosed-5.rs")
                         .fold(true)
                         .annotation(AnnotationKind::Primary.span(0..4)),
                 ),
@@ -2558,13 +2558,13 @@ pub enum E2 {
             Group::new()
                 .element(
                     Snippet::source(source)
-                        .origin("$DIR/pat-tuple-field-count-cross.rs")
+                        .path("$DIR/pat-tuple-field-count-cross.rs")
                         .fold(true)
                         .annotation(AnnotationKind::Primary.span(1760..1766)),
                 )
                 .element(
                     Snippet::source(source1)
-                        .origin("$DIR/auxiliary/declarations-for-tuple-field-count-errors.rs")
+                        .path("$DIR/auxiliary/declarations-for-tuple-field-count-errors.rs")
                         .fold(true)
                         .annotation(
                             AnnotationKind::Context
@@ -2583,7 +2583,7 @@ pub enum E2 {
                 .element(Level::HELP.title("use the tuple variant pattern syntax instead"))
                 .element(
                     Snippet::source(source)
-                        .origin("$DIR/pat-tuple-field-count-cross.rs")
+                        .path("$DIR/pat-tuple-field-count-cross.rs")
                         .fold(true)
                         .patch(Patch::new(1760..1766, r#"E1::Z1()"#)),
                 ),
@@ -2593,7 +2593,7 @@ pub enum E2 {
                 .element(Level::HELP.title("a unit variant with a similar name exists"))
                 .element(
                     Snippet::source(source)
-                        .origin("$DIR/pat-tuple-field-count-cross.rs")
+                        .path("$DIR/pat-tuple-field-count-cross.rs")
                         .fold(true)
                         .patch(Patch::new(1764..1766, r#"Z0"#)),
                 ),
@@ -2639,7 +2639,7 @@ fn unterminated_nested_comment() {
     let input = Level::ERROR.header("unterminated block comment").id("E0758").group(
         Group::new().element(
             Snippet::source(source)
-                .origin("$DIR/unterminated-nested-comment.rs")
+                .path("$DIR/unterminated-nested-comment.rs")
                 .fold(true)
                 .annotation(
                     AnnotationKind::Context
@@ -2698,7 +2698,7 @@ fn mismatched_types1() {
                 Snippet::source(file_txt_source)
                     .fold(true)
                     .line_start(3)
-                    .origin("$DIR/file.txt")
+                    .path("$DIR/file.txt")
                     .annotation(
                         AnnotationKind::Primary
                             .span(0..0)
@@ -2707,7 +2707,7 @@ fn mismatched_types1() {
             )
             .element(
                 Snippet::source(rust_source)
-                    .origin("$DIR/mismatched-types.rs")
+                    .path("$DIR/mismatched-types.rs")
                     .fold(true)
                     .annotation(
                         AnnotationKind::Context
@@ -2759,7 +2759,7 @@ fn mismatched_types2() {
         Group::new()
             .element(
                 Snippet::source(source)
-                    .origin("$DIR/mismatched-types.rs")
+                    .path("$DIR/mismatched-types.rs")
                     .fold(true)
                     .annotation(
                         AnnotationKind::Primary
@@ -2815,7 +2815,7 @@ fn main() {
         .group(
             Group::new().element(
                 Snippet::source(source)
-                    .origin("$DIR/short-error-format.rs")
+                    .path("$DIR/short-error-format.rs")
                     .fold(true)
                     .annotation(
                         AnnotationKind::Primary
@@ -2834,7 +2834,7 @@ fn main() {
                 .element(Level::NOTE.title("function defined here"))
                 .element(
                     Snippet::source(source)
-                        .origin("$DIR/short-error-format.rs")
+                        .path("$DIR/short-error-format.rs")
                         .fold(true)
                         .annotation(AnnotationKind::Context.span(48..54).label(""))
                         .annotation(AnnotationKind::Primary.span(44..47)),
@@ -2871,7 +2871,7 @@ fn main() {
         .group(
             Group::new().element(
                 Snippet::source(source)
-                    .origin("$DIR/short-error-format.rs")
+                    .path("$DIR/short-error-format.rs")
                     .fold(true)
                     .annotation(
                         AnnotationKind::Primary
@@ -2909,7 +2909,7 @@ pub struct Foo; //~^ ERROR
             Group::new()
                 .element(
                     Snippet::source(source_0)
-                        .origin("$DIR/diagnostic-width.rs")
+                        .path("$DIR/diagnostic-width.rs")
                         .fold(true)
                         .annotation(AnnotationKind::Primary.span(111..126)),
                 )
@@ -2923,7 +2923,7 @@ pub struct Foo; //~^ ERROR
                 .element(Level::NOTE.title("the lint level is defined here"))
                 .element(
                     Snippet::source(source_0)
-                        .origin("$DIR/diagnostic-width.rs")
+                        .path("$DIR/diagnostic-width.rs")
                         .fold(true)
                         .annotation(AnnotationKind::Primary.span(49..67)),
                 ),
@@ -2933,7 +2933,7 @@ pub struct Foo; //~^ ERROR
                 .element(Level::HELP.title("use an automatic link instead"))
                 .element(
                     Snippet::source(source_1)
-                        .origin("$DIR/diagnostic-width.rs")
+                        .path("$DIR/diagnostic-width.rs")
                         .line_start(4)
                         .fold(true)
                         .patch(Patch::new(40..40, "<"))
@@ -2985,7 +2985,7 @@ fn main() {
             Group::new()
                 .element(
                     Snippet::source(source1)
-                        .origin("lint_example.rs")
+                        .path("lint_example.rs")
                         .fold(true)
                         .annotation(AnnotationKind::Primary.span(40..49)),
                 )
@@ -3000,7 +3000,7 @@ fn main() {
                 )
                 .element(
                     Snippet::source(source2)
-                        .origin("lint_example.rs")
+                        .path("lint_example.rs")
                         .line_start(3)
                         .fold(true)
                         .patch(Patch::new(10..19, "iter")),
@@ -3011,7 +3011,7 @@ fn main() {
                 .element(Level::HELP.title(long_title3))
                 .element(
                     Snippet::source(source2)
-                        .origin("lint_example.rs")
+                        .path("lint_example.rs")
                         .line_start(3)
                         .fold(true)
                         .patch(Patch::new(0..0, "IntoIterator::into_iter("))


### PR DESCRIPTION
This PR addresses #208 by using origin for only one thing, and adding documentation that links `Origin` and `Snippet::path` by saying when to use the other one.