### PR TITLE
chore: Don't allow Title in element

### DIFF
--- a/examples/highlight_source.rs
+++ b/examples/highlight_source.rs
@@ -22,7 +22,7 @@ fn main() {}
                 ),
         )
         .element(
-            Level::NOTE.title("The runtime heap is not yet available at compile-time, so no runtime heap allocations can be created."),
+            Level::NOTE.message("The runtime heap is not yet available at compile-time, so no runtime heap allocations can be created."),
 
     )];
 

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -33,6 +33,7 @@ pub(crate) struct Id<'a> {
 #[derive(Clone, Debug)]
 pub struct Group<'a> {
     pub(crate) primary_level: Level<'a>,
+    pub(crate) title: Option<Title<'a>>,
     pub(crate) elements: Vec<Element<'a>>,
 }
 
@@ -40,7 +41,9 @@ impl<'a> Group<'a> {
     /// Create group with a title, deriving the primary [`Level`] for [`Annotation`]s from it
     pub fn with_title(title: Title<'a>) -> Self {
         let level = title.level.clone();
-        Self::with_level(level).element(title)
+        let mut x = Self::with_level(level);
+        x.title = Some(title);
+        x
     }
 
     /// Create a title-less group with a primary [`Level`] for [`Annotation`]s
@@ -55,6 +58,7 @@ impl<'a> Group<'a> {
     pub fn with_level(level: Level<'a>) -> Self {
         Self {
             primary_level: level,
+            title: None,
             elements: vec![],
         }
     }
@@ -70,7 +74,7 @@ impl<'a> Group<'a> {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.elements.is_empty()
+        self.elements.is_empty() && self.title.is_none()
     }
 }
 
@@ -78,18 +82,11 @@ impl<'a> Group<'a> {
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum Element<'a> {
-    Title(Title<'a>),
     Message(Message<'a>),
     Cause(Snippet<'a, Annotation<'a>>),
     Suggestion(Snippet<'a, Patch<'a>>),
     Origin(Origin<'a>),
     Padding(Padding),
-}
-
-impl<'a> From<Title<'a>> for Element<'a> {
-    fn from(value: Title<'a>) -> Self {
-        Element::Title(value)
-    }
 }
 
 impl<'a> From<Message<'a>> for Element<'a> {

--- a/tests/color/multiline_removal_suggestion.rs
+++ b/tests/color/multiline_removal_suggestion.rs
@@ -81,10 +81,10 @@ fn main() {}
             )
             .element(
                 Level::HELP
-                    .title("the trait `Iterator` is not implemented for `(bool, HashSet<u8>)`"),
+                    .message("the trait `Iterator` is not implemented for `(bool, HashSet<u8>)`"),
             )
             .element(
-                Level::NOTE.title("required for `(bool, HashSet<u8>)` to implement `IntoIterator`"),
+                Level::NOTE.message("required for `(bool, HashSet<u8>)` to implement `IntoIterator`"),
             ),
         Group::with_title(Level::NOTE.title("required by a bound in `flatten`"))
             .element(

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -1666,7 +1666,7 @@ fn main() {
                 .annotation(AnnotationKind::Primary.span(89..90))
         ).element(
             Level::NOTE
-                .title("required for the cast from `Box<Result<Result<(), Result<Result<(), Result<Result<(), Option<{integer}>>, ()>>, ()>>, ()>>` to `Box<(dyn Future<Error = Foo> + 'static)>`")
+                .message("required for the cast from `Box<Result<Result<(), Result<Result<(), Result<Result<(), Option<{integer}>>, ()>>, ()>>, ()>>` to `Box<(dyn Future<Error = Foo> + 'static)>`")
                 ,
         )];
 
@@ -1752,9 +1752,9 @@ fn main() {
                 .annotation(AnnotationKind::Primary.span(89..90))
         ).element(
             Level::NOTE
-                .title("required for the cast from `Box<Result<Result<(), Result<Result<(), Result<Result<(), Option<{integer}>>, ()>>, ()>>, ()>>` to `Box<(dyn Future<Error = Foo> + 'static)>`")
+                .message("required for the cast from `Box<Result<Result<(), Result<Result<(), Result<Result<(), Option<{integer}>>, ()>>, ()>>, ()>>` to `Box<(dyn Future<Error = Foo> + 'static)>`")
         ).element(
-            Level::NOTE.title("a second note"),
+            Level::NOTE.message("a second note"),
         )];
 
     let expected = str![[r#"
@@ -1902,13 +1902,13 @@ fn main() {
                 )
         ).element(
             Level::NOTE
-                .title("expected struct `Atype<Btype<..., i32>, i32>`\n     found enum `Result<Result<..., _>, _>`")
+                .message("expected struct `Atype<Btype<..., i32>, i32>`\n     found enum `Result<Result<..., _>, _>`")
         ).element(
             Level::NOTE
-                .title("the full name for the type has been written to '$TEST_BUILD_DIR/$FILE.long-type-hash.txt'")
+                .message("the full name for the type has been written to '$TEST_BUILD_DIR/$FILE.long-type-hash.txt'")
         ).element(
             Level::NOTE
-                .title("consider using `--verbose` to print the full type name to the console")
+                .message("consider using `--verbose` to print the full type name to the console")
                 ,
         )];
 
@@ -1986,7 +1986,7 @@ fn main() {
                 ),
         ).element(
             Level::NOTE
-                .title("expected fn pointer `for<'a> fn(Box<(dyn Any + Send + 'a)>) -> Pin<_>`\n      found fn item `fn(Box<(dyn Any + Send + 'static)>) -> Pin<_> {wrapped_fn}`")
+                .message("expected fn pointer `for<'a> fn(Box<(dyn Any + Send + 'a)>) -> Pin<_>`\n      found fn item `fn(Box<(dyn Any + Send + 'static)>) -> Pin<_> {wrapped_fn}`")
                 ,
         ),Group::with_title(
             Level::NOTE.title("function defined here"),
@@ -2077,7 +2077,7 @@ fn unicode_cut_handling2() {
                     .fold(false)
                     .annotation(AnnotationKind::Primary.span(499..500).label("expected item"))
             ).element(
-                Level::NOTE.title("for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>")
+                Level::NOTE.message("for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>")
 
        )];
 
@@ -2114,7 +2114,7 @@ fn unicode_cut_handling3() {
                     .fold(false)
                     .annotation(AnnotationKind::Primary.span(251..254).label("expected item"))
             ).element(
-                Level::NOTE.title("for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>")
+                Level::NOTE.message("for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>")
 
        )];
 
@@ -2151,7 +2151,7 @@ fn unicode_cut_handling4() {
                     .fold(false)
                     .annotation(AnnotationKind::Primary.span(334..335).label("expected item"))
             ).element(
-                Level::NOTE.title("for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>")
+                Level::NOTE.message("for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>")
 
        )];
 

--- a/tests/rustc_tests.rs
+++ b/tests/rustc_tests.rs
@@ -1365,11 +1365,11 @@ outer_macro!(FirstStruct, FirstAttrStruct);
                 )
                 .element(
                     Level::HELP
-                        .title("remove the `#[macro_export]` or move this `macro_rules!` outside the of the current function `main`")
+                        .message("remove the `#[macro_export]` or move this `macro_rules!` outside the of the current function `main`")
                 )
                 .element(
                     Level::NOTE
-                        .title("a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute")
+                        .message("a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute")
                 ),
             Group::with_title(Level::NOTE.title("the lint level is defined here"))
                 .element(
@@ -1965,7 +1965,7 @@ fn main() {
                         .annotation(AnnotationKind::Primary.span(267..380)),
                 )
                 .element(
-                    Level::NOTE.title("`Iterator::map`, like many of the methods on `Iterator`, gets executed lazily, meaning that its effects won't be visible until it is iterated")),
+                    Level::NOTE.message("`Iterator::map`, like many of the methods on `Iterator`, gets executed lazily, meaning that its effects won't be visible until it is iterated")),
             Group::with_title(Level::HELP.title("you might have meant to use `Iterator::for_each`"))
                 .element(
                     Snippet::source(source)
@@ -2555,7 +2555,8 @@ fn mismatched_types1() {
                     ),
             )
             .element(
-                Level::NOTE.title("expected reference `&[u8]`\n   found reference `&'static str`"),
+                Level::NOTE
+                    .message("expected reference `&[u8]`\n   found reference `&'static str`"),
             ),
     ];
 
@@ -2607,7 +2608,7 @@ fn mismatched_types2() {
             )
             .element(
                 Level::NOTE
-                    .title("expected reference `&str`\n   found reference `&'static [u8; 0]`"),
+                    .message("expected reference `&str`\n   found reference `&'static [u8; 0]`"),
             ),
     ];
 
@@ -2734,7 +2735,7 @@ pub struct Foo; //~^ ERROR
                     .annotation(AnnotationKind::Primary.span(111..126)),
             )
             .element(
-                Level::NOTE.title("bare URLs are not automatically turned into clickable links"),
+                Level::NOTE.message("bare URLs are not automatically turned into clickable links"),
             ),
         Group::with_title(Level::NOTE.title("the lint level is defined here")).element(
             Snippet::source(source_0)
@@ -3427,7 +3428,7 @@ fn main() {
                     .label("associated type `Pr` not found for this struct"),
             ),
     )
-    .element(Level::NOTE.title("the associated type was found for\n"))];
+    .element(Level::NOTE.message("the associated type was found for\n"))];
 
     let expected = str![[r#"
 error[E0220]: associated type `Pr` not found for `S<bool>` in the current scope


### PR DESCRIPTION
Having `Title` as an `Element` did not make sense, as `Title` is only meant to be used with `Group::with_title`, and `Message` should be used if you want similar output. Given that within our own tests, we were using `Title` when we should've been using `Message`, having both would have no doubt led to confusion for users over what to use.

Note: this adds a bit of duplication for how we handle continuations; the next few PRs should hopefully address some of it.