### PR TITLE
fix: Show suggestion if same as source

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -55,7 +55,6 @@ use std::borrow::Cow;
 use std::cmp::{max, min, Ordering, Reverse};
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
-use std::ops::Range;
 use stylesheet::Stylesheet;
 
 const ANONYMIZED_LINE_NUM: &str = "LL";
@@ -1911,9 +1910,7 @@ impl Renderer {
                     assert!(underline_start >= 0 && underline_end >= 0);
                     let padding: usize = max_line_num_len + 3;
                     for p in underline_start..underline_end {
-                        if matches!(show_code_change, DisplaySuggestion::Underline)
-                            && is_different(sm, &part.replacement, part.span.clone())
-                        {
+                        if matches!(show_code_change, DisplaySuggestion::Underline) {
                             // If this is a replacement, underline with `~`, if this is an addition
                             // underline with `+`.
                             buffer.putc(
@@ -2953,14 +2950,6 @@ struct UnderlineParts {
     multiline_end_up: char,
     multiline_end_same_line: char,
     multiline_bottom_right_with_text: char,
-}
-
-/// Whether the original and suggested code are the same.
-pub(crate) fn is_different(sm: &SourceMap<'_>, suggested: &str, range: Range<usize>) -> bool {
-    match sm.span_to_snippet(range) {
-        Some(s) => s != suggested,
-        None => true,
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/renderer/source_map.rs
+++ b/src/renderer/source_map.rs
@@ -1,4 +1,4 @@
-use crate::renderer::{char_width, is_different, num_overlap, LineAnnotation, LineAnnotationType};
+use crate::renderer::{char_width, num_overlap, LineAnnotation, LineAnnotationType};
 use crate::{Annotation, AnnotationKind, Patch};
 use std::borrow::Cow;
 use std::cmp::{max, min};
@@ -474,16 +474,10 @@ impl<'a> SourceMap<'a> {
                     _ => 1,
                 })
                 .sum();
-            if !is_different(self, &part.replacement, part.span.clone()) {
-                // Account for cases where we are suggesting the same code that's already
-                // there. This shouldn't happen often, but in some cases for multipart
-                // suggestions it's much easier to handle it here than in the origin.
-            } else {
-                line_highlight.push(SubstitutionHighlight {
-                    start: (cur_lo.char as isize + acc) as usize,
-                    end: (cur_lo.char as isize + acc + len) as usize,
-                });
-            }
+            line_highlight.push(SubstitutionHighlight {
+                start: (cur_lo.char as isize + acc) as usize,
+                end: (cur_lo.char as isize + acc + len) as usize,
+            });
             buf.push_str(&part.replacement);
             // Account for the difference between the width of the current code and the
             // snippet being suggested, so that the *later* suggestions are correctly

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -2997,6 +2997,9 @@ LL |         .sum::<_>() //~ ERROR type annotations needed
    |          ^^^ cannot infer type of the type parameter `S` declared on the method `sum`
    |
 help: consider specifying the generic argument
+   |
+LL |         .sum::<_>() //~ ERROR type annotations needed
+   |
 "#]];
     let renderer = Renderer::plain().anonymized_line_numbers(true);
     assert_data_eq!(renderer.render(input), expected);


### PR DESCRIPTION
Before this change, if a user passed in a replacement that matched the source text, we would not show the suggestion but still show the `Title`. The ideal scenario would be to also not show the `Title`, but we do not have the context to do that. The next best thing to do is to show the suggestion, so that users know they are passing a bad suggestion.