### PR TITLE
fix: Always style primary_title

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -219,10 +219,10 @@ impl Renderer {
                 let mut message_iter = group.elements.iter().enumerate().peekable();
                 if let Some(title) = &group.title {
                     let peek = message_iter.peek().map(|(_, s)| s).copied();
-                    let title_style = if g == 0 {
-                        TitleStyle::MainHeader
-                    } else {
+                    let title_style = if title.allows_styling {
                         TitleStyle::Header
+                    } else {
+                        TitleStyle::MainHeader
                     };
                     let buffer_msg_line_offset = buffer.num_lines();
                     self.render_title(

--- a/tests/color/main.rs
+++ b/tests/color/main.rs
@@ -12,6 +12,7 @@ mod fold_trailing;
 mod issue_9;
 mod multiline_removal_suggestion;
 mod multiple_annotations;
+mod primary_title_second_group;
 mod simple;
 mod strip_line;
 mod strip_line_char;

--- a/tests/color/primary_title_second_group.rs
+++ b/tests/color/primary_title_second_group.rs
@@ -1,0 +1,25 @@
+use annotate_snippets::{AnnotationKind, Group, Level, Renderer, Snippet};
+
+use snapbox::{assert_data_eq, file};
+
+#[test]
+fn case() {
+    let report =
+        &[
+            Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308")).element(
+                Snippet::source("        slices: vec![\"A\",")
+                    .line_start(13)
+                    .path("src/multislice.rs")
+                    .annotation(AnnotationKind::Primary.span(21..24).label(
+                        "expected struct `annotate_snippets::snippet::Slice`, found reference",
+                    )),
+            ),
+            Group::with_title(Level::NOTE.primary_title(
+                "expected type: `snippet::Annotation`\n   found type: `__&__snippet::Annotation`",
+            )),
+        ];
+
+    let expected = file!["primary_title_second_group.term.svg"];
+    let renderer = Renderer::styled();
+    assert_data_eq!(renderer.render(report), expected);
+}

--- a/tests/color/primary_title_second_group.term.svg
+++ b/tests/color/primary_title_second_group.term.svg
@@ -1,0 +1,41 @@
+<svg width="844px" height="164px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error[E0308]</tspan><tspan class="bold">: mismatched types</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-bright-blue bold">--&gt; </tspan><tspan>src/multislice.rs:13:22</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">13</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>         slices: vec!["A",</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>                      </tspan><tspan class="fg-bright-red bold">^^^</tspan><tspan> </tspan><tspan class="fg-bright-red bold">expected struct `annotate_snippets::snippet::Slice`, found reference</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">note</tspan><tspan>: expected type: `snippet::Annotation`</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>         found type: `__&amp;__snippet::Annotation`</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/primary_title_second_group.term.svg
+++ b/tests/color/primary_title_second_group.term.svg
@@ -32,9 +32,9 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">note</tspan><tspan>: expected type: `snippet::Annotation`</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">: expected type: `snippet::Annotation`</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>         found type: `__&amp;__snippet::Annotation`</tspan>
+    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="bold">   found type: `__&amp;__snippet::Annotation`</tspan>
 </tspan>
   </text>
 


### PR DESCRIPTION
Looking back at my PR switching to `secondary_title` (#282), I realized that none of the SVGs changed, which seemed odd to me as `primary_title` should be bolded every time. After looking into it a bit, I realized that `annotate-snippets` [would only use bold text for titles that are in the first group](https://github.com/rust-lang/annotate-snippets-rs/blob/b9dc9e5b6f713aaef36e5c915990e63e52ecb4bb/src/renderer/mod.rs#L222-L226) regardless of whether they were `primary` or `secondary`. This is a bug as `annotate-snippets` should respect `primary_title` and always bold its text, no matter the position of the `Group` it is in.