### PR TITLE
fix: Rename `Label::ERROR.text().title()` with `Label::ERROR.with_name().title()`

### DIFF
--- a/examples/custom_error.rs
+++ b/examples/custom_error.rs
@@ -17,7 +17,7 @@ pub static C: u32 = 0 - 1;
 "#;
     let message = &[Group::with_title(
         Level::ERROR
-            .text(Some("error: internal compiler error"))
+            .with_name(Some("error: internal compiler error"))
             .title("could not evaluate static initializer")
             .id("E0080"),
     )

--- a/examples/custom_level.rs
+++ b/examples/custom_level.rs
@@ -52,7 +52,7 @@ fn main() {
         ),
         Group::with_title(
             Level::HELP
-                .text(Some("suggestion"))
+                .with_name(Some("suggestion"))
                 .title("use `break` on its own without a value inside this `while` loop"),
         )
         .element(

--- a/src/level.rs
+++ b/src/level.rs
@@ -50,6 +50,8 @@ impl<'a> Level<'a> {
     pub const NOTE: Level<'a> = NOTE;
     pub const HELP: Level<'a> = HELP;
 
+    /// Replace the text describing this [`Level`]
+    ///
     /// <div class="warning">
     ///
     /// Text passed to this function is considered "untrusted input", as such

--- a/src/level.rs
+++ b/src/level.rs
@@ -50,7 +50,7 @@ impl<'a> Level<'a> {
     pub const NOTE: Level<'a> = NOTE;
     pub const HELP: Level<'a> = HELP;
 
-    /// Replace the text describing this [`Level`]
+    /// Replace the name describing this [`Level`]
     ///
     /// <div class="warning">
     ///
@@ -59,9 +59,9 @@ impl<'a> Level<'a> {
     /// not allowed to be passed to this function.
     ///
     /// </div>
-    pub fn text(self, text: impl Into<OptionCow<'a>>) -> Level<'a> {
+    pub fn with_name(self, name: impl Into<OptionCow<'a>>) -> Level<'a> {
         Level {
-            name: Some(text.into().0),
+            name: Some(name.into().0),
             level: self.level,
         }
     }

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -2397,7 +2397,7 @@ fn secondary_title_no_level_text() {
             )
             .element(
                 Level::NOTE
-                    .text(None::<&str>)
+                    .with_name(None::<&str>)
                     .title("expected reference `&str`\nfound reference `&'static [u8; 0]`"),
             ),
     ];
@@ -2442,7 +2442,7 @@ fn secondary_title_custom_level_text() {
             )
             .element(
                 Level::NOTE
-                    .text(Some("custom"))
+                    .with_name(Some("custom"))
                     .title("expected reference `&str`\nfound reference `&'static [u8; 0]`"),
             ),
     ];
@@ -2515,7 +2515,7 @@ fn main() {
         ),
         Group::with_title(
             Level::HELP
-                .text(Some("suggestion"))
+                .with_name(Some("suggestion"))
                 .title("use `break` on its own without a value inside this `while` loop")
                 .id("S0123"),
         )


### PR DESCRIPTION
The goal for this is to make the intent clearer as `text` could be interpreted as the title's text (or message when we add that)