### PR TITLE
test: annotate newline empty span

### DIFF
--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -440,6 +440,37 @@ error:
 }
 
 #[test]
+fn annotate_newline_empty_span() {
+    let message = &[Group::with_title(Level::ERROR.title("bad")).element(
+        Snippet::source("\n\n\n\n\n\n\n")
+            .path("test.txt")
+            .annotation(AnnotationKind::Primary.span(0..0)),
+    )];
+
+    let expected_ascii = str![[r#"
+error: bad
+ --> test.txt:1:1
+  |
+1 |
+  | ^
+"#]];
+
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(message), expected_ascii);
+
+    let expected_unicode = str![[r#"
+error: bad
+  ╭▸ test.txt:1:1
+  │
+1 │
+  ╰╴━
+"#]];
+
+    let renderer = renderer.theme(OutputTheme::Unicode);
+    assert_data_eq!(renderer.render(message), expected_unicode);
+}
+
+#[test]
 fn annotate_eol() {
     let source = "a\r\nb";
     let input = &[Group::with_title(Level::ERROR.title("")).element(


### PR DESCRIPTION
Issue #135 was opened over a year ago, and during that time, a change to `annotate-snippets` fixed the issue, but it was never closed. Since the issue is fixed, I figured we should add a regression test to ensure consistent behavior in the future.

Fixes #135