### PR TITLE
feat: Allow passing zero to line_start

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -985,10 +985,6 @@ impl Renderer {
         //   |  vertical divider between the column number and the code
         //   column number
 
-        if line_info.line_index == 0 {
-            return Vec::new();
-        }
-
         let source_string = normalize_whitespace(line_info.line);
 
         let line_offset = buffer.num_lines();

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -4310,6 +4310,8 @@ fn alignment() {
 error: ensure single line at line 0 rendered correctly with group line lined up
  --> Cargo.toml:0:8
   |
+0 | SELECT bar
+  |        ^^^ unexpected token
 "#]];
     let renderer = Renderer::plain();
     assert_data_eq!(renderer.render(input), expected_ascii);
@@ -4318,6 +4320,8 @@ error: ensure single line at line 0 rendered correctly with group line lined up
 error: ensure single line at line 0 rendered correctly with group line lined up
   ╭▸ Cargo.toml:0:8
   │
+0 │ SELECT bar
+  ╰╴       ━━━ unexpected token
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -4281,3 +4281,44 @@ warning: whatever
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(report), expected_unicode);
 }
+
+#[test]
+fn alignment() {
+    let source = "SELECT bar";
+
+    let title = "ensure single line at line 0 rendered correctly with group line lined up";
+
+    let input = &[
+        Group::with_title(Level::ERROR.primary_title(title)).element(
+            Snippet::source(source)
+                .path("Cargo.toml")
+                .line_start(0)
+                .annotation(
+                    AnnotationKind::Primary
+                        .span(7..10)
+                        .label("unexpected token"),
+                )
+                .annotation(
+                    AnnotationKind::Visible
+                        .span(0..10)
+                        .label("while parsing statement"),
+                ),
+        ),
+    ];
+
+    let expected_ascii = str![[r#"
+error: ensure single line at line 0 rendered correctly with group line lined up
+ --> Cargo.toml:0:8
+  |
+"#]];
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    let expected_unicode = str![[r#"
+error: ensure single line at line 0 rendered correctly with group line lined up
+  ╭▸ Cargo.toml:0:8
+  │
+"#]];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+}


### PR DESCRIPTION
This PR allows a user to pass `0` to `line_start`, which in turn makes all lines zero-based.

fixes #57