### PR TITLE
feat: Allow setting the primary level for a group

### DIFF
--- a/examples/elide_header.rs
+++ b/examples/elide_header.rs
@@ -1,0 +1,21 @@
+use annotate_snippets::{AnnotationKind, Group, Level, Renderer, Snippet};
+
+fn main() {
+    let source = r#"# Docstring followed by a newline
+
+def foobar(door, bar={}):
+    """
+    """
+"#;
+
+    let message = &[Group::new()
+        .element(
+            Snippet::source(source)
+                .fold(false)
+                .annotation(AnnotationKind::Primary.span(56..58).label("B006")),
+        )
+        .element(Level::HELP.title("Replace with `None`; initialize within function"))];
+
+    let renderer = Renderer::styled();
+    anstream::println!("{}", renderer.render(message));
+}

--- a/examples/elide_header.rs
+++ b/examples/elide_header.rs
@@ -9,6 +9,7 @@ def foobar(door, bar={}):
 "#;
 
     let message = &[Group::new()
+        .primary_level(Level::NOTE)
         .element(
             Snippet::source(source)
                 .fold(false)

--- a/examples/elide_header.svg
+++ b/examples/elide_header.svg
@@ -3,7 +3,7 @@
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
     .fg-bright-blue { fill: #5555FF }
-    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -27,7 +27,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">3</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> def foobar(door, bar={}):</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>                      </tspan><tspan class="fg-bright-cyan bold">^^</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">B006</tspan>
+    <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>                      </tspan><tspan class="fg-bright-red bold">^^</tspan><tspan> </tspan><tspan class="fg-bright-red bold">B006</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">4</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>     """</tspan>
 </tspan>

--- a/examples/elide_header.svg
+++ b/examples/elide_header.svg
@@ -1,0 +1,44 @@
+<svg width="740px" height="200px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-cyan { fill: #55FFFF }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-blue bold">1</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> # Docstring followed by a newline</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">2</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">3</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> def foobar(door, bar={}):</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>                      </tspan><tspan class="fg-bright-cyan bold">^^</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">B006</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">4</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>     """</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-blue bold">5</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>     """</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="bold">help</tspan><tspan>: Replace with `None`; initialize within function</tspan>
+</tspan>
+    <tspan x="10px" y="190px">
+</tspan>
+  </text>
+
+</svg>

--- a/examples/elide_header.svg
+++ b/examples/elide_header.svg
@@ -3,7 +3,7 @@
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
     .fg-bright-blue { fill: #5555FF }
-    .fg-bright-red { fill: #FF5555 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -27,7 +27,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">3</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> def foobar(door, bar={}):</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>                      </tspan><tspan class="fg-bright-red bold">^^</tspan><tspan> </tspan><tspan class="fg-bright-red bold">B006</tspan>
+    <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>                      </tspan><tspan class="fg-bright-green bold">^^</tspan><tspan> </tspan><tspan class="fg-bright-green bold">B006</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">4</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>     """</tspan>
 </tspan>

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -275,14 +275,16 @@ impl Renderer {
                 if og_primary_path.is_none() && primary_path.is_some() {
                     og_primary_path = primary_path;
                 }
-                let level = group
-                    .elements
-                    .first()
-                    .and_then(|s| match &s {
-                        Element::Title(title) => Some(title.level.clone()),
-                        _ => None,
-                    })
-                    .unwrap_or(Level::ERROR);
+                let level = group.primary_level.clone().unwrap_or_else(|| {
+                    group
+                        .elements
+                        .first()
+                        .and_then(|s| match &s {
+                            Element::Title(title) => Some(title.level.clone()),
+                            _ => None,
+                        })
+                        .unwrap_or(Level::ERROR)
+                });
                 let mut source_map_annotated_lines = VecDeque::new();
                 let mut max_depth = 0;
                 for e in &group.elements {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -277,8 +277,8 @@ impl Renderer {
                 }
                 let level = group
                     .elements
-                    .iter()
-                    .find_map(|s| match &s {
+                    .first()
+                    .and_then(|s| match &s {
                         Element::Title(title) => Some(title.level.clone()),
                         _ => None,
                     })

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -262,10 +262,14 @@ impl<'a> Annotation<'a> {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum AnnotationKind {
-    /// Color to the [`Level`] the first [`Title`] in [`Group`]. If no [`Title`]
-    /// is present, it will default to `error`.
+    /// Match the primary [`Level`] of the group.
     Primary,
-    /// "secondary"; fixed color
+    /// Additional context to explain the [`Primary`][Self::Primary]
+    /// [`Annotation`]
+    ///
+    /// See also [`Renderer::context`].
+    ///
+    /// [`Renderer::context`]: crate::renderer::Renderer
     Context,
 }
 

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -20,6 +20,7 @@ pub(crate) struct Id<'a> {
 /// An [`Element`] container
 #[derive(Clone, Debug)]
 pub struct Group<'a> {
+    pub(crate) primary_level: Option<Level<'a>>,
     pub(crate) elements: Vec<Element<'a>>,
 }
 
@@ -31,7 +32,10 @@ impl Default for Group<'_> {
 
 impl<'a> Group<'a> {
     pub fn new() -> Self {
-        Self { elements: vec![] }
+        Self {
+            primary_level: None,
+            elements: vec![],
+        }
     }
 
     pub fn element(mut self, section: impl Into<Element<'a>>) -> Self {
@@ -41,6 +45,15 @@ impl<'a> Group<'a> {
 
     pub fn elements(mut self, sections: impl IntoIterator<Item = impl Into<Element<'a>>>) -> Self {
         self.elements.extend(sections.into_iter().map(Into::into));
+        self
+    }
+
+    /// Set the primary [`Level`] for this [`Group`].
+    ///
+    /// If not specified, use the [`Level`] of the first element in a [`Group`]
+    /// if it is a [`Title`]. If not it will default to [`Level::ERROR`].
+    pub fn primary_level(mut self, level: Level<'a>) -> Self {
+        self.primary_level = Some(level);
         self
     }
 
@@ -263,6 +276,8 @@ impl<'a> Annotation<'a> {
 #[non_exhaustive]
 pub enum AnnotationKind {
     /// Match the primary [`Level`] of the group.
+    ///
+    /// See [`Group::primary_level`] for details about how this is determined
     Primary,
     /// Additional context to explain the [`Primary`][Self::Primary]
     /// [`Annotation`]

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -15,6 +15,13 @@ fn custom_level() {
 }
 
 #[test]
+fn elide_header() {
+    let target = "elide_header";
+    let expected = snapbox::file!["../examples/elide_header.svg": TermSvg];
+    assert_example(target, expected);
+}
+
+#[test]
 fn expected_type() {
     let target = "expected_type";
     let expected = snapbox::file!["../examples/expected_type.svg": TermSvg];


### PR DESCRIPTION
This should allow users to create a `Group` without a `Title` and control the primary `Level` for that `Group`.