### PR TITLE
fix: Render newline if a Message ends with one

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -636,7 +636,7 @@ impl Renderer {
         } else {
             (normalize_whitespace(title.text()), title_element_style)
         };
-        for (i, text) in title_str.lines().enumerate() {
+        for (i, text) in title_str.split('\n').enumerate() {
             if i != 0 {
                 buffer.append(buffer_msg_line_offset + i, &padding, ElementStyle::NoStyle);
                 if title_style == TitleStyle::Secondary

--- a/tests/rustc_tests.rs
+++ b/tests/rustc_tests.rs
@@ -3440,6 +3440,7 @@ LL |     let _: S::<bool>::Pr = ();
    |                       ^^ associated item not found in `S<bool>`
    |
    = note: the associated type was found for
+           
 "#]];
     let renderer = Renderer::plain().anonymized_line_numbers(true);
     assert_data_eq!(renderer.render(input), expected);


### PR DESCRIPTION
Before this change, we would not output a newline character if a `Message::text` ended with `\n`, this PR makes it so that we do.