### PR TITLE
fix: Render Padding as end col separator if last in Group

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -413,11 +413,19 @@ impl Renderer {
                         }
                         Element::Padding(_) => {
                             let current_line = buffer.num_lines();
-                            self.draw_col_separator_no_space(
-                                &mut buffer,
-                                current_line,
-                                max_line_num_len + 1,
-                            );
+                            if peek.is_none() {
+                                self.draw_col_separator_end(
+                                    &mut buffer,
+                                    current_line,
+                                    max_line_num_len + 1,
+                                );
+                            } else {
+                                self.draw_col_separator_no_space(
+                                    &mut buffer,
+                                    current_line,
+                                    max_line_num_len + 1,
+                                );
+                            }
                         }
                     }
                     if g == 0

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -2875,7 +2875,7 @@ error[E0282]: type annotations needed
    │
 LL │         .sum::<_>() //~ ERROR type annotations needed
    │          ━━━ cannot infer type of the type parameter `S` declared on the method `sum`
-   │
+   ╰╴
 "#]];
     let renderer = renderer.theme(OutputTheme::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
@@ -2942,7 +2942,7 @@ error[E0282]: type annotations needed
    │
 LL │         .sum::<_>() //~ ERROR type annotations needed
    │          ━━━ cannot infer type of the type parameter `S` declared on the method `sum`
-   │
+   ╰╴
 help: consider specifying the generic argument
    ╭╴
 LL -         .sum::<_>() //~ ERROR type annotations needed


### PR DESCRIPTION
When `Padding` is last in a `Group`, it always renders as `|` when it really should have "closed" the group off. This problem was extremely noticeable with `OutputTheme::Unicode`.