### PR TITLE
fix: Match rustc's annotation overlap

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1167,7 +1167,7 @@ impl Renderer {
         // otherwise the lines would end up needing to go over a message.
 
         let mut annotations = line_info.annotations.clone();
-        annotations.sort_by_key(|a| Reverse(a.start.display));
+        annotations.sort_by_key(|a| Reverse((a.start.display, a.start.char)));
 
         // First, figure out where each label will be positioned.
         //
@@ -1250,7 +1250,9 @@ impl Renderer {
                     // If we're overlapping with an un-labelled annotation with the same span
                     // we can just merge them in the output
                     if next.start.display == annotation.start.display
+                        && next.start.char == annotation.start.char
                         && next.end.display == annotation.end.display
+                        && next.end.char == annotation.end.char
                         && !next.has_label()
                     {
                         continue;
@@ -1284,7 +1286,7 @@ impl Renderer {
                         && next.takes_space())
                         || (annotation.takes_space() && next.takes_space())
                         || (overlaps(next, annotation, l)
-                        && next.end.display <= annotation.end.display
+                        && (next.end.display, next.end.char) <= (annotation.end.display, annotation.end.char)
                         && next.has_label()
                         && p == 0)
                     // Avoid #42595.

--- a/tests/rustc_tests.rs
+++ b/tests/rustc_tests.rs
@@ -3500,8 +3500,9 @@ error: extern blocks should be unsafe
   --> $DIR/unsafe-extern-suggestion.rs:6:1
    |
 LL |   extern "C" {
-   |   ^ help: needs `unsafe` before the extern keyword: `unsafe`
-   |  _|
+   |   ^
+   |   |
+   |  _help: needs `unsafe` before the extern keyword: `unsafe`
    | |
 LL | |     //~^ ERROR extern blocks should be unsafe [missing_unsafe_on_extern]
 LL | |     //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!


### PR DESCRIPTION
While working on `rustc`, I saw that `annotate-snippets` and `rustc` had different outputs for [`unsafe_extern_suggestion`](https://github.com/rust-lang/rust/blob/f838cbc06de60819faff3413f374706b74824ca2/tests/ui/rust-2024/unsafe-extern-blocks/unsafe-extern-suggestion.rs). I spent some time digging into this, and it turns out we did not match how `rustc` handled overlaps. Some of the ways I attempted to fix this divergence caused [`alloc_error_handler_bad_signature_2`](https://github.com/rust-lang/rust/blob/f838cbc06de60819faff3413f374706b74824ca2/tests/ui/alloc-error/alloc-error-handler-bad-signature-2.rs) and [`str_escape`](https://github.com/rust-lang/rust/blob/f838cbc06de60819faff3413f374706b74824ca2/tests/ui/str/str-escape.rs) to regress, so I figured I would add them to help catch any future changes.