### PR TITLE
feat: Add a way to keep lines with no annotations

### DIFF
--- a/examples/struct_name_as_context.rs
+++ b/examples/struct_name_as_context.rs
@@ -17,7 +17,8 @@ fn main() {
             .element(
                 Snippet::source(source)
                     .path("$DIR/struct_name_as_context.rs")
-                    .annotation(AnnotationKind::Primary.span(91..102)),
+                    .annotation(AnnotationKind::Primary.span(91..102))
+                    .annotation(AnnotationKind::Visible.span(0..8)),
             )
             .element(
                 Level::HELP.message(

--- a/examples/struct_name_as_context.rs
+++ b/examples/struct_name_as_context.rs
@@ -1,0 +1,31 @@
+use annotate_snippets::{AnnotationKind, Group, Level, Renderer, Snippet};
+fn main() {
+    let source = r#"struct S {
+    field1: usize,
+    field2: usize,
+    field3: usize,
+    field4: usize,
+    fn foo() {},
+    field6: usize,
+}
+"#;
+    let message =
+        &[
+            Group::with_title(
+                Level::ERROR.title("functions are not allowed in struct definitions"),
+            )
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/struct_name_as_context.rs")
+                    .annotation(AnnotationKind::Primary.span(91..102)),
+            )
+            .element(
+                Level::HELP.message(
+                    "unlike in C++, Java, and C#, functions are declared in `impl` blocks",
+                ),
+            ),
+        ];
+
+    let renderer = Renderer::styled();
+    anstream::println!("{}", renderer.render(message));
+}

--- a/examples/struct_name_as_context.svg
+++ b/examples/struct_name_as_context.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="164px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="200px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -25,15 +25,19 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">6</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>     fn foo() {},</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">1</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> struct S {</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>     </tspan><tspan class="fg-bright-red bold">^^^^^^^^^^^</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-blue bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">6</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>     fn foo() {},</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="bold">help</tspan><tspan>: unlike in C++, Java, and C#, functions are declared in `impl` blocks</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>     </tspan><tspan class="fg-bright-red bold">^^^^^^^^^^^</tspan>
 </tspan>
-    <tspan x="10px" y="154px">
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="bold">help</tspan><tspan>: unlike in C++, Java, and C#, functions are declared in `impl` blocks</tspan>
+</tspan>
+    <tspan x="10px" y="190px">
 </tspan>
   </text>
 

--- a/examples/struct_name_as_context.svg
+++ b/examples/struct_name_as_context.svg
@@ -1,0 +1,40 @@
+<svg width="740px" height="164px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">: functions are not allowed in struct definitions</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> </tspan><tspan class="fg-bright-blue bold">--&gt; </tspan><tspan>$DIR/struct_name_as_context.rs:6:5</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">6</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>     fn foo() {},</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>     </tspan><tspan class="fg-bright-red bold">^^^^^^^^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="bold">help</tspan><tspan>: unlike in C++, Java, and C#, functions are declared in `impl` blocks</tspan>
+</tspan>
+    <tspan x="10px" y="154px">
+</tspan>
+  </text>
+
+</svg>

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -313,6 +313,24 @@ pub enum AnnotationKind {
     ///
     /// [`Renderer::context`]: crate::renderer::Renderer
     Context,
+    /// Prevents the annotated text from getting [folded][Snippet::fold]
+    ///
+    /// By default, [`Snippet`]s will [fold][`Snippet::fold`] (remove) lines
+    /// that do not contain any annotations. [`Visible`][Self::Visible] makes
+    /// it possible to selectively prevent this behavior for specific text,
+    /// allowing context to be preserved without adding any annotation
+    /// characters.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[allow(clippy::needless_doctest_main)]
+    #[doc = include_str!("../examples/struct_name_as_context.rs")]
+    /// ```
+    ///
+    #[doc = include_str!("../examples/struct_name_as_context.svg")]
+    ///
+    Visible,
 }
 
 impl AnnotationKind {

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -70,6 +70,13 @@ fn multislice() {
     assert_example(target, expected);
 }
 
+#[test]
+fn struct_name_as_context() {
+    let target = "struct_name_as_context";
+    let expected = snapbox::file!["../examples/struct_name_as_context.svg": TermSvg];
+    assert_example(target, expected);
+}
+
 #[track_caller]
 fn assert_example(target: &str, expected: snapbox::Data) {
     let bin_path = snapbox::cmd::compile_example(target, ["--features=testing-colors"]).unwrap();

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -3005,3 +3005,67 @@ LL |         .sum::<_>() //~ ERROR type annotations needed
     let renderer = Renderer::plain().anonymized_line_numbers(true);
     assert_data_eq!(renderer.render(input), expected);
 }
+
+#[test]
+fn keep_lines1() {
+    let source = r#"
+cargo
+fuzzy
+pizza
+jumps
+crazy
+quack
+zappy
+"#;
+
+    let input_new = &[Group::with_title(
+        Level::ERROR
+            .title("the size for values of type `T` cannot be known at compilation time")
+            .id("E0277"),
+    )
+    .element(
+        Snippet::source(source)
+            .line_start(11)
+            .annotation(AnnotationKind::Primary.span(1..6)),
+    )];
+    let expected = str![[r#"
+error[E0277]: the size for values of type `T` cannot be known at compilation time
+   |
+12 | cargo
+   | ^^^^^
+"#]];
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input_new), expected);
+}
+
+#[test]
+fn keep_lines2() {
+    let source = r#"
+cargo
+fuzzy
+pizza
+jumps
+crazy
+quack
+zappy
+"#;
+
+    let input_new = &[Group::with_title(
+        Level::ERROR
+            .title("the size for values of type `T` cannot be known at compilation time")
+            .id("E0277"),
+    )
+    .element(
+        Snippet::source(source)
+            .line_start(11)
+            .annotation(AnnotationKind::Primary.span(1..6)),
+    )];
+    let expected = str![[r#"
+error[E0277]: the size for values of type `T` cannot be known at compilation time
+   |
+12 | cargo
+   | ^^^^^
+"#]];
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input_new), expected);
+}

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -3026,13 +3026,16 @@ zappy
     .element(
         Snippet::source(source)
             .line_start(11)
-            .annotation(AnnotationKind::Primary.span(1..6)),
+            .annotation(AnnotationKind::Primary.span(1..6))
+            .annotation(AnnotationKind::Visible.span(37..41)),
     )];
     let expected = str![[r#"
 error[E0277]: the size for values of type `T` cannot be known at compilation time
    |
 12 | cargo
    | ^^^^^
+...
+18 | zappy
 "#]];
     let renderer = Renderer::plain();
     assert_data_eq!(renderer.render(input_new), expected);
@@ -3058,13 +3061,16 @@ zappy
     .element(
         Snippet::source(source)
             .line_start(11)
-            .annotation(AnnotationKind::Primary.span(1..6)),
+            .annotation(AnnotationKind::Primary.span(1..6))
+            .annotation(AnnotationKind::Visible.span(16..18)),
     )];
     let expected = str![[r#"
 error[E0277]: the size for values of type `T` cannot be known at compilation time
    |
 12 | cargo
    | ^^^^^
+13 | fuzzy
+14 | pizza
 "#]];
     let renderer = Renderer::plain();
     assert_data_eq!(renderer.render(input_new), expected);


### PR DESCRIPTION
This PR makes it so that you can "annotate" text with `AnnotationKind::Visible` to keep it from getting folded, allowing you to keep some lines around as context without underlining them with annotation characters.

```
error: functions are not allowed in struct definitions
  --> $DIR/struct-fn-in-definition.rs:9:5
   |
LL | struct S {
...
LL |     fn foo() {}
   |     ^^^^^^^^^^^
   |
   = help: unlike in C++, Java, and C#, functions are declared in `impl` blocks
```