### PR TITLE
fix!: Rename Renderer::theme to decor_style

### DIFF
--- a/examples/custom_error.rs
+++ b/examples/custom_error.rs
@@ -29,6 +29,6 @@ pub static C: u32 = 0 - 1;
         ),
     )];
 
-    let renderer = Renderer::styled().theme(DecorStyle::Unicode);
+    let renderer = Renderer::styled().decor_style(DecorStyle::Unicode);
     anstream::println!("{}", renderer.render(message));
 }

--- a/examples/custom_level.rs
+++ b/examples/custom_level.rs
@@ -63,6 +63,6 @@ fn main() {
         ),
     ];
 
-    let renderer = Renderer::styled().theme(DecorStyle::Unicode);
+    let renderer = Renderer::styled().decor_style(DecorStyle::Unicode);
     anstream::println!("{}", renderer.render(message));
 }

--- a/examples/id_hyperlink.rs
+++ b/examples/id_hyperlink.rs
@@ -29,6 +29,6 @@ fn main() {
             ),
     )];
 
-    let renderer = Renderer::styled().theme(DecorStyle::Unicode);
+    let renderer = Renderer::styled().decor_style(DecorStyle::Unicode);
     anstream::println!("{}", renderer.render(message));
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -67,7 +67,7 @@ pub const DEFAULT_TERM_WIDTH: usize = 140;
 pub struct Renderer {
     anonymized_line_numbers: bool,
     term_width: usize,
-    theme: DecorStyle,
+    decor_style: DecorStyle,
     stylesheet: Stylesheet,
     short_message: bool,
 }
@@ -78,7 +78,7 @@ impl Renderer {
         Self {
             anonymized_line_numbers: false,
             term_width: DEFAULT_TERM_WIDTH,
-            theme: DecorStyle::Ascii,
+            decor_style: DecorStyle::Ascii,
             stylesheet: Stylesheet::plain(),
             short_message: false,
         }
@@ -153,8 +153,8 @@ impl Renderer {
         self
     }
 
-    pub const fn theme(mut self, output_theme: DecorStyle) -> Self {
-        self.theme = output_theme;
+    pub const fn decor_style(mut self, decor_style: DecorStyle) -> Self {
+        self.decor_style = decor_style;
         self
     }
 
@@ -606,7 +606,7 @@ impl Renderer {
                 buffer.append(buffer_msg_line_offset + i, &padding, ElementStyle::NoStyle);
                 if title_style == TitleStyle::Secondary
                     && is_cont
-                    && matches!(self.theme, DecorStyle::Unicode)
+                    && matches!(self.decor_style, DecorStyle::Unicode)
                 {
                     // There's another note after this one, associated to the subwindow above.
                     // We write additional vertical lines to join them:
@@ -765,7 +765,7 @@ impl Renderer {
         } else {
             let buffer_msg_line_offset = buffer.num_lines();
             if is_primary {
-                if self.theme == DecorStyle::Unicode {
+                if self.decor_style == DecorStyle::Unicode {
                     buffer.puts(
                         buffer_msg_line_offset,
                         max_line_num_len,
@@ -2330,7 +2330,7 @@ impl Renderer {
         depth: usize,
         style: ElementStyle,
     ) {
-        let chr = match (style, self.theme) {
+        let chr = match (style, self.decor_style) {
             (ElementStyle::UnderlinePrimary | ElementStyle::LabelPrimary, DecorStyle::Ascii) => '|',
             (_, DecorStyle::Ascii) => '|',
             (ElementStyle::UnderlinePrimary | ElementStyle::LabelPrimary, DecorStyle::Unicode) => {
@@ -2342,14 +2342,14 @@ impl Renderer {
     }
 
     fn col_separator(&self) -> char {
-        match self.theme {
+        match self.decor_style {
             DecorStyle::Ascii => '|',
             DecorStyle::Unicode => '│',
         }
     }
 
     fn multi_suggestion_separator(&self) -> &'static str {
-        match self.theme {
+        match self.decor_style {
             DecorStyle::Ascii => "|",
             DecorStyle::Unicode => "├╴",
         }
@@ -2372,7 +2372,7 @@ impl Renderer {
     }
 
     fn draw_col_separator_start(&self, buffer: &mut StyledBuffer, line: usize, col: usize) {
-        match self.theme {
+        match self.decor_style {
             DecorStyle::Ascii => {
                 self.draw_col_separator_no_space_with_style(
                     buffer,
@@ -2402,7 +2402,7 @@ impl Renderer {
     }
 
     fn draw_col_separator_end(&self, buffer: &mut StyledBuffer, line: usize, col: usize) {
-        match self.theme {
+        match self.decor_style {
             DecorStyle::Ascii => {
                 self.draw_col_separator_no_space_with_style(
                     buffer,
@@ -2454,7 +2454,7 @@ impl Renderer {
     }
 
     fn file_start(&self, is_first: bool) -> &'static str {
-        match self.theme {
+        match self.decor_style {
             DecorStyle::Ascii => "--> ",
             DecorStyle::Unicode if is_first => " ╭▸ ",
             DecorStyle::Unicode => " ├▸ ",
@@ -2462,7 +2462,7 @@ impl Renderer {
     }
 
     fn secondary_file_start(&self) -> &'static str {
-        match self.theme {
+        match self.decor_style {
             DecorStyle::Ascii => "::: ",
             DecorStyle::Unicode => " ⸬  ",
         }
@@ -2475,7 +2475,7 @@ impl Renderer {
         col: usize,
         is_cont: bool,
     ) {
-        let chr = match self.theme {
+        let chr = match self.decor_style {
             DecorStyle::Ascii => "= ",
             DecorStyle::Unicode if is_cont => "├ ",
             DecorStyle::Unicode => "╰ ",
@@ -2484,14 +2484,14 @@ impl Renderer {
     }
 
     fn diff(&self) -> char {
-        match self.theme {
+        match self.decor_style {
             DecorStyle::Ascii => '~',
             DecorStyle::Unicode => '±',
         }
     }
 
     fn draw_line_separator(&self, buffer: &mut StyledBuffer, line: usize, col: usize) {
-        let (column, dots) = match self.theme {
+        let (column, dots) = match self.decor_style {
             DecorStyle::Ascii => (0, "..."),
             DecorStyle::Unicode => (col - 2, "‡"),
         };
@@ -2499,7 +2499,7 @@ impl Renderer {
     }
 
     fn margin(&self) -> &'static str {
-        match self.theme {
+        match self.decor_style {
             DecorStyle::Ascii => "...",
             DecorStyle::Unicode => "…",
         }
@@ -2530,7 +2530,7 @@ impl Renderer {
         //                        ┃  ╿ < multiline_end_up
         //                        ┗━━┛ < bottom_right
 
-        match (self.theme, is_primary) {
+        match (self.decor_style, is_primary) {
             (DecorStyle::Ascii, true) => UnderlineParts {
                 style: ElementStyle::UnderlinePrimary,
                 underline: '^',

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -472,7 +472,7 @@ error: bad
   ╰╴━
 "#]];
 
-    let renderer = renderer.theme(DecorStyle::Unicode);
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(message), expected_unicode);
 }
 
@@ -1747,7 +1747,7 @@ LL │     type Error = E;
 "#]];
     let renderer = Renderer::plain()
         .term_width(40)
-        .theme(DecorStyle::Unicode)
+        .decor_style(DecorStyle::Unicode)
         .anonymized_line_numbers(true);
     assert_data_eq!(renderer.render(input_new), expected);
 }
@@ -1835,7 +1835,7 @@ LL │     type Error = E;
 "#]];
     let renderer = Renderer::plain()
         .term_width(40)
-        .theme(DecorStyle::Unicode)
+        .decor_style(DecorStyle::Unicode)
         .anonymized_line_numbers(true);
     assert_data_eq!(renderer.render(input_new), expected);
 }
@@ -1996,7 +1996,7 @@ LL │  ┃     )))))))))))))))))))))))))))))];
 "#]];
     let renderer = Renderer::plain()
         .term_width(60)
-        .theme(DecorStyle::Unicode)
+        .decor_style(DecorStyle::Unicode)
         .anonymized_line_numbers(true);
     assert_data_eq!(renderer.render(input_new), expected);
 }
@@ -2076,7 +2076,7 @@ LL │ ┃ )>>) {}
    ╰╴┗━━━┛
 "#]];
     let renderer = Renderer::plain()
-        .theme(DecorStyle::Unicode)
+        .decor_style(DecorStyle::Unicode)
         .anonymized_line_numbers(true);
     assert_data_eq!(renderer.render(input_new), expected);
 }
@@ -2122,7 +2122,7 @@ error: title
 5 │ ┃ ]
   ╰╴┗━┛ annotation
 "#]];
-    let renderer_unicode = renderer_ascii.theme(DecorStyle::Unicode);
+    let renderer_unicode = renderer_ascii.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer_unicode.render(input), expected_unicode);
 }
 
@@ -2159,7 +2159,7 @@ error: expected item, found `?`
   │
   ╰ note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 "#]];
-    let renderer_unicode = renderer_ascii.theme(DecorStyle::Unicode);
+    let renderer_unicode = renderer_ascii.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer_unicode.render(input), expected_unicode);
 }
 
@@ -2196,7 +2196,7 @@ error: expected item, found `?`
   │
   ╰ note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 "#]];
-    let renderer_unicode = renderer_ascii.theme(DecorStyle::Unicode);
+    let renderer_unicode = renderer_ascii.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer_unicode.render(input), expected_unicode);
 }
 
@@ -2233,7 +2233,7 @@ error: expected item, found `?`
   │
   ╰ note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 "#]];
-    let renderer_unicode = renderer_ascii.theme(DecorStyle::Unicode);
+    let renderer_unicode = renderer_ascii.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer_unicode.render(input), expected_unicode);
 }
 
@@ -2285,7 +2285,7 @@ LL │ …♥♦♧♨♩♪♫♬♭♮♯♰♱♲♳♴♵♶♷♸♹♺♻�
    │                                                  │
    ╰╴                                                 expected due to this
 "#]];
-    let renderer_unicode = renderer_ascii.theme(DecorStyle::Unicode);
+    let renderer_unicode = renderer_ascii.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer_unicode.render(input), expected_unicode);
 }
 
@@ -2368,7 +2368,7 @@ LL │     let _ = "ༀ༁༂༃༄༅༆༇༈༉༊་༌།༎༏༐༑༒༓
    ╰╴                                                                                                                                                                                        +++++++++++
 "#]];
 
-    let renderer_unicode = renderer_ascii.theme(DecorStyle::Unicode);
+    let renderer_unicode = renderer_ascii.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer_unicode.render(input), expected_unicode);
 }
 
@@ -2432,7 +2432,7 @@ LL │ �|�␂!5�cc␕␂�Ӻi��WWj�ȥ�'�}�␒�J�ȉ��W
    │ ━
    ╰ note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 "#]];
-    let renderer_unicode = renderer_ascii.theme(DecorStyle::Unicode);
+    let renderer_unicode = renderer_ascii.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer_unicode.render(input), expected_unicode);
 }
 
@@ -2634,7 +2634,7 @@ LL -         });
 LL +         break;
    ╰╴
 "#]];
-    let renderer_unicode = renderer_ascii.theme(DecorStyle::Unicode);
+    let renderer_unicode = renderer_ascii.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer_unicode.render(input), expected_unicode);
 }
 
@@ -2841,7 +2841,7 @@ error:
 1 │ def __call__(self, *vals: bytes, maxlen: int | None = None) -> list[bytes]: ...
   ╰╴    ━━━━━━━━ annotation
 "#]];
-    let renderer = Renderer::plain().theme(DecorStyle::Unicode);
+    let renderer = Renderer::plain().decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
 
@@ -2883,7 +2883,7 @@ error:
 1 │ def __call__(self, *vals: bytes, maxlen: int | None = None) -> list[bytes]: ...
   ╰╴    ━━━━━━━━ annotation
 "#]];
-    let renderer = Renderer::plain().theme(DecorStyle::Unicode);
+    let renderer = Renderer::plain().decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
 
@@ -2941,7 +2941,7 @@ LL │         .sum::<_>() //~ ERROR type annotations needed
    │          ━━━ cannot infer type of the type parameter `S` declared on the method `sum`
    ╰╴
 "#]];
-    let renderer = renderer.theme(DecorStyle::Unicode);
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
 
@@ -3018,7 +3018,7 @@ LL -         .sum::<_>() //~ ERROR type annotations needed
 LL +         .sum::<GENERIC_ARG>() //~ ERROR type annotations needed
    ╰╴
 "#]];
-    let renderer = renderer.theme(DecorStyle::Unicode);
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
 
@@ -3220,6 +3220,6 @@ error[E0609]: no field `field` on type `Thing`
 LL │     t.field;
    ╰╴      ━━━━━ unknown field
 "#]];
-    let renderer = renderer.theme(DecorStyle::Unicode);
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }

--- a/tests/rustc_tests.rs
+++ b/tests/rustc_tests.rs
@@ -1895,7 +1895,7 @@ LL │ …u8 = [0, 0, 0…0];
     let renderer = Renderer::plain()
         .anonymized_line_numbers(true)
         .term_width(12)
-        .theme(DecorStyle::Unicode);
+        .decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected);
 }
 
@@ -1929,7 +1929,7 @@ LL │ …u8 = [0, 0, 0, 0, 0, 0, 0, 0, 0, …, 0, 0, 0, 0, 0, 0, 0];
     let renderer = Renderer::plain()
         .anonymized_line_numbers(true)
         .term_width(80)
-        .theme(DecorStyle::Unicode);
+        .decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected);
 }
 
@@ -3006,7 +3006,7 @@ note: the foreign item type `Box<isize>` doesn't implement `Add`
    │
    ╰ note: not implement `Add`
 "#]];
-    let renderer = renderer.theme(DecorStyle::Unicode);
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
 
@@ -3146,7 +3146,7 @@ help: trait `Future` which provides `poll` is implemented but not in scope; perh
 LL + use std::future::Future;
    ╰╴
 "#]];
-    let renderer = renderer.theme(DecorStyle::Unicode);
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
 
@@ -3246,7 +3246,7 @@ note: the foreign item types don't implement required traits for this operation 
    │
    ╰ note: not implement `PartialEq`
 "#]];
-    let renderer = renderer.theme(DecorStyle::Unicode);
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
 
@@ -3319,7 +3319,7 @@ LL │ #[derive(Eqr)]
    │
    ╰ note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 "#]];
-    let renderer = renderer.theme(DecorStyle::Unicode);
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
 
@@ -3426,7 +3426,7 @@ note: the traits `Iterator` and `ToTokens` must be implemented
    ╭▸ $SRC_DIR/proc_macro/src/to_tokens.rs:11:0
    ╭▸ $SRC_DIR/core/src/iter/traits/iterator.rs:39:0
 "#]];
-    let renderer = renderer.theme(DecorStyle::Unicode);
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
 
@@ -3835,7 +3835,7 @@ LL +         Some(Private { misc: true, .. }) => todo!()
 "#]];
     let renderer = Renderer::plain()
         .anonymized_line_numbers(true)
-        .theme(DecorStyle::Unicode);
+        .decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected);
 }
 
@@ -3926,7 +3926,7 @@ LL │ fn ord_prefer_dot(s: String) -> impl Ord {
 "#]];
     let renderer = Renderer::plain()
         .anonymized_line_numbers(true)
-        .theme(DecorStyle::Unicode);
+        .decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected);
 }
 
@@ -4012,7 +4012,7 @@ note: the foreign item types don't implement required traits for this operation 
 "#]];
     let renderer = Renderer::plain()
         .anonymized_line_numbers(true)
-        .theme(DecorStyle::Unicode);
+        .decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected);
 }
 
@@ -4143,7 +4143,7 @@ LL + use std::collections::btree_set::IntoIter;
    │
    ╰ and 9 other candidates
 "#]];
-    let renderer = renderer.theme(DecorStyle::Unicode);
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
 
@@ -4283,7 +4283,7 @@ help: consider using the `Default` trait
 LL │     let _ = <std::collections::HashMap as std::default::Default>::default();
    ╰╴            +                          ++++++++++++++++++++++++++++++++++
 "#]];
-    let renderer = renderer.theme(DecorStyle::Unicode);
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
 
@@ -4467,7 +4467,7 @@ LL -         wtf: Some(Box(U {
 LL +         wtf: Some(<Box as std::default::Default>::default()),
    ╰╴
 "#]];
-    let renderer = renderer.theme(DecorStyle::Unicode);
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
 
@@ -4601,7 +4601,7 @@ LL │     t.a3.bar();
    │       +++
    ╰ and 6 other candidates
 "#]];
-    let renderer = renderer.theme(DecorStyle::Unicode);
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
 


### PR DESCRIPTION
In #276, I renamed `OutputTheme` to `DecorStyle` but forgot to rename the `theme` field and function on `Renderer`. This PR addresses that oversight.