### PR TITLE
fix: Align multi-line secondary titles by level text

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -555,13 +555,14 @@ impl Renderer {
                 buffer.prepend(buffer_msg_line_offset, " ", ElementStyle::NoStyle);
             }
 
+            self.draw_note_separator(
+                buffer,
+                buffer_msg_line_offset,
+                max_line_num_len + 1,
+                is_cont,
+            );
+
             if title.level.name != Some(None) {
-                self.draw_note_separator(
-                    buffer,
-                    buffer_msg_line_offset,
-                    max_line_num_len + 1,
-                    is_cont,
-                );
                 buffer.append(
                     buffer_msg_line_offset,
                     title.level.as_str(),

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -562,17 +562,37 @@ impl Renderer {
                 is_cont,
             );
 
-            if title.level.name != Some(None) {
+            let label_width = if title.level.name != Some(None) {
                 buffer.append(
                     buffer_msg_line_offset,
                     title.level.as_str(),
                     ElementStyle::MainHeaderMsg,
                 );
                 buffer.append(buffer_msg_line_offset, ": ", ElementStyle::NoStyle);
-            }
+                title.level.as_str().len() + 2
+            } else {
+                0
+            };
+            // The extra 3 ` ` is padding that's always needed to align to the
+            // label i.e. `note: `:
+            //
+            //   error: message
+            //     --> file.rs:13:20
+            //      |
+            //   13 |     <CODE>
+            //      |      ^^^^
+            //      |
+            //      = note: multiline
+            //              message
+            //   ++^^^------
+            //    |  |     |
+            //    |  |     |
+            //    |  |     width of label
+            //    |  magic `3`
+            //    `max_line_num_len`
+            let padding = max_line_num_len + 3 + label_width;
 
-            let printed_lines =
-                self.msgs_to_buffer(buffer, title.title, max_line_num_len, "note", None);
+            let printed_lines = self.msgs_to_buffer(buffer, title.title, padding, None);
             if is_cont && matches!(self.theme, OutputTheme::Unicode) {
                 // There's another note after this one, associated to the subwindow above.
                 // We write additional vertical lines to join them:
@@ -660,26 +680,9 @@ impl Renderer {
         buffer: &mut StyledBuffer,
         title: &str,
         padding: usize,
-        label: &str,
         override_style: Option<ElementStyle>,
     ) -> usize {
-        // The extra 5 ` ` is padding that's always needed to align to the `note: `:
-        //
-        //   error: message
-        //     --> file.rs:13:20
-        //      |
-        //   13 |     <CODE>
-        //      |      ^^^^
-        //      |
-        //      = note: multiline
-        //              message
-        //   ++^^^----xx
-        //    |  |   | |
-        //    |  |   | magic `2`
-        //    |  |   length of label
-        //    |  magic `3`
-        //    `max_line_num_len`
-        let padding = " ".repeat(padding + label.len() + 5);
+        let padding = " ".repeat(padding);
 
         let mut line_number = buffer.num_lines().saturating_sub(1);
 

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -2494,3 +2494,96 @@ LL │ �|�␂!5�cc␕␂�Ӻi��WWj�ȥ�'�}�␒�J�ȉ��W
     let renderer_unicode = renderer_ascii.theme(OutputTheme::Unicode);
     assert_data_eq!(renderer_unicode.render(input), expected_unicode);
 }
+
+#[test]
+fn secondary_title_no_level_text() {
+    let source = r#"fn main() {
+    let b: &[u8] = include_str!("file.txt");    //~ ERROR mismatched types
+    let s: &str = include_bytes!("file.txt");   //~ ERROR mismatched types
+}"#;
+
+    let input = Level::ERROR.header("mismatched types").id("E0308").group(
+        Group::new()
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/mismatched-types.rs")
+                    .fold(true)
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(105..131)
+                            .label("expected `&str`, found `&[u8; 0]`"),
+                    )
+                    .annotation(
+                        AnnotationKind::Context
+                            .span(98..102)
+                            .label("expected due to this"),
+                    ),
+            )
+            .element(
+                Level::NOTE
+                    .text(None)
+                    .title("expected reference `&str`\nfound reference `&'static [u8; 0]`"),
+            ),
+    );
+
+    let expected = str![[r#"
+error[E0308]: mismatched types
+  --> $DIR/mismatched-types.rs:3:19
+   |
+LL |     let s: &str = include_bytes!("file.txt");   //~ ERROR mismatched types
+   |            ----   ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&str`, found `&[u8; 0]`
+   |            |
+   |            expected due to this
+  expected reference `&str`
+           found reference `&'static [u8; 0]`
+"#]];
+    let renderer = Renderer::plain().anonymized_line_numbers(true);
+    assert_data_eq!(renderer.render(input), expected);
+}
+
+#[test]
+fn secondary_title_custom_level_text() {
+    let source = r#"fn main() {
+    let b: &[u8] = include_str!("file.txt");    //~ ERROR mismatched types
+    let s: &str = include_bytes!("file.txt");   //~ ERROR mismatched types
+}"#;
+
+    let input = Level::ERROR.header("mismatched types").id("E0308").group(
+        Group::new()
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/mismatched-types.rs")
+                    .fold(true)
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(105..131)
+                            .label("expected `&str`, found `&[u8; 0]`"),
+                    )
+                    .annotation(
+                        AnnotationKind::Context
+                            .span(98..102)
+                            .label("expected due to this"),
+                    ),
+            )
+            .element(
+                Level::NOTE
+                    .text(Some("custom"))
+                    .title("expected reference `&str`\nfound reference `&'static [u8; 0]`"),
+            ),
+    );
+
+    let expected = str![[r#"
+error[E0308]: mismatched types
+  --> $DIR/mismatched-types.rs:3:19
+   |
+LL |     let s: &str = include_bytes!("file.txt");   //~ ERROR mismatched types
+   |            ----   ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&str`, found `&[u8; 0]`
+   |            |
+   |            expected due to this
+   |
+   = custom: expected reference `&str`
+           found reference `&'static [u8; 0]`
+"#]];
+    let renderer = Renderer::plain().anonymized_line_numbers(true);
+    assert_data_eq!(renderer.render(input), expected);
+}

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -2534,7 +2534,7 @@ LL |     let s: &str = include_bytes!("file.txt");   //~ ERROR mismatched types
    |            ----   ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&str`, found `&[u8; 0]`
    |            |
    |            expected due to this
-  expected reference `&str`
+   = expected reference `&str`
            found reference `&'static [u8; 0]`
 "#]];
     let renderer = Renderer::plain().anonymized_line_numbers(true);

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -2535,7 +2535,7 @@ LL |     let s: &str = include_bytes!("file.txt");   //~ ERROR mismatched types
    |            |
    |            expected due to this
    = expected reference `&str`
-           found reference `&'static [u8; 0]`
+     found reference `&'static [u8; 0]`
 "#]];
     let renderer = Renderer::plain().anonymized_line_numbers(true);
     assert_data_eq!(renderer.render(input), expected);
@@ -2582,7 +2582,7 @@ LL |     let s: &str = include_bytes!("file.txt");   //~ ERROR mismatched types
    |            expected due to this
    |
    = custom: expected reference `&str`
-           found reference `&'static [u8; 0]`
+             found reference `&'static [u8; 0]`
 "#]];
     let renderer = Renderer::plain().anonymized_line_numbers(true);
     assert_data_eq!(renderer.render(input), expected);


### PR DESCRIPTION
Before this change, all multi-line secondary titles were aligned as if their level text was `note`, regardless of their actual level text. This made subsequent lines of the title start before the first one. This PR ensures that level text is always taken into account when rendering subsequent lines of a multi-line title.