### PR TITLE
fix: Address clippy::needless_doctest_main

### DIFF
--- a/src/level.rs
+++ b/src/level.rs
@@ -144,6 +144,7 @@ impl<'a> Level<'a> {
     /// # Example
     ///
     /// ```rust
+    /// # #[allow(clippy::needless_doctest_main)]
     #[doc = include_str!("../examples/custom_level.rs")]
     /// ```
     #[doc = include_str!("../examples/custom_level.svg")]

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -26,6 +26,7 @@ pub(crate) struct Id<'a> {
 /// # Example
 ///
 /// ```rust
+/// # #[allow(clippy::needless_doctest_main)]
 #[doc = include_str!("../examples/highlight_message.rs")]
 /// ```
 #[doc = include_str!("../examples/highlight_message.svg")]
@@ -47,6 +48,7 @@ impl<'a> Group<'a> {
     /// # Example
     ///
     /// ```rust
+    /// # #[allow(clippy::needless_doctest_main)]
     #[doc = include_str!("../examples/elide_header.rs")]
     /// ```
     #[doc = include_str!("../examples/elide_header.svg")]


### PR DESCRIPTION
#245 made `clippy::needless_doctest_main` fire locally, and this fixes those warnings.