### PR TITLE
Remove accidental, undocumented `memchr` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ harness = false
 
 [features]
 default = []
-simd = ["memchr"]
+simd = ["dep:memchr"]
 testing-colors = []
 
 [lints]


### PR DESCRIPTION
The "memchr" feature does nothing on its own.