### PR TITLE
feat: Add convenience methods for Group::with_title

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet};
 
 #[divan::bench]
 fn simple() -> String {
@@ -24,8 +24,10 @@ fn simple() -> String {
             _ => continue,
         }
     }"#;
-    let message = &[
-        Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308")).element(
+    let message = &[Level::ERROR
+        .primary_title("mismatched types")
+        .id("E0308")
+        .element(
             Snippet::source(source)
                 .line_start(51)
                 .path("src/format.rs")
@@ -39,8 +41,7 @@ fn simple() -> String {
                         .span(26..724)
                         .label("expected enum `std::option::Option`"),
                 ),
-        ),
-    ];
+        )];
 
     let renderer = Renderer::plain();
     let rendered = renderer.render(message);
@@ -69,17 +70,16 @@ fn fold(bencher: divan::Bencher<'_, '_>, context: usize) {
             (input, span)
         })
         .bench_values(|(input, span)| {
-            let message =
-                &[
-                    Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308"))
-                        .element(
-                            Snippet::source(&input).path("src/format.rs").annotation(
-                                AnnotationKind::Context
-                                    .span(span)
-                                    .label("expected `Option<String>` because of return type"),
-                            ),
-                        ),
-                ];
+            let message = &[Level::ERROR
+                .primary_title("mismatched types")
+                .id("E0308")
+                .element(
+                    Snippet::source(&input).path("src/format.rs").annotation(
+                        AnnotationKind::Context
+                            .span(span)
+                            .label("expected `Option<String>` because of return type"),
+                    ),
+                )];
 
             let renderer = Renderer::plain();
             let rendered = renderer.render(message);

--- a/examples/custom_error.rs
+++ b/examples/custom_error.rs
@@ -1,5 +1,5 @@
 use annotate_snippets::renderer::DecorStyle;
-use annotate_snippets::{AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet};
 
 fn main() {
     let source = r#"//@ compile-flags: -Ztreat-err-as-bug
@@ -15,19 +15,17 @@ fn main() {
 pub static C: u32 = 0 - 1;
 //~^ ERROR could not evaluate static initializer
 "#;
-    let report = &[Group::with_title(
-        Level::ERROR
-            .with_name(Some("error: internal compiler error"))
-            .primary_title("could not evaluate static initializer")
-            .id("E0080"),
-    )
-    .element(
-        Snippet::source(source).path("$DIR/err.rs").annotation(
-            AnnotationKind::Primary
-                .span(386..391)
-                .label("attempt to compute `0_u32 - 1_u32`, which would overflow"),
-        ),
-    )];
+    let report = &[Level::ERROR
+        .with_name(Some("error: internal compiler error"))
+        .primary_title("could not evaluate static initializer")
+        .id("E0080")
+        .element(
+            Snippet::source(source).path("$DIR/err.rs").annotation(
+                AnnotationKind::Primary
+                    .span(386..391)
+                    .label("attempt to compute `0_u32 - 1_u32`, which would overflow"),
+            ),
+        )];
 
     let renderer = Renderer::styled().decor_style(DecorStyle::Unicode);
     anstream::println!("{}", renderer.render(report));

--- a/examples/custom_level.rs
+++ b/examples/custom_level.rs
@@ -1,5 +1,5 @@
 use annotate_snippets::renderer::DecorStyle;
-use annotate_snippets::{AnnotationKind, Group, Level, Patch, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Patch, Renderer, Snippet};
 
 fn main() {
     let source = r#"// Regression test for issue #114529
@@ -29,13 +29,10 @@ fn main() {
     }
 }
 "#;
-    let report =
-        &[
-            Group::with_title(
-                Level::ERROR
-                    .primary_title("`break` with value from a `while` loop")
-                    .id("E0571"),
-            )
+    let report = &[
+        Level::ERROR
+            .primary_title("`break` with value from a `while` loop")
+            .id("E0571")
             .element(
                 Snippet::source(source)
                     .line_start(1)
@@ -51,16 +48,16 @@ fn main() {
                             .label("you can't `break` with a value in a `while` loop"),
                     ),
             ),
-            Group::with_title(Level::HELP.with_name(Some("suggestion")).secondary_title(
-                "use `break` on its own without a value inside this `while` loop",
-            ))
+        Level::HELP
+            .with_name(Some("suggestion"))
+            .secondary_title("use `break` on its own without a value inside this `while` loop")
             .element(
                 Snippet::source(source)
                     .line_start(1)
                     .path("$DIR/issue-114529-illegal-break-with-value.rs")
                     .patch(Patch::new(483..581, "break")),
             ),
-        ];
+    ];
 
     let renderer = Renderer::styled().decor_style(DecorStyle::Unicode);
     anstream::println!("{}", renderer.render(report));

--- a/examples/expected_type.rs
+++ b/examples/expected_type.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 
 fn main() {
     let source = r#"                annotations: vec![SourceAnnotation {
@@ -6,8 +6,9 @@ fn main() {
                     ,
                 range: <22, 25>,"#;
     let report =
-        &[
-            Group::with_title(Level::ERROR.primary_title("expected type, found `22`")).element(
+        &[Level::ERROR
+            .primary_title("expected type, found `22`")
+            .element(
                 Snippet::source(source)
                     .line_start(26)
                     .path("examples/footer.rs")
@@ -19,8 +20,7 @@ fn main() {
                             .span(34..50)
                             .label("while parsing this struct"),
                     ),
-            ),
-        ];
+            )];
 
     let renderer = Renderer::styled().decor_style(DecorStyle::Unicode);
     anstream::println!("{}", renderer.render(report));

--- a/examples/footer.rs
+++ b/examples/footer.rs
@@ -1,9 +1,11 @@
 use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
 
 fn main() {
-    let report =
-        &[
-            Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308")).element(
+    let report = &[
+        Level::ERROR
+            .primary_title("mismatched types")
+            .id("E0308")
+            .element(
                 Snippet::source("        slices: vec![\"A\",")
                     .line_start(13)
                     .path("src/multislice.rs")
@@ -11,10 +13,10 @@ fn main() {
                         "expected struct `annotate_snippets::snippet::Slice`, found reference",
                     )),
             ),
-            Group::with_title(Level::NOTE.secondary_title(
-                "expected type: `snippet::Annotation`\n   found type: `__&__snippet::Annotation`",
-            )),
-        ];
+        Group::with_title(Level::NOTE.secondary_title(
+            "expected type: `snippet::Annotation`\n   found type: `__&__snippet::Annotation`",
+        )),
+    ];
 
     let renderer = Renderer::styled().decor_style(DecorStyle::Unicode);
     anstream::println!("{}", renderer.render(report));

--- a/examples/format.rs
+++ b/examples/format.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 
 fn main() {
     let source = r#") -> Option<String> {
@@ -23,8 +23,10 @@ fn main() {
             _ => continue,
         }
     }"#;
-    let report = &[
-        Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308")).element(
+    let report = &[Level::ERROR
+        .primary_title("mismatched types")
+        .id("E0308")
+        .element(
             Snippet::source(source)
                 .line_start(51)
                 .path("src/format.rs")
@@ -39,8 +41,7 @@ fn main() {
                         .span(26..724)
                         .label("expected enum `std::option::Option`"),
                 ),
-        ),
-    ];
+        )];
 
     let renderer = Renderer::styled().decor_style(DecorStyle::Unicode);
     anstream::println!("{}", renderer.render(report));

--- a/examples/highlight_message.rs
+++ b/examples/highlight_message.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 use anstyle::AnsiColor;
 use anstyle::Effects;
 use anstyle::Style;
@@ -34,7 +34,9 @@ fn main() {
     );
 
     let report = &[
-        Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308"))
+        Level::ERROR
+            .primary_title("mismatched types")
+            .id("E0308")
             .element(
                 Snippet::source(source)
                     .path("$DIR/highlighting.rs")
@@ -50,12 +52,14 @@ fn main() {
                     ),
             )
             .element(Level::NOTE.message(&message)),
-        Group::with_title(Level::NOTE.secondary_title("function defined here")).element(
-            Snippet::source(source)
-                .path("$DIR/highlighting.rs")
-                .annotation(AnnotationKind::Context.span(200..333).label(""))
-                .annotation(AnnotationKind::Primary.span(194..199)),
-        ),
+        Level::NOTE
+            .secondary_title("function defined here")
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/highlighting.rs")
+                    .annotation(AnnotationKind::Context.span(200..333).label(""))
+                    .annotation(AnnotationKind::Primary.span(194..199)),
+            ),
     ];
 
     let renderer = Renderer::styled()

--- a/examples/highlight_source.rs
+++ b/examples/highlight_source.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 
 fn main() {
     let source = r#"//@ compile-flags: -Z teach
@@ -9,8 +9,8 @@ const CON: Vec<i32> = vec![1, 2, 3]; //~ ERROR E0010
 //~| ERROR cannot call non-const method
 fn main() {}
 "#;
-    let report = &[Group::with_title(Level::ERROR.primary_title("allocations are not allowed in constants")
-        .id("E0010"))
+    let report = &[Level::ERROR.primary_title("allocations are not allowed in constants")
+        .id("E0010")
         .element(
             Snippet::source(source)
                 .path("$DIR/E0010-teach.rs")

--- a/examples/id_hyperlink.rs
+++ b/examples/id_hyperlink.rs
@@ -1,5 +1,5 @@
 use annotate_snippets::renderer::DecorStyle;
-use annotate_snippets::{AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet};
 
 fn main() {
     let source = r#"//@ compile-flags: -Zterminal-urls=yes
@@ -7,27 +7,25 @@ fn main() {
     let () = 4; //~ ERROR
 }
 "#;
-    let report = &[Group::with_title(
-        Level::ERROR
-            .primary_title("mismatched types")
-            .id("E0308")
-            .id_url("https://doc.rust-lang.org/error_codes/E0308.html"),
-    )
-    .element(
-        Snippet::source(source)
-            .line_start(1)
-            .path("$DIR/terminal_urls.rs")
-            .annotation(
-                AnnotationKind::Primary
-                    .span(59..61)
-                    .label("expected integer, found `()`"),
-            )
-            .annotation(
-                AnnotationKind::Context
-                    .span(64..65)
-                    .label("this expression has type `{integer}`"),
-            ),
-    )];
+    let report = &[Level::ERROR
+        .primary_title("mismatched types")
+        .id("E0308")
+        .id_url("https://doc.rust-lang.org/error_codes/E0308.html")
+        .element(
+            Snippet::source(source)
+                .line_start(1)
+                .path("$DIR/terminal_urls.rs")
+                .annotation(
+                    AnnotationKind::Primary
+                        .span(59..61)
+                        .label("expected integer, found `()`"),
+                )
+                .annotation(
+                    AnnotationKind::Context
+                        .span(64..65)
+                        .label("this expression has type `{integer}`"),
+                ),
+        )];
 
     let renderer = Renderer::styled().decor_style(DecorStyle::Unicode);
     anstream::println!("{}", renderer.render(report));

--- a/examples/multi_suggestion.rs
+++ b/examples/multi_suggestion.rs
@@ -1,6 +1,4 @@
-use annotate_snippets::{
-    renderer::DecorStyle, AnnotationKind, Group, Level, Patch, Renderer, Snippet,
-};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Patch, Renderer, Snippet};
 
 fn main() {
     let source = r#"
@@ -24,40 +22,43 @@ fn main() {
 "#;
 
     let report = &[
-        Group::with_title(Level::ERROR.primary_title(
-            "cannot construct `Box<_, _>` with struct literal syntax due to private fields",
-        ))
-        .element(
-            Snippet::source(source)
-                .path("$DIR/multi-suggestion.rs")
-                .annotation(AnnotationKind::Primary.span(295..298)),
-        )
-        .element(Level::NOTE.message("private fields `0` and `1` that were not provided")),
-        Group::with_title(Level::HELP.secondary_title(
-            "you might have meant to use an associated function to build this type",
-        ))
-        .element(
-            Snippet::source(source)
-                .path("$DIR/multi-suggestion.rs")
-                .patch(Patch::new(298..301, "::new(_)")),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/multi-suggestion.rs")
-                .patch(Patch::new(298..301, "::new_uninit()")),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/multi-suggestion.rs")
-                .patch(Patch::new(298..301, "::new_zeroed()")),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/multi-suggestion.rs")
-                .patch(Patch::new(298..301, "::new_in(_, _)")),
-        )
-        .element(Level::NOTE.no_name().message("and 12 other candidates")),
-        Group::with_title(Level::HELP.secondary_title("consider using the `Default` trait"))
+        Level::ERROR
+            .primary_title(
+                "cannot construct `Box<_, _>` with struct literal syntax due to private fields",
+            )
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/multi-suggestion.rs")
+                    .annotation(AnnotationKind::Primary.span(295..298)),
+            )
+            .element(Level::NOTE.message("private fields `0` and `1` that were not provided")),
+        Level::HELP
+            .secondary_title(
+                "you might have meant to use an associated function to build this type",
+            )
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/multi-suggestion.rs")
+                    .patch(Patch::new(298..301, "::new(_)")),
+            )
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/multi-suggestion.rs")
+                    .patch(Patch::new(298..301, "::new_uninit()")),
+            )
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/multi-suggestion.rs")
+                    .patch(Patch::new(298..301, "::new_zeroed()")),
+            )
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/multi-suggestion.rs")
+                    .patch(Patch::new(298..301, "::new_in(_, _)")),
+            )
+            .element(Level::NOTE.no_name().message("and 12 other candidates")),
+        Level::HELP
+            .secondary_title("consider using the `Default` trait")
             .element(
                 Snippet::source(source)
                     .path("$DIR/multi-suggestion.rs")

--- a/examples/multislice.rs
+++ b/examples/multislice.rs
@@ -1,21 +1,20 @@
-use annotate_snippets::{renderer::DecorStyle, Annotation, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, Annotation, Level, Renderer, Snippet};
 
 fn main() {
-    let report = &[
-        Group::with_title(Level::ERROR.primary_title("mismatched types"))
-            .element(
-                Snippet::<Annotation<'_>>::source("Foo")
-                    .line_start(51)
-                    .fold(false)
-                    .path("src/format.rs"),
-            )
-            .element(
-                Snippet::<Annotation<'_>>::source("Faa")
-                    .line_start(129)
-                    .fold(false)
-                    .path("src/display.rs"),
-            ),
-    ];
+    let report = &[Level::ERROR
+        .primary_title("mismatched types")
+        .element(
+            Snippet::<Annotation<'_>>::source("Foo")
+                .line_start(51)
+                .fold(false)
+                .path("src/format.rs"),
+        )
+        .element(
+            Snippet::<Annotation<'_>>::source("Faa")
+                .line_start(129)
+                .fold(false)
+                .path("src/display.rs"),
+        )];
 
     let renderer = Renderer::styled().decor_style(DecorStyle::Unicode);
     anstream::println!("{}", renderer.render(report));

--- a/examples/struct_name_as_context.rs
+++ b/examples/struct_name_as_context.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 fn main() {
     let source = r#"struct S {
     field1: usize,
@@ -9,18 +9,18 @@ fn main() {
     field6: usize,
 }
 "#;
-    let report = &[Group::with_title(
-        Level::ERROR.primary_title("functions are not allowed in struct definitions"),
-    )
-    .element(
-        Snippet::source(source)
-            .path("$DIR/struct_name_as_context.rs")
-            .annotation(AnnotationKind::Primary.span(91..102))
-            .annotation(AnnotationKind::Visible.span(0..8)),
-    )
-    .element(
-        Level::HELP.message("unlike in C++, Java, and C#, functions are declared in `impl` blocks"),
-    )];
+    let report = &[Level::ERROR
+        .primary_title("functions are not allowed in struct definitions")
+        .element(
+            Snippet::source(source)
+                .path("$DIR/struct_name_as_context.rs")
+                .annotation(AnnotationKind::Primary.span(91..102))
+                .annotation(AnnotationKind::Visible.span(0..8)),
+        )
+        .element(
+            Level::HELP
+                .message("unlike in C++, Java, and C#, functions are declared in `impl` blocks"),
+        )];
 
     let renderer = Renderer::styled().decor_style(DecorStyle::Unicode);
     anstream::println!("{}", renderer.render(report));

--- a/src/level.rs
+++ b/src/level.rs
@@ -43,12 +43,8 @@ pub const HELP: Level<'_> = Level {
 /// ```rust
 /// # use annotate_snippets::*;
 /// let report = &[
-///     Group::with_title(
-///         Level::ERROR.primary_title("mismatched types").id("E0308")
-///     )
-///         .element(
-///             Level::NOTE.message("expected reference"),
-///         ),
+///     Level::ERROR.primary_title("mismatched types").id("E0308")
+///         .element(Level::NOTE.message("expected reference")),
 ///     Group::with_title(
 ///         Level::HELP.secondary_title("function defined here")
 ///     ),
@@ -186,7 +182,7 @@ impl<'a> Level<'a> {
     ///     let s: &str = include_bytes!("file.txt");   //~ ERROR mismatched types
     /// }"#;
     /// let report = &[
-    ///     Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308"))
+    ///     Level::ERROR.primary_title("mismatched types").id("E0308")
     ///         .element(
     ///             Snippet::source(source)
     ///                 .path("$DIR/mismatched-types.rs")

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -496,7 +496,7 @@ impl<'a> Patch<'a> {
 /// ```rust
 /// # use annotate_snippets::{Group, Snippet, AnnotationKind, Level, Origin};
 /// let report = &[
-///     Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308"))
+///     Level::ERROR.primary_title("mismatched types").id("E0308")
 ///         .element(
 ///             Origin::path("$DIR/mismatched-types.rs")
 ///         )

--- a/tests/color/ann_eof.rs
+++ b/tests/color/ann_eof.rs
@@ -1,17 +1,15 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 
 use snapbox::{assert_data_eq, file};
 
 #[test]
 fn case() {
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("expected `.`, `=`")).element(
-            Snippet::source("asdf")
-                .path("Cargo.toml")
-                .line_start(1)
-                .annotation(AnnotationKind::Primary.span(4..4).label("")),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("expected `.`, `=`").element(
+        Snippet::source("asdf")
+            .path("Cargo.toml")
+            .line_start(1)
+            .annotation(AnnotationKind::Primary.span(4..4).label("")),
+    )];
 
     let expected_ascii = file!["ann_eof.ascii.term.svg": TermSvg];
     let renderer = Renderer::styled();

--- a/tests/color/ann_insertion.rs
+++ b/tests/color/ann_insertion.rs
@@ -1,17 +1,15 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 
 use snapbox::{assert_data_eq, file};
 
 #[test]
 fn case() {
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("expected `.`, `=`")).element(
-            Snippet::source("asf")
-                .path("Cargo.toml")
-                .line_start(1)
-                .annotation(AnnotationKind::Primary.span(2..2).label("'d' belongs here")),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("expected `.`, `=`").element(
+        Snippet::source("asf")
+            .path("Cargo.toml")
+            .line_start(1)
+            .annotation(AnnotationKind::Primary.span(2..2).label("'d' belongs here")),
+    )];
 
     let expected_ascii = file!["ann_insertion.ascii.term.svg": TermSvg];
     let renderer = Renderer::styled();

--- a/tests/color/ann_multiline.rs
+++ b/tests/color/ann_multiline.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 
 use snapbox::{assert_data_eq, file};
 
@@ -9,22 +9,20 @@ fn case() {
                         } = body[body_idx]
 "#;
 
-    let input = &[Group::with_title(
-        Level::ERROR
-            .primary_title("pattern does not mention fields `lineno`, `content`")
-            .id("E0027"),
-    )
-    .element(
-        Snippet::source(source)
-            .path("src/display_list.rs")
-            .line_start(139)
-            .fold(false)
-            .annotation(
-                AnnotationKind::Primary
-                    .span(31..128)
-                    .label("missing fields `lineno`, `content`"),
-            ),
-    )];
+    let input = &[Level::ERROR
+        .primary_title("pattern does not mention fields `lineno`, `content`")
+        .id("E0027")
+        .element(
+            Snippet::source(source)
+                .path("src/display_list.rs")
+                .line_start(139)
+                .fold(false)
+                .annotation(
+                    AnnotationKind::Primary
+                        .span(31..128)
+                        .label("missing fields `lineno`, `content`"),
+                ),
+        )];
 
     let expected_ascii = file!["ann_multiline.ascii.term.svg": TermSvg];
     let renderer = Renderer::styled();

--- a/tests/color/ann_multiline2.rs
+++ b/tests/color/ann_multiline2.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 
 use snapbox::{assert_data_eq, file};
 
@@ -9,22 +9,20 @@ of an edge case of an annotation overflowing
 to exactly one character on next line.
 "#;
 
-    let input = &[Group::with_title(
-        Level::ERROR
-            .primary_title("spacing error found")
-            .id("E####"),
-    )
-    .element(
-        Snippet::source(source)
-            .path("foo.txt")
-            .line_start(26)
-            .fold(false)
-            .annotation(
-                AnnotationKind::Primary
-                    .span(11..19)
-                    .label("this should not be on separate lines"),
-            ),
-    )];
+    let input = &[Level::ERROR
+        .primary_title("spacing error found")
+        .id("E####")
+        .element(
+            Snippet::source(source)
+                .path("foo.txt")
+                .line_start(26)
+                .fold(false)
+                .annotation(
+                    AnnotationKind::Primary
+                        .span(11..19)
+                        .label("this should not be on separate lines"),
+                ),
+        )];
 
     let expected_ascii = file!["ann_multiline2.ascii.term.svg": TermSvg];
     let renderer = Renderer::styled();

--- a/tests/color/ann_removed_nl.rs
+++ b/tests/color/ann_removed_nl.rs
@@ -1,17 +1,15 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 
 use snapbox::{assert_data_eq, file};
 
 #[test]
 fn case() {
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("expected `.`, `=`")).element(
-            Snippet::source("asdf")
-                .path("Cargo.toml")
-                .line_start(1)
-                .annotation(AnnotationKind::Primary.span(4..5).label("")),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("expected `.`, `=`").element(
+        Snippet::source("asdf")
+            .path("Cargo.toml")
+            .line_start(1)
+            .annotation(AnnotationKind::Primary.span(4..5).label("")),
+    )];
 
     let expected_ascii = file!["ann_removed_nl.ascii.term.svg": TermSvg];
     let renderer = Renderer::styled();

--- a/tests/color/ensure_emoji_highlight_width.rs
+++ b/tests/color/ensure_emoji_highlight_width.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 
 use snapbox::{assert_data_eq, file};
 
@@ -7,7 +7,7 @@ fn case() {
     let source = r#""haha this isn't a valid name 🐛" = { package = "libc", version = "0.1" }
 "#;
 
-    let input = &[Group::with_title(Level::ERROR.primary_title("invalid character ` ` in package name: `haha this isn't a valid name 🐛`, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)"))
+    let input = &[Level::ERROR.primary_title("invalid character ` ` in package name: `haha this isn't a valid name 🐛`, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)")
         .element(
             Snippet::source(source)
                 .path("<file>")

--- a/tests/color/first_snippet_is_primary.rs
+++ b/tests/color/first_snippet_is_primary.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 
 use snapbox::{assert_data_eq, file};
 
@@ -11,37 +11,36 @@ fn case() {
     let s: &str = include_bytes!("file.txt");
 }"#;
 
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308"))
-            .element(
-                Snippet::source(file_txt_source)
-                    .line_start(3)
-                    .path("$DIR/file.txt")
-                    .annotation(
-                        AnnotationKind::Context
-                            .span(0..23)
-                            .label("the macro expands to this string"),
-                    ),
-            )
-            .element(
-                Snippet::source(rust_source)
-                    .path("$DIR/mismatched-types.rs")
-                    .annotation(
-                        AnnotationKind::Context
-                            .span(23..28)
-                            .label("expected due to this"),
-                    )
-                    .annotation(
-                        AnnotationKind::Primary
-                            .span(31..55)
-                            .label("expected `&[u8]`, found `&str`"),
-                    ),
-            )
-            .element(
-                Level::NOTE
-                    .message("expected reference `&[u8]`\n   found reference `&'static str`"),
-            ),
-    ];
+    let input = &[Level::ERROR
+        .primary_title("mismatched types")
+        .id("E0308")
+        .element(
+            Snippet::source(file_txt_source)
+                .line_start(3)
+                .path("$DIR/file.txt")
+                .annotation(
+                    AnnotationKind::Context
+                        .span(0..23)
+                        .label("the macro expands to this string"),
+                ),
+        )
+        .element(
+            Snippet::source(rust_source)
+                .path("$DIR/mismatched-types.rs")
+                .annotation(
+                    AnnotationKind::Context
+                        .span(23..28)
+                        .label("expected due to this"),
+                )
+                .annotation(
+                    AnnotationKind::Primary
+                        .span(31..55)
+                        .label("expected `&[u8]`, found `&str`"),
+                ),
+        )
+        .element(
+            Level::NOTE.message("expected reference `&[u8]`\n   found reference `&'static str`"),
+        )];
 
     let expected_ascii = file!["first_snippet_is_primary.ascii.term.svg": TermSvg];
     let renderer = Renderer::styled();

--- a/tests/color/fold_ann_multiline.rs
+++ b/tests/color/fold_ann_multiline.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 
 use snapbox::{assert_data_eq, file};
 
@@ -28,8 +28,10 @@ fn case() {
     }
 "#;
 
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308")).element(
+    let input = &[Level::ERROR
+        .primary_title("mismatched types")
+        .id("E0308")
+        .element(
             Snippet::source(source)
                 .path("src/format.rs")
                 .line_start(51)
@@ -41,8 +43,7 @@ fn case() {
                         .span(22..766)
                         .label("expected enum `std::option::Option`, found ()"),
                 ),
-        ),
-    ];
+        )];
 
     let expected_ascii = file!["fold_ann_multiline.ascii.term.svg": TermSvg];
     let renderer = Renderer::styled();

--- a/tests/color/fold_bad_origin_line.rs
+++ b/tests/color/fold_bad_origin_line.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 
 use snapbox::{assert_data_eq, file};
 
@@ -9,7 +9,7 @@ fn case() {
 invalid syntax
 "#;
 
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source)
             .path("path/to/error.rs")
             .line_start(1)

--- a/tests/color/fold_leading.rs
+++ b/tests/color/fold_leading.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 
 use snapbox::{assert_data_eq, file};
 
@@ -17,17 +17,15 @@ edition = "2021"
 workspace = 20
 "#;
 
-    let input = &[Group::with_title(
-        Level::ERROR
-            .primary_title("invalid type: integer `20`, expected a bool")
-            .id("E0308"),
-    )
-    .element(
-        Snippet::source(source)
-            .path("Cargo.toml")
-            .line_start(1)
-            .annotation(AnnotationKind::Primary.span(132..134).label("")),
-    )];
+    let input = &[Level::ERROR
+        .primary_title("invalid type: integer `20`, expected a bool")
+        .id("E0308")
+        .element(
+            Snippet::source(source)
+                .path("Cargo.toml")
+                .line_start(1)
+                .annotation(AnnotationKind::Primary.span(132..134).label("")),
+        )];
 
     let expected_ascii = file!["fold_leading.ascii.term.svg": TermSvg];
     let renderer = Renderer::styled();

--- a/tests/color/fold_trailing.rs
+++ b/tests/color/fold_trailing.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 
 use snapbox::{assert_data_eq, file};
 
@@ -16,17 +16,15 @@ rust-version = "1.70"
 edition = "2021"
 "#;
 
-    let input = &[Group::with_title(
-        Level::ERROR
-            .primary_title("invalid type: integer `20`, expected a lints table")
-            .id("E0308"),
-    )
-    .element(
-        Snippet::source(source)
-            .path("Cargo.toml")
-            .line_start(1)
-            .annotation(AnnotationKind::Primary.span(8..10).label("")),
-    )];
+    let input = &[Level::ERROR
+        .primary_title("invalid type: integer `20`, expected a lints table")
+        .id("E0308")
+        .element(
+            Snippet::source(source)
+                .path("Cargo.toml")
+                .line_start(1)
+                .annotation(AnnotationKind::Primary.span(8..10).label("")),
+        )];
 
     let expected_ascii = file!["fold_trailing.ascii.term.svg": TermSvg];
     let renderer = Renderer::styled();

--- a/tests/color/issue_9.rs
+++ b/tests/color/issue_9.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 
 use snapbox::{assert_data_eq, file};
 
@@ -12,7 +12,7 @@ let y = x;
 x;
 "#;
 
-    let input = &[Group::with_title(Level::ERROR.primary_title("expected one of `.`, `;`, `?`, or an operator, found `for`"))
+    let input = &[Level::ERROR.primary_title("expected one of `.`, `;`, `?`, or an operator, found `for`")
         .element(
             Snippet::source(source)
                 .path("/code/rust/src/test/ui/annotate-snippet/suggestion.rs")

--- a/tests/color/multiline_removal_suggestion.rs
+++ b/tests/color/multiline_removal_suggestion.rs
@@ -1,5 +1,5 @@
 use annotate_snippets::{
-    renderer::DecorStyle, AnnotationKind, Group, Level, Origin, Patch, Renderer, Snippet,
+    renderer::DecorStyle, AnnotationKind, Level, Origin, Patch, Renderer, Snippet,
 };
 
 use snapbox::{assert_data_eq, file};
@@ -67,11 +67,9 @@ fn main() {}
 "#;
 
     let input = &[
-        Group::with_title(
                 Level::ERROR
                     .primary_title("`(bool, HashSet<u8>)` is not an iterator")
-                    .id("E0277"),
-            )
+                    .id("E0277")
             .element(
                 Snippet::source(source)
                     .path("$DIR/multiline-removal-suggestion.rs")
@@ -88,13 +86,13 @@ fn main() {}
             .element(
                 Level::NOTE.message("required for `(bool, HashSet<u8>)` to implement `IntoIterator`"),
             ),
-        Group::with_title(Level::NOTE.secondary_title("required by a bound in `flatten`"))
+        Level::NOTE.secondary_title("required by a bound in `flatten`")
             .element(
                 Origin::path("/rustc/FAKE_PREFIX/library/core/src/iter/traits/iterator.rs")
                     .line(1556)
                     .char_column(4),
             ),
-        Group::with_title(Level::HELP.secondary_title("consider removing this method call, as the receiver has type `std::vec::IntoIter<HashSet<u8>>` and `std::vec::IntoIter<HashSet<u8>>: Iterator` trivially holds")).element(
+        Level::HELP.secondary_title("consider removing this method call, as the receiver has type `std::vec::IntoIter<HashSet<u8>>` and `std::vec::IntoIter<HashSet<u8>>: Iterator` trivially holds").element(
             Snippet::source(source)
                 .path("$DIR/multiline-removal-suggestion.rs")
 

--- a/tests/color/multiple_annotations.rs
+++ b/tests/color/multiple_annotations.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 
 use snapbox::{assert_data_eq, file};
 
@@ -15,7 +15,7 @@ fn case() {
 }
 "#;
 
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source)
             .line_start(96)
             .fold(false)

--- a/tests/color/primary_title_second_group.rs
+++ b/tests/color/primary_title_second_group.rs
@@ -4,9 +4,11 @@ use snapbox::{assert_data_eq, file};
 
 #[test]
 fn case() {
-    let report =
-        &[
-            Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308")).element(
+    let report = &[
+        Level::ERROR
+            .primary_title("mismatched types")
+            .id("E0308")
+            .element(
                 Snippet::source("        slices: vec![\"A\",")
                     .line_start(13)
                     .path("src/multislice.rs")
@@ -14,10 +16,10 @@ fn case() {
                         "expected struct `annotate_snippets::snippet::Slice`, found reference",
                     )),
             ),
-            Group::with_title(Level::NOTE.primary_title(
-                "expected type: `snippet::Annotation`\n   found type: `__&__snippet::Annotation`",
-            )),
-        ];
+        Group::with_title(Level::NOTE.primary_title(
+            "expected type: `snippet::Annotation`\n   found type: `__&__snippet::Annotation`",
+        )),
+    ];
 
     let expected_ascii = file!["primary_title_second_group.ascii.term.svg": TermSvg];
     let renderer = Renderer::styled();

--- a/tests/color/simple.rs
+++ b/tests/color/simple.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 
 use snapbox::{assert_data_eq, file};
 
@@ -9,24 +9,23 @@ fn case() {
         for line in &self.body {
 "#;
 
-    let input = &[Group::with_title(
-        Level::ERROR.primary_title("expected one of `.`, `;`, `?`, or an operator, found `for`"),
-    )
-    .element(
-        Snippet::source(source)
-            .path("src/format_color.rs")
-            .line_start(169)
-            .annotation(
-                AnnotationKind::Primary
-                    .span(20..23)
-                    .label("unexpected token"),
-            )
-            .annotation(
-                AnnotationKind::Context
-                    .span(10..11)
-                    .label("expected one of `.`, `;`, `?`, or an operator here"),
-            ),
-    )];
+    let input = &[Level::ERROR
+        .primary_title("expected one of `.`, `;`, `?`, or an operator, found `for`")
+        .element(
+            Snippet::source(source)
+                .path("src/format_color.rs")
+                .line_start(169)
+                .annotation(
+                    AnnotationKind::Primary
+                        .span(20..23)
+                        .label("unexpected token"),
+                )
+                .annotation(
+                    AnnotationKind::Context
+                        .span(10..11)
+                        .label("expected one of `.`, `;`, `?`, or an operator here"),
+                ),
+        )];
 
     let expected_ascii = file!["simple.ascii.term.svg": TermSvg];
     let renderer = Renderer::styled();

--- a/tests/color/strip_line.rs
+++ b/tests/color/strip_line.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 
 use snapbox::{assert_data_eq, file};
 
@@ -6,8 +6,10 @@ use snapbox::{assert_data_eq, file};
 fn case() {
     let source = r#"                                                                                                                                                                                    let _: () = 42;"#;
 
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308")).element(
+    let input = &[Level::ERROR
+        .primary_title("mismatched types")
+        .id("E0308")
+        .element(
             Snippet::source(source)
                 .path("$DIR/whitespace-trimming.rs")
                 .line_start(4)
@@ -16,8 +18,7 @@ fn case() {
                         .span(192..194)
                         .label("expected (), found integer"),
                 ),
-        ),
-    ];
+        )];
 
     let expected_ascii = file!["strip_line.ascii.term.svg": TermSvg];
     let renderer = Renderer::styled().anonymized_line_numbers(true);

--- a/tests/color/strip_line_char.rs
+++ b/tests/color/strip_line_char.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 
 use snapbox::{assert_data_eq, file};
 
@@ -6,8 +6,10 @@ use snapbox::{assert_data_eq, file};
 fn case() {
     let source = r#"                                                                                                                                                                                    let _: () = 42ñ"#;
 
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308")).element(
+    let input = &[Level::ERROR
+        .primary_title("mismatched types")
+        .id("E0308")
+        .element(
             Snippet::source(source)
                 .path("$DIR/whitespace-trimming.rs")
                 .line_start(4)
@@ -16,8 +18,7 @@ fn case() {
                         .span(192..194)
                         .label("expected (), found integer"),
                 ),
-        ),
-    ];
+        )];
 
     let expected_ascii = file!["strip_line_char.ascii.term.svg": TermSvg];
     let renderer = Renderer::styled().anonymized_line_numbers(true);

--- a/tests/color/strip_line_non_ws.rs
+++ b/tests/color/strip_line_non_ws.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 
 use snapbox::{assert_data_eq, file};
 
@@ -7,8 +7,10 @@ fn case() {
     let source = r#"	let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = 42; let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = (); let _: () = ();
 "#;
 
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308")).element(
+    let input = &[Level::ERROR
+        .primary_title("mismatched types")
+        .id("E0308")
+        .element(
             Snippet::source(source)
                 .path("$DIR/non-whitespace-trimming.rs")
                 .line_start(4)
@@ -22,8 +24,7 @@ fn case() {
                         .span(232..234)
                         .label("expected due to this"),
                 ),
-        ),
-    ];
+        )];
 
     let expected_ascii = file!["strip_line_non_ws.ascii.term.svg": TermSvg];
     let renderer = Renderer::styled().anonymized_line_numbers(true);

--- a/tests/color/styled_title.rs
+++ b/tests/color/styled_title.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
 use anstyle::{AnsiColor, Effects, Style};
 
 use snapbox::{assert_data_eq, file};
@@ -24,13 +24,13 @@ use c::cnb_runtime;
         "one version of crate `c` is used here, as a direct dependency of the current crate";
 
     let input = &[
-        Group::with_title(Level::ERROR.primary_title(title_1).id("E0277")).element(
+        Level::ERROR.primary_title(title_1).id("E0277").element(
             Snippet::source(source)
                 .path("src/main.rs")
                 .annotation(AnnotationKind::Primary.span(65..86).label(label_1))
                 .annotation(AnnotationKind::Context.span(53..64).label(label_2)),
         ),
-        Group::with_title(Level::HELP.secondary_title(title_2)).element(
+        Level::HELP.secondary_title(title_2).element(
             Snippet::source(source)
                 .path("src/main.rs")
                 .annotation(AnnotationKind::Primary.span(4..5).label(label_3))

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -7,13 +7,11 @@ use snapbox::{assert_data_eq, str};
 
 #[test]
 fn test_i_29() {
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("oops")).element(
-            Snippet::source("First line\r\nSecond oops line")
-                .path("<current file>")
-                .annotation(AnnotationKind::Primary.span(19..23).label("oops")),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("oops").element(
+        Snippet::source("First line\r\nSecond oops line")
+            .path("<current file>")
+            .annotation(AnnotationKind::Primary.span(19..23).label("oops")),
+    )];
     let expected_ascii = str![[r#"
 error: oops
  --> <current file>:2:8
@@ -38,7 +36,7 @@ error: oops
 
 #[test]
 fn test_point_to_double_width_characters() {
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source("こんにちは、世界")
             .path("<current file>")
             .annotation(AnnotationKind::Primary.span(18..24).label("world")),
@@ -68,7 +66,7 @@ error:
 
 #[test]
 fn test_point_to_double_width_characters_across_lines() {
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source("おはよう\nございます")
             .path("<current file>")
             .annotation(AnnotationKind::Primary.span(6..22).label("Good morning")),
@@ -102,7 +100,7 @@ error:
 
 #[test]
 fn test_point_to_double_width_characters_multiple() {
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source("お寿司\n食べたい🍣")
             .path("<current file>")
             .annotation(AnnotationKind::Primary.span(0..9).label("Sushi1"))
@@ -137,7 +135,7 @@ error:
 
 #[test]
 fn test_point_to_double_width_characters_mixed() {
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source("こんにちは、新しいWorld！")
             .path("<current file>")
             .annotation(AnnotationKind::Primary.span(18..32).label("New world")),
@@ -183,7 +181,7 @@ fn test_format_title() {
 #[test]
 fn test_format_snippet_only() {
     let source = "This is line 1\nThis is line 2";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::<Annotation<'_>>::source(source)
             .line_start(5402)
             .fold(false),
@@ -214,7 +212,8 @@ error:
 fn test_format_snippets_continuation() {
     let src_0 = "This is slice 1";
     let src_1 = "This is slice 2";
-    let input = &[Group::with_title(Level::ERROR.primary_title(""))
+    let input = &[Level::ERROR
+        .primary_title("")
         .element(
             Snippet::<Annotation<'_>>::source(src_0)
                 .line_start(5402)
@@ -263,7 +262,7 @@ fn test_format_snippet_annotation_standalone() {
     let source = [line_1, line_2].join("\n");
     // In line 2
     let range = 22..24;
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(&source)
             .line_start(5402)
             .fold(false)
@@ -296,7 +295,8 @@ error:
 
 #[test]
 fn test_format_footer_title() {
-    let input = &[Group::with_title(Level::ERROR.primary_title(""))
+    let input = &[Level::ERROR
+        .primary_title("")
         .element(Level::ERROR.message("This __is__ a title"))];
     let expected_ascii = str![[r#"
 error: 
@@ -320,7 +320,7 @@ error:
 fn test_i26() {
     let source = "short";
     let label = "label";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source).line_start(0).annotation(
             AnnotationKind::Primary
                 .span(0..source.len() + 2)
@@ -334,7 +334,7 @@ fn test_i26() {
 #[test]
 fn test_source_content() {
     let source = "This is an example\nof content lines";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::<Annotation<'_>>::source(source)
             .line_start(56)
             .fold(false),
@@ -363,7 +363,7 @@ error:
 #[test]
 fn test_source_annotation_standalone_singleline() {
     let source = "tests";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source)
             .line_start(1)
             .annotation(AnnotationKind::Context.span(0..5).label("Example string")),
@@ -390,7 +390,7 @@ error:
 #[test]
 fn test_source_annotation_standalone_multiline() {
     let source = "tests";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source)
             .line_start(1)
             .annotation(AnnotationKind::Context.span(0..5).label("Example string"))
@@ -423,7 +423,7 @@ error:
 
 #[test]
 fn test_only_source() {
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::<Annotation<'_>>::source("")
             .path("file.rs")
             .fold(false),
@@ -452,7 +452,7 @@ error:
 #[test]
 fn test_anon_lines() {
     let source = "This is an example\nof content lines\n\nabc";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::<Annotation<'_>>::source(source)
             .line_start(56)
             .fold(false),
@@ -484,15 +484,13 @@ LL │ abc
 
 #[test]
 fn issue_130() {
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("dummy")).element(
-            Snippet::source("foo\nbar\nbaz")
-                .path("file/path")
-                .line_start(3)
-                .annotation(AnnotationKind::Primary.span(4..11)),
-            // bar\nbaz
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("dummy").element(
+        Snippet::source("foo\nbar\nbaz")
+            .path("file/path")
+            .line_start(3)
+            .annotation(AnnotationKind::Primary.span(4..11)),
+        // bar\nbaz
+    )];
 
     let expected_ascii = str![[r#"
 error: dummy
@@ -523,7 +521,7 @@ fn unterminated_string_multiline() {
 a\"
 // ...
 ";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source)
             .path("file/path")
             .line_start(3)
@@ -556,7 +554,7 @@ error:
 #[test]
 fn char_and_nl_annotate_char() {
     let source = "a\r\nb";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source)
             .path("file/path")
             .line_start(3)
@@ -592,7 +590,7 @@ error:
 #[test]
 fn char_eol_annotate_char() {
     let source = "a\r\nb";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source)
             .path("file/path")
             .line_start(3)
@@ -624,7 +622,7 @@ error:
 
 #[test]
 fn char_eol_annotate_char_double_width() {
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source("こん\r\nにちは\r\n世界")
             .path("<current file>")
             .fold(false)
@@ -664,13 +662,11 @@ error:
 
 #[test]
 fn annotate_newline_empty_span() {
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("bad")).element(
-            Snippet::source("\n\n\n\n\n\n\n")
-                .path("test.txt")
-                .annotation(AnnotationKind::Primary.span(0..0)),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("bad").element(
+        Snippet::source("\n\n\n\n\n\n\n")
+            .path("test.txt")
+            .annotation(AnnotationKind::Primary.span(0..0)),
+    )];
 
     let expected_ascii = str![[r#"
 error: bad
@@ -698,7 +694,7 @@ error: bad
 #[test]
 fn annotate_eol() {
     let source = "a\r\nb";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source)
             .path("file/path")
             .line_start(3)
@@ -734,7 +730,7 @@ error:
 #[test]
 fn annotate_eol2() {
     let source = "a\r\nb";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source)
             .path("file/path")
             .line_start(3)
@@ -769,7 +765,7 @@ error:
 #[test]
 fn annotate_eol3() {
     let source = "a\r\nb";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source)
             .path("file/path")
             .line_start(3)
@@ -804,7 +800,7 @@ error:
 #[test]
 fn annotate_eol4() {
     let source = "a\r\nb";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source)
             .path("file/path")
             .line_start(3)
@@ -839,7 +835,7 @@ error:
 
 #[test]
 fn annotate_eol_double_width() {
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source("こん\r\nにちは\r\n世界")
             .path("<current file>")
             .fold(false)
@@ -880,7 +876,7 @@ error:
 #[test]
 fn multiline_eol_start() {
     let source = "a\r\nb";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source)
             .path("file/path")
             .line_start(3)
@@ -915,7 +911,7 @@ error:
 #[test]
 fn multiline_eol_start2() {
     let source = "a\r\nb";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source)
             .path("file/path")
             .line_start(3)
@@ -950,7 +946,7 @@ error:
 #[test]
 fn multiline_eol_start3() {
     let source = "a\nb";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source)
             .path("file/path")
             .line_start(3)
@@ -984,7 +980,7 @@ error:
 
 #[test]
 fn multiline_eol_start_double_width() {
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source("こん\r\nにちは\r\n世界")
             .path("<current file>")
             .fold(false)
@@ -1025,7 +1021,7 @@ error:
 #[test]
 fn multiline_eol_start_eol_end() {
     let source = "a\nb\nc";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source)
             .path("file/path")
             .line_start(3)
@@ -1062,7 +1058,7 @@ error:
 #[test]
 fn multiline_eol_start_eol_end2() {
     let source = "a\r\nb\r\nc";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source)
             .path("file/path")
             .line_start(3)
@@ -1102,7 +1098,7 @@ error:
 #[test]
 fn multiline_eol_start_eol_end3() {
     let source = "a\r\nb\r\nc";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source)
             .path("file/path")
             .line_start(3)
@@ -1139,7 +1135,7 @@ error:
 #[test]
 fn multiline_eol_start_eof_end() {
     let source = "a\r\nb";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source)
             .path("file/path")
             .line_start(3)
@@ -1174,7 +1170,7 @@ error:
 #[test]
 fn multiline_eol_start_eof_end_double_width() {
     let source = "ん\r\nに";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source)
             .path("file/path")
             .line_start(3)
@@ -1209,8 +1205,9 @@ error:
 #[test]
 fn two_single_line_same_line() {
     let source = r#"bar = { version = "0.1.0", optional = true }"#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("unused optional dependency")).element(
+    let input = &[Level::ERROR
+        .primary_title("unused optional dependency")
+        .element(
             Snippet::source(source)
                 .path("Cargo.toml")
                 .line_start(4)
@@ -1224,8 +1221,7 @@ fn two_single_line_same_line() {
                         .span(27..42)
                         .label("This should also be long but not too long"),
                 ),
-        ),
-    ];
+        )];
     let expected_ascii = str![[r#"
 error: unused optional dependency
  --> Cargo.toml:4:1
@@ -1258,8 +1254,9 @@ this is another line
 so is this
 bar = { version = "0.1.0", optional = true }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("unused optional dependency")).element(
+    let input = &[Level::ERROR
+        .primary_title("unused optional dependency")
+        .element(
             Snippet::source(source)
                 .line_start(4)
                 .annotation(
@@ -1272,8 +1269,7 @@ bar = { version = "0.1.0", optional = true }
                         .span(27..42)
                         .label("This should also be long but not too long"),
                 ),
-        ),
-    ];
+        )];
     let expected_ascii = str![[r#"
 error: unused optional dependency
   |
@@ -1312,8 +1308,9 @@ this is another line
 so is this
 bar = { version = "0.1.0", optional = true }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("unused optional dependency")).element(
+    let input = &[Level::ERROR
+        .primary_title("unused optional dependency")
+        .element(
             Snippet::source(source)
                 .line_start(4)
                 .annotation(
@@ -1331,8 +1328,7 @@ bar = { version = "0.1.0", optional = true }
                         .span(27..42)
                         .label("This should also be long but not too long"),
                 ),
-        ),
-    ];
+        )];
     let expected_ascii = str![[r#"
 error: unused optional dependency
   |
@@ -1378,8 +1374,9 @@ so is this
 bar = { version = "0.1.0", optional = true }
 this is another line
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("unused optional dependency")).element(
+    let input = &[Level::ERROR
+        .primary_title("unused optional dependency")
+        .element(
             Snippet::source(source)
                 .line_start(4)
                 .annotation(
@@ -1402,8 +1399,7 @@ this is another line
                         .span(27..42)
                         .label("This should also be long but not too long"),
                 ),
-        ),
-    ];
+        )];
     let expected_ascii = str![[r#"
 error: unused optional dependency
   |
@@ -1450,14 +1446,12 @@ error: unused optional dependency
 #[test]
 fn origin_correct_start_line() {
     let source = "aaa\nbbb\nccc\nddd\n";
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("title")).element(
-            Snippet::source(source)
-                .path("origin.txt")
-                .fold(false)
-                .annotation(AnnotationKind::Primary.span(8..8 + 3).label("annotation")),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("title").element(
+        Snippet::source(source)
+            .path("origin.txt")
+            .fold(false)
+            .annotation(AnnotationKind::Primary.span(8..8 + 3).label("annotation")),
+    )];
 
     let expected_ascii = str![[r#"
 error: title
@@ -1491,18 +1485,16 @@ error: title
 #[test]
 fn origin_correct_mid_line() {
     let source = "aaa\nbbb\nccc\nddd\n";
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("title")).element(
-            Snippet::source(source)
-                .path("origin.txt")
-                .fold(false)
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(8 + 1..8 + 3)
-                        .label("annotation"),
-                ),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("title").element(
+        Snippet::source(source)
+            .path("origin.txt")
+            .fold(false)
+            .annotation(
+                AnnotationKind::Primary
+                    .span(8 + 1..8 + 3)
+                    .label("annotation"),
+            ),
+    )];
 
     let expected_ascii = str![[r#"
 error: title
@@ -1537,18 +1529,14 @@ error: title
 fn two_suggestions_same_span() {
     let source = r#"    A.foo();"#;
     let input = &[
-        Group::with_title(
-            Level::ERROR
-                .primary_title("expected value, found enum `A`")
-                .id("E0423"),
-        )
-        .element(Snippet::source(source).annotation(AnnotationKind::Primary.span(4..5))),
-        Group::with_title(
-            Level::HELP
-                .secondary_title("you might have meant to use one of the following enum variants"),
-        )
-        .element(Snippet::source(source).patch(Patch::new(4..5, "(A::Tuple())")))
-        .element(Snippet::source(source).patch(Patch::new(4..5, "A::Unit"))),
+        Level::ERROR
+            .primary_title("expected value, found enum `A`")
+            .id("E0423")
+            .element(Snippet::source(source).annotation(AnnotationKind::Primary.span(4..5))),
+        Level::HELP
+            .secondary_title("you might have meant to use one of the following enum variants")
+            .element(Snippet::source(source).patch(Patch::new(4..5, "(A::Tuple())")))
+            .element(Snippet::source(source).patch(Patch::new(4..5, "A::Unit"))),
     ];
 
     let expected_ascii = str![[r#"
@@ -1608,9 +1596,9 @@ fn main() {
     banana::Chaenomeles.pick()
 }"#;
     let input =
-        &[Group::with_title(Level::ERROR
+        &[Level::ERROR
             .primary_title("no method named `pick` found for struct `Chaenomeles` in the current scope")
-            .id("E0599")).element(
+            .id("E0599").element(
                     Snippet::source(source)
                         .line_start(1)
 
@@ -1625,9 +1613,9 @@ fn main() {
                                 .label("method not found in `Chaenomeles`"),
                         ),
                 ),
-                Group::with_title(Level::HELP.secondary_title(
+                Level::HELP.secondary_title(
                         "the following traits which provide `pick` are implemented but not in scope; perhaps you want to import one of them",
-                    ))
+                    )
                     .element(
                         Snippet::source(source)
 
@@ -1682,17 +1670,16 @@ fn single_line_non_overlapping_suggestions() {
     let source = r#"    A.foo();"#;
 
     let input = &[
-        Group::with_title(
-            Level::ERROR
-                .primary_title("expected value, found enum `A`")
-                .id("E0423"),
-        )
-        .element(
-            Snippet::source(source)
-                .line_start(1)
-                .annotation(AnnotationKind::Primary.span(4..5)),
-        ),
-        Group::with_title(Level::HELP.secondary_title("make these changes and things will work"))
+        Level::ERROR
+            .primary_title("expected value, found enum `A`")
+            .id("E0423")
+            .element(
+                Snippet::source(source)
+                    .line_start(1)
+                    .annotation(AnnotationKind::Primary.span(4..5)),
+            ),
+        Level::HELP
+            .secondary_title("make these changes and things will work")
             .element(
                 Snippet::source(source)
                     .patch(Patch::new(4..5, "(A::Tuple())"))
@@ -1735,17 +1722,16 @@ LL +     (A::Tuple()).bar();
 fn single_line_non_overlapping_suggestions2() {
     let source = r#"    ThisIsVeryLong.foo();"#;
     let input = &[
-        Group::with_title(
-            Level::ERROR
-                .primary_title("Found `ThisIsVeryLong`")
-                .id("E0423"),
-        )
-        .element(
-            Snippet::source(source)
-                .line_start(1)
-                .annotation(AnnotationKind::Primary.span(4..18)),
-        ),
-        Group::with_title(Level::HELP.secondary_title("make these changes and things will work"))
+        Level::ERROR
+            .primary_title("Found `ThisIsVeryLong`")
+            .id("E0423")
+            .element(
+                Snippet::source(source)
+                    .line_start(1)
+                    .annotation(AnnotationKind::Primary.span(4..18)),
+            ),
+        Level::HELP
+            .secondary_title("make these changes and things will work")
             .element(
                 Snippet::source(source)
                     .patch(Patch::new(4..18, "(A::Tuple())"))
@@ -1795,47 +1781,43 @@ fn multiple_replacements() {
 "#;
 
     let input = &[
-        Group::with_title(
-            Level::ERROR
-                .primary_title(
-                    "cannot borrow `*self` as mutable because it is also borrowed as immutable",
-                )
-                .id("E0502"),
-        )
-        .element(
-            Snippet::source(source)
-                .line_start(1)
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(49..59)
-                        .label("mutable borrow occurs here"),
-                )
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(13..15)
-                        .label("immutable borrow occurs here"),
-                )
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(26..30)
-                        .label("first borrow occurs due to use of `*self` in closure"),
-                )
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(65..66)
-                        .label("immutable borrow later used here"),
-                ),
-        ),
-        Group::with_title(
-            Level::HELP
-                .secondary_title("try explicitly pass `&Self` into the Closure as an argument"),
-        )
-        .element(
-            Snippet::source(source)
-                .patch(Patch::new(14..14, "this: &Self"))
-                .patch(Patch::new(26..30, "this"))
-                .patch(Patch::new(66..68, "(self)")),
-        ),
+        Level::ERROR
+            .primary_title(
+                "cannot borrow `*self` as mutable because it is also borrowed as immutable",
+            )
+            .id("E0502")
+            .element(
+                Snippet::source(source)
+                    .line_start(1)
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(49..59)
+                            .label("mutable borrow occurs here"),
+                    )
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(13..15)
+                            .label("immutable borrow occurs here"),
+                    )
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(26..30)
+                            .label("first borrow occurs due to use of `*self` in closure"),
+                    )
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(65..66)
+                            .label("immutable borrow later used here"),
+                    ),
+            ),
+        Level::HELP
+            .secondary_title("try explicitly pass `&Self` into the Closure as an argument")
+            .element(
+                Snippet::source(source)
+                    .patch(Patch::new(14..14, "this: &Self"))
+                    .patch(Patch::new(26..30, "this"))
+                    .patch(Patch::new(66..68, "(self)")),
+            ),
     ];
     let expected_ascii = str![[r#"
 error[E0502]: cannot borrow `*self` as mutable because it is also borrowed as immutable
@@ -1903,33 +1885,31 @@ fn main() {
 }"#;
 
     let input = &[
-        Group::with_title(
-            Level::ERROR
-                .primary_title("cannot borrow `chars` as mutable more than once at a time")
-                .id("E0499"),
-        )
-        .element(
-            Snippet::source(source)
-                .line_start(1)
-                .annotation(
-                    AnnotationKind::Context
-                        .span(65..70)
-                        .label("first mutable borrow occurs here"),
-                )
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(90..95)
-                        .label("second mutable borrow occurs here"),
-                )
-                .annotation(
-                    AnnotationKind::Context
-                        .span(65..79)
-                        .label("first borrow later used here"),
-                ),
-        ),
-        Group::with_title(Level::HELP.secondary_title(
+        Level::ERROR
+            .primary_title("cannot borrow `chars` as mutable more than once at a time")
+            .id("E0499")
+            .element(
+                Snippet::source(source)
+                    .line_start(1)
+                    .annotation(
+                        AnnotationKind::Context
+                            .span(65..70)
+                            .label("first mutable borrow occurs here"),
+                    )
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(90..95)
+                            .label("second mutable borrow occurs here"),
+                    )
+                    .annotation(
+                        AnnotationKind::Context
+                            .span(65..79)
+                            .label("first borrow later used here"),
+                    ),
+            ),
+        Level::HELP.secondary_title(
             "if you want to call `next` on a iterator within the loop, consider using `while let`",
-        ))
+        )
         .element(
             Snippet::source(source)
                 .patch(Patch::new(
@@ -2004,28 +1984,25 @@ struct Foo {
 fn main() {}"#;
 
     let input = &[
-        Group::with_title(
-            Level::ERROR
-                .primary_title("failed to resolve: use of undeclared crate or module `st`")
-                .id("E0433"),
-        )
-        .element(
-            Snippet::source(source).line_start(1).annotation(
-                AnnotationKind::Primary
-                    .span(122..124)
-                    .label("use of undeclared crate or module `st`"),
+        Level::ERROR
+            .primary_title("failed to resolve: use of undeclared crate or module `st`")
+            .id("E0433")
+            .element(
+                Snippet::source(source).line_start(1).annotation(
+                    AnnotationKind::Primary
+                        .span(122..124)
+                        .label("use of undeclared crate or module `st`"),
+                ),
             ),
-        ),
-        Group::with_title(
-            Level::HELP.secondary_title("there is a crate or module with a similar name"),
-        )
-        .element(Snippet::source(source).patch(Patch::new(122..124, "std"))),
-        Group::with_title(Level::HELP.secondary_title("consider importing this module"))
+        Level::HELP
+            .secondary_title("there is a crate or module with a similar name")
+            .element(Snippet::source(source).patch(Patch::new(122..124, "std"))),
+        Level::HELP
+            .secondary_title("consider importing this module")
             .element(Snippet::source(source).patch(Patch::new(1..1, "use std::cell;\n"))),
-        Group::with_title(
-            Level::HELP.secondary_title("if you import `cell`, refer to it directly"),
-        )
-        .element(Snippet::source(source).patch(Patch::new(122..126, ""))),
+        Level::HELP
+            .secondary_title("if you import `cell`, refer to it directly")
+            .element(Snippet::source(source).patch(Patch::new(122..126, ""))),
     ];
     let expected_ascii = str![[r#"
 error[E0433]: failed to resolve: use of undeclared crate or module `st`
@@ -2094,31 +2071,28 @@ where
 fn main() {}"#;
 
     let input = &[
-        Group::with_title(
-            Level::ERROR
-                .primary_title(
-                    "the size for values of type `T` cannot be known at compilation time",
-                )
-                .id("E0277"),
-        )
-        .element(
-            Snippet::source(source)
-                .line_start(1)
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(39..49)
-                        .label("doesn't have a size known at compile-time"),
-                )
-                .annotation(
-                    AnnotationKind::Context
-                        .span(31..32)
-                        .label("this type parameter needs to be `Sized`"),
-                ),
-        ),
-        Group::with_title(Level::HELP.secondary_title(
-            "consider removing the `?Sized` bound to make the type parameter `Sized`",
-        ))
-        .element(Snippet::source(source).patch(Patch::new(52..85, ""))),
+        Level::ERROR
+            .primary_title("the size for values of type `T` cannot be known at compilation time")
+            .id("E0277")
+            .element(
+                Snippet::source(source)
+                    .line_start(1)
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(39..49)
+                            .label("doesn't have a size known at compile-time"),
+                    )
+                    .annotation(
+                        AnnotationKind::Context
+                            .span(31..32)
+                            .label("this type parameter needs to be `Sized`"),
+                    ),
+            ),
+        Level::HELP
+            .secondary_title(
+                "consider removing the `?Sized` bound to make the type parameter `Sized`",
+            )
+            .element(Snippet::source(source).patch(Patch::new(52..85, ""))),
     ];
     let expected_ascii = str![[r#"
 error[E0277]: the size for values of type `T` cannot be known at compilation time
@@ -2178,65 +2152,65 @@ and where
 }
 
 fn main() {}"#;
-    let input = &[Group::with_title(Level::ERROR
-        .primary_title("the size for values of type `T` cannot be known at compilation time")
-        .id("E0277")).element(Snippet::source(source)
-            .line_start(1)
-            .path("$DIR/removal-of-multiline-trait-bound-in-where-clause.rs")
-
-            .annotation(
-                AnnotationKind::Primary
-                    .span(39..49)
-                    .label("doesn't have a size known at compile-time"),
-            )
-            .annotation(
-                AnnotationKind::Context
-                    .span(31..32)
-                    .label("this type parameter needs to be `Sized`"),
-            ))
-        ,Group::with_title(
-            Level::NOTE
-                .secondary_title("required by an implicit `Sized` bound in `Wrapper`")
-        ).element(
-            Snippet::source(source)
+    let input = &[
+        Level::ERROR
+            .primary_title("the size for values of type `T` cannot be known at compilation time")
+            .id("E0277").element(Snippet::source(source)
                 .line_start(1)
                 .path("$DIR/removal-of-multiline-trait-bound-in-where-clause.rs")
 
                 .annotation(
                     AnnotationKind::Primary
-                        .span(16..17)
-                        .label("required by the implicit `Sized` requirement on this type parameter in `Wrapper`"),
-                )
-        ), Group::with_title(
-            Level::HELP
-                .secondary_title("you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`")
-            )
-            .element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("$DIR/removal-of-multiline-trait-bound-in-where-clause.rs")
-
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(16..17)
-                        .label("this could be changed to `T: ?Sized`..."),
+                        .span(39..49)
+                        .label("doesn't have a size known at compile-time"),
                 )
                 .annotation(
                     AnnotationKind::Context
-                        .span(19..20)
-                        .label("...if indirection were used here: `Box<T>`"),
+                        .span(31..32)
+                        .label("this type parameter needs to be `Sized`"),
                 )
+            ),
+        Level::NOTE
+            .secondary_title("required by an implicit `Sized` bound in `Wrapper`")
+            .element(
+                Snippet::source(source)
+                    .line_start(1)
+                    .path("$DIR/removal-of-multiline-trait-bound-in-where-clause.rs")
 
-        ),Group::with_title(
-            Level::HELP
-                .secondary_title("consider removing the `?Sized` bound to make the type parameter `Sized`")
-        ).element(
-            Snippet::source(source)
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(16..17)
+                            .label("required by the implicit `Sized` requirement on this type parameter in `Wrapper`"),
+                    )
+            ),
+        Level::HELP
+            .secondary_title("you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`")
+            .element(
+                Snippet::source(source)
+                    .line_start(1)
+                    .path("$DIR/removal-of-multiline-trait-bound-in-where-clause.rs")
 
-                .patch(Patch::new(56..89, ""))
-                .patch(Patch::new(89..89, "+ Send"))
-                ,
-        )];
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(16..17)
+                            .label("this could be changed to `T: ?Sized`..."),
+                    )
+                    .annotation(
+                        AnnotationKind::Context
+                            .span(19..20)
+                            .label("...if indirection were used here: `Box<T>`"),
+                    )
+            ),
+        Level::HELP
+            .secondary_title("consider removing the `?Sized` bound to make the type parameter `Sized`")
+            .element(
+                Snippet::source(source)
+
+                    .patch(Patch::new(56..89, ""))
+                    .patch(Patch::new(89..89, "+ Send"))
+                    ,
+            )
+    ];
     let expected_ascii = str![[r#"
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:4:16
@@ -2327,15 +2301,16 @@ zappy
                 .id("E0277"),
         ),
         // We need an empty group here to ensure the HELP line is rendered correctly
-        Group::with_title(Level::HELP.secondary_title(
-            "consider removing the `?Sized` bound to make the type parameter `Sized`",
-        ))
-        .element(
-            Snippet::source(source)
-                .line_start(7)
-                .patch(Patch::new(3..21, ""))
-                .patch(Patch::new(22..40, "")),
-        ),
+        Level::HELP
+            .secondary_title(
+                "consider removing the `?Sized` bound to make the type parameter `Sized`",
+            )
+            .element(
+                Snippet::source(source)
+                    .line_start(7)
+                    .patch(Patch::new(3..21, ""))
+                    .patch(Patch::new(22..40, "")),
+            ),
     ];
     let expected_ascii = str![[r#"
 error[E0277]: the size for values of type `T` cannot be known at compilation time
@@ -2404,29 +2379,31 @@ fn main() {
 }
 "#;
 
-    let input = &[Group::with_title(Level::ERROR
-        .primary_title("type mismatch resolving `<Result<Result<(), Result<Result<(), Result<Result<(), Option<{integer}>>, ...>>, ...>>, ...> as Future>::Error == Foo`")
-        .id("E0271")).element(Snippet::source(source)
-            .line_start(4)
-            .path("$DIR/E0271.rs")
-
-            .annotation(
-                AnnotationKind::Primary
-                    .span(208..510)
-                    .label("type mismatch resolving `<Result<Result<(), Result<Result<(), ...>, ...>>, ...> as Future>::Error == Foo`"),
-            )),Group::with_title(
-            Level::NOTE.secondary_title("expected this to be `Foo`")
-        ).element(
-            Snippet::source(source)
+    let input = &[
+        Level::ERROR
+            .primary_title("type mismatch resolving `<Result<Result<(), Result<Result<(), Result<Result<(), Option<{integer}>>, ...>>, ...>>, ...> as Future>::Error == Foo`")
+            .id("E0271")
+            .element(Snippet::source(source)
                 .line_start(4)
                 .path("$DIR/E0271.rs")
-
-                .annotation(AnnotationKind::Primary.span(89..90))
-        ).element(
-            Level::NOTE
-                .message("required for the cast from `Box<Result<Result<(), Result<Result<(), Result<Result<(), Option<{integer}>>, ()>>, ()>>, ()>>` to `Box<(dyn Future<Error = Foo> + 'static)>`")
-                ,
-        )];
+                .annotation(
+                    AnnotationKind::Primary
+                        .span(208..510)
+                        .label("type mismatch resolving `<Result<Result<(), Result<Result<(), ...>, ...>>, ...> as Future>::Error == Foo`"),
+                )
+            ),
+        Level::NOTE.secondary_title("expected this to be `Foo`")
+            .element(
+                Snippet::source(source)
+                    .line_start(4)
+                    .path("$DIR/E0271.rs")
+                    .annotation(AnnotationKind::Primary.span(89..90))
+            )
+            .element(
+                Level::NOTE
+                    .message("required for the cast from `Box<Result<Result<(), Result<Result<(), Result<Result<(), Option<{integer}>>, ()>>, ()>>, ()>>` to `Box<(dyn Future<Error = Foo> + 'static)>`")
+            )
+        ];
 
     let expected_ascii = str![[r#"
 error[E0271]: type mismatch resolving `<Result<Result<(), Result<Result<(), Result<Result<(), Option<{integer}>>, ...>>, ...>>, ...> as Future>::Error == Foo`
@@ -2511,30 +2488,34 @@ fn main() {
 }
 "#;
 
-    let input = &[Group::with_title(Level::ERROR
-        .primary_title("type mismatch resolving `<Result<Result<(), Result<Result<(), Result<Result<(), Option<{integer}>>, ...>>, ...>>, ...> as Future>::Error == Foo`")
-        .id("E0271")).element(Snippet::source(source)
-            .line_start(4)
-            .path("$DIR/E0271.rs")
-
-            .annotation(
-                AnnotationKind::Primary
-                    .span(208..510)
-                    .label("type mismatch resolving `<Result<Result<(), Result<Result<(), ...>, ...>>, ...> as Future>::Error == Foo`"),
-            )),Group::with_title(
-            Level::NOTE.secondary_title("expected this to be `Foo`")
-        ).element(
-            Snippet::source(source)
+    let input = &[
+        Level::ERROR
+            .primary_title("type mismatch resolving `<Result<Result<(), Result<Result<(), Result<Result<(), Option<{integer}>>, ...>>, ...>>, ...> as Future>::Error == Foo`")
+            .id("E0271")
+            .element(Snippet::source(source)
                 .line_start(4)
                 .path("$DIR/E0271.rs")
 
-                .annotation(AnnotationKind::Primary.span(89..90))
-        ).element(
-            Level::NOTE
-                .message("required for the cast from `Box<Result<Result<(), Result<Result<(), Result<Result<(), Option<{integer}>>, ()>>, ()>>, ()>>` to `Box<(dyn Future<Error = Foo> + 'static)>`")
-        ).element(
-            Level::NOTE.message("a second note"),
-        )];
+                .annotation(
+                    AnnotationKind::Primary
+                        .span(208..510)
+                        .label("type mismatch resolving `<Result<Result<(), Result<Result<(), ...>, ...>>, ...> as Future>::Error == Foo`"),
+                )
+            ),
+        Level::NOTE.secondary_title("expected this to be `Foo`")
+            .element(
+                Snippet::source(source)
+                    .line_start(4)
+                    .path("$DIR/E0271.rs")
+
+                    .annotation(AnnotationKind::Primary.span(89..90))
+            ).element(
+                Level::NOTE
+                    .message("required for the cast from `Box<Result<Result<(), Result<Result<(), Result<Result<(), Option<{integer}>>, ()>>, ()>>, ()>>` to `Box<(dyn Future<Error = Foo> + 'static)>`")
+            ).element(
+                Level::NOTE.message("a second note"),
+            )
+    ];
 
     let expected_ascii = str![[r#"
 error[E0271]: type mismatch resolving `<Result<Result<(), Result<Result<(), Result<Result<(), Option<{integer}>>, ...>>, ...>>, ...> as Future>::Error == Foo`
@@ -2684,9 +2665,10 @@ fn main() {
 }
 "#;
 
-    let input = &[Group::with_title(Level::ERROR
+    let input = &[Level::ERROR
         .primary_title("mismatched types")
-        .id("E0308")).element(
+        .id("E0308")
+        .element(
             Snippet::source(source)
                 .line_start(7)
                 .path("$DIR/long-E0308.rs")
@@ -2796,9 +2778,10 @@ fn main() {
 }
 "#;
 
-    let input = &[Group::with_title(Level::ERROR
+    let input = &[Level::ERROR
         .primary_title("mismatched types")
-        .id("E0308")).element(
+        .id("E0308")
+        .element(
             Snippet::source(source)
                 .line_start(7)
                 .path("$DIR/unicode-output.rs")
@@ -2817,16 +2800,16 @@ fn main() {
             Level::NOTE
                 .message("expected fn pointer `for<'a> fn(Box<(dyn Any + Send + 'a)>) -> Pin<_>`\n      found fn item `fn(Box<(dyn Any + Send + 'static)>) -> Pin<_> {wrapped_fn}`")
                 ,
-        ),Group::with_title(
-            Level::NOTE.secondary_title("function defined here"),
-        ).element(
-            Snippet::source(source)
-                .line_start(7)
-                .path("$DIR/unicode-output.rs")
+        ),
+        Level::NOTE.secondary_title("function defined here")
+            .element(
+                Snippet::source(source)
+                    .line_start(7)
+                    .path("$DIR/unicode-output.rs")
 
-                .annotation(AnnotationKind::Primary.span(77..210))
-                .annotation(AnnotationKind::Context.span(71..76)),
-        )];
+                    .annotation(AnnotationKind::Primary.span(77..210))
+                    .annotation(AnnotationKind::Context.span(71..76)),
+            )];
 
     let expected_ascii = str![[r#"
 error[E0308]: mismatched types
@@ -2884,13 +2867,11 @@ LL │ ┃ )>>) {}
 #[test]
 fn unicode_cut_handling() {
     let source = "version = \"0.1.0\"\n# Ensure that the spans from toml handle utf-8 correctly\nauthors = [\n    { name = \"Z\u{351}\u{36b}\u{343}\u{36a}\u{302}\u{36b}\u{33d}\u{34f}\u{334}\u{319}\u{324}\u{31e}\u{349}\u{35a}\u{32f}\u{31e}\u{320}\u{34d}A\u{36b}\u{357}\u{334}\u{362}\u{335}\u{31c}\u{330}\u{354}L\u{368}\u{367}\u{369}\u{358}\u{320}G\u{311}\u{357}\u{30e}\u{305}\u{35b}\u{341}\u{334}\u{33b}\u{348}\u{34d}\u{354}\u{339}O\u{342}\u{30c}\u{30c}\u{358}\u{328}\u{335}\u{339}\u{33b}\u{31d}\u{333}\", email = 1 }\n]\n";
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("title")).element(
-            Snippet::source(source)
-                .fold(false)
-                .annotation(AnnotationKind::Primary.span(85..228).label("annotation")),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("title").element(
+        Snippet::source(source)
+            .fold(false)
+            .annotation(AnnotationKind::Primary.span(85..228).label("annotation")),
+    )];
     let expected_ascii = str![[r#"
 error: title
   |
@@ -2923,8 +2904,8 @@ error: title
 #[test]
 fn unicode_cut_handling2() {
     let source = "/*这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。*/?";
-    let input = &[Group::with_title(Level::ERROR
-        .primary_title("expected item, found `?`")).element(
+    let input = &[Level::ERROR
+        .primary_title("expected item, found `?`").element(
                 Snippet::source(source)
                     .fold(false)
                     .annotation(AnnotationKind::Primary.span(499..500).label("expected item"))
@@ -2960,8 +2941,8 @@ error: expected item, found `?`
 #[test]
 fn unicode_cut_handling3() {
     let source = "/*这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。*/?";
-    let input = &[Group::with_title(Level::ERROR
-        .primary_title("expected item, found `?`")).element(
+    let input = &[Level::ERROR
+        .primary_title("expected item, found `?`").element(
                 Snippet::source(source)
                     .fold(false)
                     .annotation(AnnotationKind::Primary.span(251..254).label("expected item"))
@@ -2997,8 +2978,8 @@ error: expected item, found `?`
 #[test]
 fn unicode_cut_handling4() {
     let source = "/*aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa*/?";
-    let input = &[Group::with_title(Level::ERROR
-        .primary_title("expected item, found `?`")).element(
+    let input = &[Level::ERROR
+        .primary_title("expected item, found `?`").element(
                 Snippet::source(source)
                     .fold(false)
                     .annotation(AnnotationKind::Primary.span(334..335).label("expected item"))
@@ -3040,8 +3021,10 @@ fn main() {
 //~^ ERROR mismatched types
 }
 "##;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308")).element(
+    let input = &[Level::ERROR
+        .primary_title("mismatched types")
+        .id("E0308")
+        .element(
             Snippet::source(source)
                 .path("$DIR/non-whitespace-trimming-unicode.rs")
                 .annotation(
@@ -3054,8 +3037,7 @@ fn main() {
                         .span(1202..1204)
                         .label("expected due to this"),
                 ),
-        ),
-    ];
+        )];
 
     let expected_ascii = str![[r#"
 error[E0308]: mismatched types
@@ -3096,33 +3078,30 @@ fn main() {
 }
 "##;
     let input = &[
-        Group::with_title(
-            Level::ERROR
-                .primary_title("cannot add `&str` to `&str`")
-                .id("E0369"),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/non-1-width-unicode-multiline-label.rs")
-                .annotation(AnnotationKind::Context.span(970..984).label("&str"))
-                .annotation(AnnotationKind::Context.span(987..1001).label("&str"))
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(985..986)
-                        .label("`+` cannot be used to concatenate two `&str` strings"),
-                ),
-        )
-        .element(
-            Level::NOTE.message("string concatenation requires an owned `String` on the left"),
-        ),
-        Group::with_title(
-            Level::HELP.secondary_title("create an owned `String` from a string reference"),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/non-1-width-unicode-multiline-label.rs")
-                .patch(Patch::new(984..984, ".to_owned()")),
-        ),
+        Level::ERROR
+            .primary_title("cannot add `&str` to `&str`")
+            .id("E0369")
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/non-1-width-unicode-multiline-label.rs")
+                    .annotation(AnnotationKind::Context.span(970..984).label("&str"))
+                    .annotation(AnnotationKind::Context.span(987..1001).label("&str"))
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(985..986)
+                            .label("`+` cannot be used to concatenate two `&str` strings"),
+                    ),
+            )
+            .element(
+                Level::NOTE.message("string concatenation requires an owned `String` on the left"),
+            ),
+        Level::HELP
+            .secondary_title("create an owned `String` from a string reference")
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/non-1-width-unicode-multiline-label.rs")
+                    .patch(Patch::new(984..984, ".to_owned()")),
+            ),
     ];
 
     let expected_ascii = str![[r#"
@@ -3177,14 +3156,14 @@ fn foo() {
 }
 "##;
     let bin_source = "�|�\u{0002}!5�cc\u{0015}\u{0002}�Ӻi��WWj�ȥ�'�}�\u{0012}�J�ȉ��W�\u{001e}O�@����\u{001c}w�V���LO����\u{0014}[ \u{0003}_�'���SQ�~ذ��ų&��-\t��lN~��!@␌ _#���kQ��h�\u{001d}�:�\u{001c}\u{0007}�";
-    let input = &[Group::with_title(Level::ERROR
-        .primary_title("couldn't read `$DIR/not-utf8.bin`: stream did not contain valid UTF-8")).element(
+    let input = &[Level::ERROR
+        .primary_title("couldn't read `$DIR/not-utf8.bin`: stream did not contain valid UTF-8").element(
                 Snippet::source(source)
                     .path("$DIR/not-utf8.rs")
 
                     .annotation(AnnotationKind::Primary.span(136..160)),
             ),
-            Group::with_title(Level::NOTE.secondary_title("byte `193` is not valid utf-8"))
+            Level::NOTE.secondary_title("byte `193` is not valid utf-8")
                 .element(
                     Snippet::source(bin_source)
                         .path("$DIR/not-utf8.bin")
@@ -3237,28 +3216,28 @@ fn secondary_title_no_level_text() {
     let s: &str = include_bytes!("file.txt");   //~ ERROR mismatched types
 }"#;
 
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308"))
-            .element(
-                Snippet::source(source)
-                    .path("$DIR/mismatched-types.rs")
-                    .annotation(
-                        AnnotationKind::Primary
-                            .span(105..131)
-                            .label("expected `&str`, found `&[u8; 0]`"),
-                    )
-                    .annotation(
-                        AnnotationKind::Context
-                            .span(98..102)
-                            .label("expected due to this"),
-                    ),
-            )
-            .element(
-                Level::NOTE
-                    .no_name()
-                    .message("expected reference `&str`\nfound reference `&'static [u8; 0]`"),
-            ),
-    ];
+    let input = &[Level::ERROR
+        .primary_title("mismatched types")
+        .id("E0308")
+        .element(
+            Snippet::source(source)
+                .path("$DIR/mismatched-types.rs")
+                .annotation(
+                    AnnotationKind::Primary
+                        .span(105..131)
+                        .label("expected `&str`, found `&[u8; 0]`"),
+                )
+                .annotation(
+                    AnnotationKind::Context
+                        .span(98..102)
+                        .label("expected due to this"),
+                ),
+        )
+        .element(
+            Level::NOTE
+                .no_name()
+                .message("expected reference `&str`\nfound reference `&'static [u8; 0]`"),
+        )];
 
     let expected_ascii = str![[r#"
 error[E0308]: mismatched types
@@ -3298,28 +3277,28 @@ fn secondary_title_custom_level_text() {
     let s: &str = include_bytes!("file.txt");   //~ ERROR mismatched types
 }"#;
 
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308"))
-            .element(
-                Snippet::source(source)
-                    .path("$DIR/mismatched-types.rs")
-                    .annotation(
-                        AnnotationKind::Primary
-                            .span(105..131)
-                            .label("expected `&str`, found `&[u8; 0]`"),
-                    )
-                    .annotation(
-                        AnnotationKind::Context
-                            .span(98..102)
-                            .label("expected due to this"),
-                    ),
-            )
-            .element(
-                Level::NOTE
-                    .with_name(Some("custom"))
-                    .message("expected reference `&str`\nfound reference `&'static [u8; 0]`"),
-            ),
-    ];
+    let input = &[Level::ERROR
+        .primary_title("mismatched types")
+        .id("E0308")
+        .element(
+            Snippet::source(source)
+                .path("$DIR/mismatched-types.rs")
+                .annotation(
+                    AnnotationKind::Primary
+                        .span(105..131)
+                        .label("expected `&str`, found `&[u8; 0]`"),
+                )
+                .annotation(
+                    AnnotationKind::Context
+                        .span(98..102)
+                        .label("expected due to this"),
+                ),
+        )
+        .element(
+            Level::NOTE
+                .with_name(Some("custom"))
+                .message("expected reference `&str`\nfound reference `&'static [u8; 0]`"),
+        )];
 
     let expected_ascii = str![[r#"
 error[E0308]: mismatched types
@@ -3382,38 +3361,34 @@ fn main() {
 }
 "#;
     let input = &[
-        Group::with_title(
-            Level::ERROR
-                .primary_title("`break` with value from a `while` loop")
-                .id("E0571"),
-        )
-        .element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("$DIR/issue-114529-illegal-break-with-value.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(483..581)
-                        .label("can only break with a value inside `loop` or breakable block"),
-                )
-                .annotation(
-                    AnnotationKind::Context
-                        .span(462..472)
-                        .label("you can't `break` with a value in a `while` loop"),
-                ),
-        ),
-        Group::with_title(
-            Level::HELP
-                .with_name(Some("suggestion"))
-                .secondary_title("use `break` on its own without a value inside this `while` loop")
-                .id("S0123"),
-        )
-        .element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("$DIR/issue-114529-illegal-break-with-value.rs")
-                .patch(Patch::new(483..581, "break")),
-        ),
+        Level::ERROR
+            .primary_title("`break` with value from a `while` loop")
+            .id("E0571")
+            .element(
+                Snippet::source(source)
+                    .line_start(1)
+                    .path("$DIR/issue-114529-illegal-break-with-value.rs")
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(483..581)
+                            .label("can only break with a value inside `loop` or breakable block"),
+                    )
+                    .annotation(
+                        AnnotationKind::Context
+                            .span(462..472)
+                            .label("you can't `break` with a value in a `while` loop"),
+                    ),
+            ),
+        Level::HELP
+            .with_name(Some("suggestion"))
+            .secondary_title("use `break` on its own without a value inside this `while` loop")
+            .id("S0123")
+            .element(
+                Snippet::source(source)
+                    .line_start(1)
+                    .path("$DIR/issue-114529-illegal-break-with-value.rs")
+                    .patch(Patch::new(483..581, "break")),
+            ),
     ];
 
     let expected_ascii = str![[r#"
@@ -3473,17 +3448,15 @@ quack
 zappy
 "#;
 
-    let input = &[Group::with_title(
-        Level::ERROR
-            .primary_title("the size for values of type `T` cannot be known at compilation time")
-            .id("E0277"),
-    )
-    .element(
-        Snippet::source(source)
-            .line_start(8)
-            .fold(false)
-            .annotation(AnnotationKind::Primary.span(6..11)),
-    )];
+    let input = &[Level::ERROR
+        .primary_title("the size for values of type `T` cannot be known at compilation time")
+        .id("E0277")
+        .element(
+            Snippet::source(source)
+                .line_start(8)
+                .fold(false)
+                .annotation(AnnotationKind::Primary.span(6..11)),
+        )];
     let expected_ascii = str![[r#"
 error[E0277]: the size for values of type `T` cannot be known at compilation time
    |
@@ -3570,7 +3543,8 @@ fn main() {
     let long_title3 = "or use `IntoIterator::into_iter(..)` instead of `.into_iter()` to explicitly iterate by value";
 
     let input = &[
-        Group::with_title(Level::WARNING.primary_title(long_title1))
+        Level::WARNING
+            .primary_title(long_title1)
             .element(
                 Snippet::source(snippet_source)
                     .path("lint_example.rs")
@@ -3579,17 +3553,15 @@ fn main() {
             .element(Level::WARNING.message("this changes meaning in Rust 2021"))
             .element(Level::NOTE.message(long_title2))
             .element(Level::NOTE.message("`#[warn(array_into_iter)]` on by default")),
-        Group::with_title(
-            Level::HELP
-                .secondary_title("use `.iter()` instead of `.into_iter()` to avoid ambiguity"),
-        )
-        .element(
-            Snippet::source(suggestion_source)
-                .path("lint_example.rs")
-                .line_start(3)
-                .patch(Patch::new(10..19, "iter")),
-        ),
-        Group::with_title(Level::HELP.secondary_title(long_title3)).element(
+        Level::HELP
+            .secondary_title("use `.iter()` instead of `.into_iter()` to avoid ambiguity")
+            .element(
+                Snippet::source(suggestion_source)
+                    .path("lint_example.rs")
+                    .line_start(3)
+                    .patch(Patch::new(10..19, "iter")),
+            ),
+        Level::HELP.secondary_title(long_title3).element(
             Snippet::source(suggestion_source)
                 .path("lint_example.rs")
                 .line_start(3)
@@ -3663,7 +3635,8 @@ fn main() {
     let long_title3 = "or use `IntoIterator::into_iter(..)` instead of `.into_iter()` to explicitly iterate by value";
 
     let input = &[
-        Group::with_title(Level::WARNING.primary_title(long_title1))
+        Level::WARNING
+            .primary_title(long_title1)
             .element(
                 Snippet::source(snippet_source)
                     .path("lint_example.rs")
@@ -3672,17 +3645,15 @@ fn main() {
             .element(Level::WARNING.message("this changes meaning in Rust 2021"))
             .element(Level::NOTE.message(long_title2))
             .element(Level::NOTE.message("`#[warn(array_into_iter)]` on by default")),
-        Group::with_title(
-            Level::HELP
-                .secondary_title("use `.iter()` instead of `.into_iter()` to avoid ambiguity"),
-        )
-        .element(
-            Snippet::source(suggestion_source)
-                .path("lint_example.rs")
-                .line_start(3)
-                .patch(Patch::new(10..19, "iter")),
-        ),
-        Group::with_title(Level::HELP.secondary_title(long_title3)).element(
+        Level::HELP
+            .secondary_title("use `.iter()` instead of `.into_iter()` to avoid ambiguity")
+            .element(
+                Snippet::source(suggestion_source)
+                    .path("lint_example.rs")
+                    .line_start(3)
+                    .patch(Patch::new(10..19, "iter")),
+            ),
+        Level::HELP.secondary_title(long_title3).element(
             Snippet::source(suggestion_source)
                 .path("lint_example.rs")
                 .line_start(3)
@@ -3702,7 +3673,7 @@ fn snippet_no_path() {
     // Taken from: https://docs.python.org/3/library/typing.html#annotating-callable-objects
 
     let source = "def __call__(self, *vals: bytes, maxlen: int | None = None) -> list[bytes]: ...";
-    let input = &[Group::with_title(Level::ERROR.primary_title("")).element(
+    let input = &[Level::ERROR.primary_title("").element(
         Snippet::source(source).annotation(AnnotationKind::Primary.span(4..12).label("annotation")),
     )];
 
@@ -3730,7 +3701,8 @@ fn multiple_snippet_no_path() {
     // Taken from: https://docs.python.org/3/library/typing.html#annotating-callable-objects
 
     let source = "def __call__(self, *vals: bytes, maxlen: int | None = None) -> list[bytes]: ...";
-    let input = &[Group::with_title(Level::ERROR.primary_title(""))
+    let input = &[Level::ERROR
+        .primary_title("")
         .element(
             Snippet::source(source)
                 .annotation(AnnotationKind::Primary.span(4..12).label("annotation")),
@@ -3787,12 +3759,9 @@ fn courier_to_des_moines_and_points_west(data: &[u32]) -> String {
 fn main() {}
 "#;
 
-    let input =
-        &[Group::with_title(
-            Level::ERROR
-                .primary_title("type annotations needed")
-                .id("E0282"),
-        )
+    let input = &[Level::ERROR
+        .primary_title("type annotations needed")
+        .id("E0282")
         .element(
             Snippet::source(source)
                 .path("$DIR/issue-42234-unknown-receiver-type.rs")
@@ -3846,20 +3815,19 @@ fn main() {}
 "#;
 
     let input = &[
-        Group::with_title(
-            Level::ERROR
-                .primary_title("type annotations needed")
-                .id("E0282"),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/issue-42234-unknown-receiver-type.rs")
-                .annotation(AnnotationKind::Primary.span(449..452).label(
-                    "cannot infer type of the type parameter `S` declared on the method `sum`",
-                )),
-        )
-        .element(Padding),
-        Group::with_title(Level::HELP.secondary_title("consider specifying the generic argument"))
+        Level::ERROR
+            .primary_title("type annotations needed")
+            .id("E0282")
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/issue-42234-unknown-receiver-type.rs")
+                    .annotation(AnnotationKind::Primary.span(449..452).label(
+                        "cannot infer type of the type parameter `S` declared on the method `sum`",
+                    )),
+            )
+            .element(Padding),
+        Level::HELP
+            .secondary_title("consider specifying the generic argument")
             .element(
                 Snippet::source(source)
                     .path("$DIR/issue-42234-unknown-receiver-type.rs")
@@ -3923,19 +3891,18 @@ fn main() {}
 "#;
 
     let input = &[
-        Group::with_title(
-            Level::ERROR
-                .primary_title("type annotations needed")
-                .id("E0282"),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/issue-42234-unknown-receiver-type.rs")
-                .annotation(AnnotationKind::Primary.span(449..452).label(
-                    "cannot infer type of the type parameter `S` declared on the method `sum`",
-                )),
-        ),
-        Group::with_title(Level::HELP.secondary_title("consider specifying the generic argument"))
+        Level::ERROR
+            .primary_title("type annotations needed")
+            .id("E0282")
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/issue-42234-unknown-receiver-type.rs")
+                    .annotation(AnnotationKind::Primary.span(449..452).label(
+                        "cannot infer type of the type parameter `S` declared on the method `sum`",
+                    )),
+            ),
+        Level::HELP
+            .secondary_title("consider specifying the generic argument")
             .element(
                 Snippet::source(source)
                     .path("$DIR/issue-42234-unknown-receiver-type.rs")
@@ -3987,17 +3954,15 @@ quack
 zappy
 "#;
 
-    let input = &[Group::with_title(
-        Level::ERROR
-            .primary_title("the size for values of type `T` cannot be known at compilation time")
-            .id("E0277"),
-    )
-    .element(
-        Snippet::source(source)
-            .line_start(11)
-            .annotation(AnnotationKind::Primary.span(1..6))
-            .annotation(AnnotationKind::Visible.span(37..41)),
-    )];
+    let input = &[Level::ERROR
+        .primary_title("the size for values of type `T` cannot be known at compilation time")
+        .id("E0277")
+        .element(
+            Snippet::source(source)
+                .line_start(11)
+                .annotation(AnnotationKind::Primary.span(1..6))
+                .annotation(AnnotationKind::Visible.span(37..41)),
+        )];
     let expected_ascii = str![[r#"
 error[E0277]: the size for values of type `T` cannot be known at compilation time
    |
@@ -4035,17 +4000,15 @@ quack
 zappy
 "#;
 
-    let input = &[Group::with_title(
-        Level::ERROR
-            .primary_title("the size for values of type `T` cannot be known at compilation time")
-            .id("E0277"),
-    )
-    .element(
-        Snippet::source(source)
-            .line_start(11)
-            .annotation(AnnotationKind::Primary.span(1..6))
-            .annotation(AnnotationKind::Visible.span(16..18)),
-    )];
+    let input = &[Level::ERROR
+        .primary_title("the size for values of type `T` cannot be known at compilation time")
+        .id("E0277")
+        .element(
+            Snippet::source(source)
+                .line_start(11)
+                .annotation(AnnotationKind::Primary.span(1..6))
+                .annotation(AnnotationKind::Visible.span(16..18)),
+        )];
     let expected_ascii = str![[r#"
 error[E0277]: the size for values of type `T` cannot be known at compilation time
    |
@@ -4104,21 +4067,19 @@ fn bar(t: Thing) {
 fn main() {}
 "#;
 
-    let input = &[Group::with_title(
-        Level::ERROR
-            .primary_title("no field `field` on type `Thing`")
-            .id("E0609"),
-    )
-    .element(Level::NOTE.message("a `Title` then a `Message`!?!?"))
-    .element(
-        Snippet::source(source)
-            .path("$DIR/too-many-field-suggestions.rs")
-            .annotation(
-                AnnotationKind::Primary
-                    .span(270..275)
-                    .label("unknown field"),
-            ),
-    )];
+    let input = &[Level::ERROR
+        .primary_title("no field `field` on type `Thing`")
+        .id("E0609")
+        .element(Level::NOTE.message("a `Title` then a `Message`!?!?"))
+        .element(
+            Snippet::source(source)
+                .path("$DIR/too-many-field-suggestions.rs")
+                .annotation(
+                    AnnotationKind::Primary
+                        .span(270..275)
+                        .label("unknown field"),
+                ),
+        )];
 
     let expected_ascii = str![[r#"
 error[E0609]: no field `field` on type `Thing`
@@ -4161,14 +4122,12 @@ fn multiple_line_num_widths() {
 
     let title = "invalid character `^` in path base name: `^^not-valid^^`, the first character must be a Unicode XID start character (most letters or `_`)";
 
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title(title)).element(
-            Snippet::source(source)
-                .path("Cargo.toml")
-                .annotation(AnnotationKind::Primary.span(243..282))
-                .annotation(AnnotationKind::Visible.span(206..219)),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title(title).element(
+        Snippet::source(source)
+            .path("Cargo.toml")
+            .annotation(AnnotationKind::Primary.span(243..282))
+            .annotation(AnnotationKind::Visible.span(206..219)),
+    )];
 
     let expected_ascii = str![[r#"
 error: invalid character `^` in path base name: `^^not-valid^^`, the first character must be a Unicode XID start character (most letters or `_`)
@@ -4202,14 +4161,12 @@ fn tab() {
 
     let title = "showing how tabs are rendered";
 
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title(title)).element(
-            Snippet::source(source)
-                .path("tabbed.txt")
-                .annotation(AnnotationKind::Primary.span(2..3))
-                .annotation(AnnotationKind::Context.span(5..6)),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title(title).element(
+        Snippet::source(source)
+            .path("tabbed.txt")
+            .annotation(AnnotationKind::Primary.span(2..3))
+            .annotation(AnnotationKind::Context.span(5..6)),
+    )];
 
     let expected_ascii = str![[r#"
 error: showing how tabs are rendered
@@ -4242,14 +4199,12 @@ fn duplicate_annotations() {
 
             foobar 🚀
 "#;
-    let report = &[
-        Group::with_title(Level::WARNING.primary_title("whatever")).element(
-            Snippet::source(source)
-                .path("whatever")
-                .annotation(AnnotationKind::Primary.span(0..source.len()).label("blah"))
-                .annotation(AnnotationKind::Primary.span(0..source.len()).label("blah")),
-        ),
-    ];
+    let report = &[Level::WARNING.primary_title("whatever").element(
+        Snippet::source(source)
+            .path("whatever")
+            .annotation(AnnotationKind::Primary.span(0..source.len()).label("blah"))
+            .annotation(AnnotationKind::Primary.span(0..source.len()).label("blah")),
+    )];
 
     let expected_ascii = str![[r#"
 warning: whatever
@@ -4288,23 +4243,21 @@ fn alignment() {
 
     let title = "ensure single line at line 0 rendered correctly with group line lined up";
 
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title(title)).element(
-            Snippet::source(source)
-                .path("Cargo.toml")
-                .line_start(0)
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(7..10)
-                        .label("unexpected token"),
-                )
-                .annotation(
-                    AnnotationKind::Visible
-                        .span(0..10)
-                        .label("while parsing statement"),
-                ),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title(title).element(
+        Snippet::source(source)
+            .path("Cargo.toml")
+            .line_start(0)
+            .annotation(
+                AnnotationKind::Primary
+                    .span(7..10)
+                    .label("unexpected token"),
+            )
+            .annotation(
+                AnnotationKind::Visible
+                    .span(0..10)
+                    .label("while parsing statement"),
+            ),
+    )];
 
     let expected_ascii = str![[r#"
 error: ensure single line at line 0 rendered correctly with group line lined up

--- a/tests/rustc_tests.rs
+++ b/tests/rustc_tests.rs
@@ -13,14 +13,12 @@ fn ends_on_col0() {
 fn foo() {
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(AnnotationKind::Primary.span(10..13).label("test")),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(AnnotationKind::Primary.span(10..13).label("test")),
+    )];
 
     let expected_ascii = str![[r#"
 error: foo
@@ -54,14 +52,12 @@ fn foo() {
 
   }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(AnnotationKind::Primary.span(10..17).label("test")),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(AnnotationKind::Primary.span(10..17).label("test")),
+    )];
     let expected_ascii = str![[r#"
 error: foo
  --> test.rs:2:10
@@ -97,23 +93,21 @@ fn foo() {
   X2 Y2
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(14..32)
-                        .label("`X` is a good letter"),
-                )
-                .annotation(
-                    AnnotationKind::Context
-                        .span(17..35)
-                        .label("`Y` is a good letter too"),
-                ),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(
+                AnnotationKind::Primary
+                    .span(14..32)
+                    .label("`X` is a good letter"),
+            )
+            .annotation(
+                AnnotationKind::Context
+                    .span(17..35)
+                    .label("`Y` is a good letter too"),
+            ),
+    )];
 
     let expected_ascii = str![[r#"
 error: foo
@@ -155,23 +149,21 @@ fn foo() {
   Y1 X1
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(14..27)
-                        .label("`X` is a good letter"),
-                )
-                .annotation(
-                    AnnotationKind::Context
-                        .span(17..24)
-                        .label("`Y` is a good letter too"),
-                ),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(
+                AnnotationKind::Primary
+                    .span(14..27)
+                    .label("`X` is a good letter"),
+            )
+            .annotation(
+                AnnotationKind::Context
+                    .span(17..24)
+                    .label("`Y` is a good letter too"),
+            ),
+    )];
 
     let expected_ascii = str![[r#"
 error: foo
@@ -213,23 +205,21 @@ fn foo() {
   X3 Y3 Z3
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(17..38)
-                        .label("`X` is a good letter"),
-                )
-                .annotation(
-                    AnnotationKind::Context
-                        .span(31..49)
-                        .label("`Y` is a good letter too"),
-                ),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(
+                AnnotationKind::Primary
+                    .span(17..38)
+                    .label("`X` is a good letter"),
+            )
+            .annotation(
+                AnnotationKind::Context
+                    .span(31..49)
+                    .label("`Y` is a good letter too"),
+            ),
+    )];
 
     let expected_ascii = str![[r#"
 error: foo
@@ -272,24 +262,22 @@ fn foo() {
   X2 Y2 Z2
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(14..38)
-                        .label("`X` is a good letter"),
-                )
-                .annotation(
-                    AnnotationKind::Context
-                        .span(17..41)
-                        .label("`Y` is a good letter too"),
-                )
-                .annotation(AnnotationKind::Context.span(20..44).label("`Z` label")),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(
+                AnnotationKind::Primary
+                    .span(14..38)
+                    .label("`X` is a good letter"),
+            )
+            .annotation(
+                AnnotationKind::Context
+                    .span(17..41)
+                    .label("`Y` is a good letter too"),
+            )
+            .annotation(AnnotationKind::Context.span(20..44).label("`Z` label")),
+    )];
 
     let expected_ascii = str![[r#"
 error: foo
@@ -336,24 +324,22 @@ fn foo() {
   X2 Y2 Z2
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(14..38)
-                        .label("`X` is a good letter"),
-                )
-                .annotation(
-                    AnnotationKind::Context
-                        .span(14..38)
-                        .label("`Y` is a good letter too"),
-                )
-                .annotation(AnnotationKind::Context.span(14..38).label("`Z` label")),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(
+                AnnotationKind::Primary
+                    .span(14..38)
+                    .label("`X` is a good letter"),
+            )
+            .annotation(
+                AnnotationKind::Context
+                    .span(14..38)
+                    .label("`Y` is a good letter too"),
+            )
+            .annotation(AnnotationKind::Context.span(14..38).label("`Z` label")),
+    )];
 
     // This should have a `^` but we currently don't support the idea of a
     // "primary" annotation, which would solve this
@@ -399,24 +385,22 @@ fn foo() {
   X3 Y3 Z3
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(17..27)
-                        .label("`X` is a good letter"),
-                )
-                .annotation(
-                    AnnotationKind::Context
-                        .span(28..44)
-                        .label("`Y` is a good letter too"),
-                )
-                .annotation(AnnotationKind::Context.span(36..52).label("`Z`")),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(
+                AnnotationKind::Primary
+                    .span(17..27)
+                    .label("`X` is a good letter"),
+            )
+            .annotation(
+                AnnotationKind::Context
+                    .span(28..44)
+                    .label("`Y` is a good letter too"),
+            )
+            .annotation(AnnotationKind::Context.span(36..52).label("`Z`")),
+    )];
 
     let expected_ascii = str![[r#"
 error: foo
@@ -468,23 +452,21 @@ fn foo() {
   X3 Y3 Z3
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(14..27)
-                        .label("`X` is a good letter"),
-                )
-                .annotation(
-                    AnnotationKind::Context
-                        .span(39..55)
-                        .label("`Y` is a good letter too"),
-                ),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(
+                AnnotationKind::Primary
+                    .span(14..27)
+                    .label("`X` is a good letter"),
+            )
+            .annotation(
+                AnnotationKind::Context
+                    .span(39..55)
+                    .label("`Y` is a good letter too"),
+            ),
+    )];
 
     let expected_ascii = str![[r#"
 error: foo
@@ -526,23 +508,21 @@ fn foo() {
   X3 Y3 Z3
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(17..27)
-                        .label("`X` is a good letter"),
-                )
-                .annotation(
-                    AnnotationKind::Context
-                        .span(31..55)
-                        .label("`Y` is a good letter too"),
-                ),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(
+                AnnotationKind::Primary
+                    .span(17..27)
+                    .label("`X` is a good letter"),
+            )
+            .annotation(
+                AnnotationKind::Context
+                    .span(31..55)
+                    .label("`Y` is a good letter too"),
+            ),
+    )];
 
     let expected_ascii = str![[r#"
 error: foo
@@ -585,20 +565,18 @@ fn foo() {
   a { b { c } d }
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(AnnotationKind::Primary.span(18..25).label(""))
-                .annotation(
-                    AnnotationKind::Context
-                        .span(14..27)
-                        .label("`a` is a good letter"),
-                )
-                .annotation(AnnotationKind::Context.span(22..23).label("")),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(AnnotationKind::Primary.span(18..25).label(""))
+            .annotation(
+                AnnotationKind::Context
+                    .span(14..27)
+                    .label("`a` is a good letter"),
+            )
+            .annotation(AnnotationKind::Context.span(22..23).label("")),
+    )];
 
     let expected_ascii = str![[r#"
 error: foo
@@ -627,19 +605,17 @@ fn foo() {
   a { b { c } d }
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(14..27)
-                        .label("`a` is a good letter"),
-                )
-                .annotation(AnnotationKind::Context.span(18..25).label("")),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(
+                AnnotationKind::Primary
+                    .span(14..27)
+                    .label("`a` is a good letter"),
+            )
+            .annotation(AnnotationKind::Context.span(18..25).label("")),
+    )];
 
     let expected_ascii = str![[r#"
 error: foo
@@ -668,20 +644,18 @@ fn foo() {
   a { b { c } d }
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(18..25)
-                        .label("`b` is a good letter"),
-                )
-                .annotation(AnnotationKind::Context.span(14..27).label(""))
-                .annotation(AnnotationKind::Context.span(22..23).label("")),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(
+                AnnotationKind::Primary
+                    .span(18..25)
+                    .label("`b` is a good letter"),
+            )
+            .annotation(AnnotationKind::Context.span(14..27).label(""))
+            .annotation(AnnotationKind::Context.span(22..23).label("")),
+    )];
 
     let expected_ascii = str![[r#"
 error: foo
@@ -714,19 +688,17 @@ fn foo() {
   a { b { c } d }
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(AnnotationKind::Primary.span(14..27).label(""))
-                .annotation(
-                    AnnotationKind::Context
-                        .span(18..25)
-                        .label("`b` is a good letter"),
-                ),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(AnnotationKind::Primary.span(14..27).label(""))
+            .annotation(
+                AnnotationKind::Context
+                    .span(18..25)
+                    .label("`b` is a good letter"),
+            ),
+    )];
 
     let expected_ascii = str![[r#"
 error: foo
@@ -759,19 +731,17 @@ fn foo() {
   a  bc  d
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(14..18)
-                        .label("`a` is a good letter"),
-                )
-                .annotation(AnnotationKind::Context.span(18..22).label("")),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(
+                AnnotationKind::Primary
+                    .span(14..18)
+                    .label("`a` is a good letter"),
+            )
+            .annotation(AnnotationKind::Context.span(18..22).label("")),
+    )];
 
     let expected_ascii = str![[r#"
 error: foo
@@ -804,15 +774,13 @@ fn foo() {
   a { b { c } d }
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(AnnotationKind::Primary.span(14..27).label(""))
-                .annotation(AnnotationKind::Context.span(18..25).label("")),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(AnnotationKind::Primary.span(14..27).label(""))
+            .annotation(AnnotationKind::Context.span(18..25).label("")),
+    )];
 
     let expected_ascii = str![[r#"
 error: foo
@@ -841,16 +809,14 @@ fn foo() {
   a { b { c } d }
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(AnnotationKind::Primary.span(18..25).label(""))
-                .annotation(AnnotationKind::Context.span(14..27).label(""))
-                .annotation(AnnotationKind::Context.span(22..23).label("")),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(AnnotationKind::Primary.span(18..25).label(""))
+            .annotation(AnnotationKind::Context.span(14..27).label(""))
+            .annotation(AnnotationKind::Context.span(22..23).label("")),
+    )];
 
     let expected_ascii = str![[r#"
 error: foo
@@ -879,23 +845,21 @@ fn foo() {
   a { b { c } d }
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(14..27)
-                        .label("`a` is a good letter"),
-                )
-                .annotation(
-                    AnnotationKind::Context
-                        .span(18..25)
-                        .label("`b` is a good letter"),
-                ),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(
+                AnnotationKind::Primary
+                    .span(14..27)
+                    .label("`a` is a good letter"),
+            )
+            .annotation(
+                AnnotationKind::Context
+                    .span(18..25)
+                    .label("`b` is a good letter"),
+            ),
+    )];
 
     let expected_ascii = str![[r#"
 error: foo
@@ -930,18 +894,16 @@ fn foo() {
   a { b { c } d }
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(14..27)
-                        .label("`a` is a good letter"),
-                ),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(
+                AnnotationKind::Primary
+                    .span(14..27)
+                    .label("`a` is a good letter"),
+            ),
+    )];
 
     let expected_ascii = str![[r#"
 error: foo
@@ -970,14 +932,12 @@ fn foo() {
   a { b { c } d }
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(AnnotationKind::Primary.span(14..27).label("")),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(AnnotationKind::Primary.span(14..27).label("")),
+    )];
 
     let expected_ascii = str![[r#"
 error: foo
@@ -1019,23 +979,21 @@ fn foo() {
   X3 Y3 Z3
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(17..27)
-                        .label("`X` is a good letter"),
-                )
-                .annotation(
-                    AnnotationKind::Context
-                        .span(31..76)
-                        .label("`Y` is a good letter too"),
-                ),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(
+                AnnotationKind::Primary
+                    .span(17..27)
+                    .label("`X` is a good letter"),
+            )
+            .annotation(
+                AnnotationKind::Context
+                    .span(31..76)
+                    .label("`Y` is a good letter too"),
+            ),
+    )];
 
     let expected_ascii = str![[r#"
 error: foo
@@ -1099,23 +1057,21 @@ fn foo() {
   X3 Y3 Z3
 }
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("foo")).element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("test.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(17..73)
-                        .label("`Y` is a good letter"),
-                )
-                .annotation(
-                    AnnotationKind::Context
-                        .span(37..56)
-                        .label("`Z` is a good letter too"),
-                ),
-        ),
-    ];
+    let input = &[Level::ERROR.primary_title("foo").element(
+        Snippet::source(source)
+            .line_start(1)
+            .path("test.rs")
+            .annotation(
+                AnnotationKind::Primary
+                    .span(17..73)
+                    .label("`Y` is a good letter"),
+            )
+            .annotation(
+                AnnotationKind::Context
+                    .span(37..56)
+                    .label("`Z` is a good letter too"),
+            ),
+    )];
 
     let expected_ascii = str![[r#"
 error: foo
@@ -1176,30 +1132,29 @@ fn issue_91334() {
 
 fn f(){||yield(((){),
 "#;
-    let input = &[Group::with_title(
-        Level::ERROR.primary_title("this file contains an unclosed delimiter"),
-    )
-    .element(
-        Snippet::source(source)
-            .line_start(1)
-            .path("$DIR/issue-91334.rs")
-            .annotation(
-                AnnotationKind::Context
-                    .span(151..152)
-                    .label("unclosed delimiter"),
-            )
-            .annotation(
-                AnnotationKind::Context
-                    .span(159..160)
-                    .label("unclosed delimiter"),
-            )
-            .annotation(
-                AnnotationKind::Context
-                    .span(164..164)
-                    .label("missing open `(` for this delimiter"),
-            )
-            .annotation(AnnotationKind::Primary.span(167..167)),
-    )];
+    let input = &[Level::ERROR
+        .primary_title("this file contains an unclosed delimiter")
+        .element(
+            Snippet::source(source)
+                .line_start(1)
+                .path("$DIR/issue-91334.rs")
+                .annotation(
+                    AnnotationKind::Context
+                        .span(151..152)
+                        .label("unclosed delimiter"),
+                )
+                .annotation(
+                    AnnotationKind::Context
+                        .span(159..160)
+                        .label("unclosed delimiter"),
+                )
+                .annotation(
+                    AnnotationKind::Context
+                        .span(164..164)
+                        .label("missing open `(` for this delimiter"),
+                )
+                .annotation(AnnotationKind::Primary.span(167..167)),
+        )];
     let expected_ascii = str![[r#"
 error: this file contains an unclosed delimiter
   --> $DIR/issue-91334.rs:7:23
@@ -1260,36 +1215,32 @@ fn main() {
 }
 "#;
     let input = &[
-        Group::with_title(
-            Level::ERROR
-                .primary_title("`break` with value from a `while` loop")
-                .id("E0571"),
-        )
-        .element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("$DIR/issue-114529-illegal-break-with-value.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(483..581)
-                        .label("can only break with a value inside `loop` or breakable block"),
-                )
-                .annotation(
-                    AnnotationKind::Context
-                        .span(462..472)
-                        .label("you can't `break` with a value in a `while` loop"),
-                ),
-        ),
-        Group::with_title(
-            Level::HELP
-                .secondary_title("use `break` on its own without a value inside this `while` loop"),
-        )
-        .element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("$DIR/issue-114529-illegal-break-with-value.rs")
-                .annotation(AnnotationKind::Context.span(483..581).label("break")),
-        ),
+        Level::ERROR
+            .primary_title("`break` with value from a `while` loop")
+            .id("E0571")
+            .element(
+                Snippet::source(source)
+                    .line_start(1)
+                    .path("$DIR/issue-114529-illegal-break-with-value.rs")
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(483..581)
+                            .label("can only break with a value inside `loop` or breakable block"),
+                    )
+                    .annotation(
+                        AnnotationKind::Context
+                            .span(462..472)
+                            .label("you can't `break` with a value in a `while` loop"),
+                    ),
+            ),
+        Level::HELP
+            .secondary_title("use `break` on its own without a value inside this `while` loop")
+            .element(
+                Snippet::source(source)
+                    .line_start(1)
+                    .path("$DIR/issue-114529-illegal-break-with-value.rs")
+                    .annotation(AnnotationKind::Context.span(483..581).label("break")),
+            ),
     ];
     let expected_ascii = str![[r#"
 error[E0571]: `break` with value from a `while` loop
@@ -1487,39 +1438,37 @@ fn nsize() {
     }
 }
 "#;
-    let input = &[
-        Group::with_title(
+    let input =
+        &[
             Level::ERROR
                 .primary_title("`V0usize` cannot be safely transmuted into `[usize; 2]`")
-                .id("E0277"),
-        )
-        .element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("$DIR/primitive_reprs_should_have_correct_length.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(4375..4381)
-                        .label("the size of `V0usize` is smaller than the size of `[usize; 2]`"),
+                .id("E0277")
+                .element(
+                    Snippet::source(source)
+                        .line_start(1)
+                        .path("$DIR/primitive_reprs_should_have_correct_length.rs")
+                        .annotation(AnnotationKind::Primary.span(4375..4381).label(
+                            "the size of `V0usize` is smaller than the size of `[usize; 2]`",
+                        )),
                 ),
-        ),
-        Group::with_title(Level::NOTE.secondary_title("required by a bound in `is_transmutable`"))
-            .element(
-                Snippet::source(source)
-                    .line_start(1)
-                    .path("$DIR/primitive_reprs_should_have_correct_length.rs")
-                    .annotation(
-                        AnnotationKind::Context
-                            .span(225..240)
-                            .label("required by a bound in this function"),
-                    )
-                    .annotation(
-                        AnnotationKind::Primary
-                            .span(276..470)
-                            .label("required by this bound in `is_transmutable`"),
-                    ),
-            ),
-    ];
+            Level::NOTE
+                .secondary_title("required by a bound in `is_transmutable`")
+                .element(
+                    Snippet::source(source)
+                        .line_start(1)
+                        .path("$DIR/primitive_reprs_should_have_correct_length.rs")
+                        .annotation(
+                            AnnotationKind::Context
+                                .span(225..240)
+                                .label("required by a bound in this function"),
+                        )
+                        .annotation(
+                            AnnotationKind::Primary
+                                .span(276..470)
+                                .label("required by this bound in `is_transmutable`"),
+                        ),
+                ),
+        ];
     let expected_ascii = str![[r#"
 error[E0277]: `V0usize` cannot be safely transmuted into `[usize; 2]`
   --> $DIR/primitive_reprs_should_have_correct_length.rs:144:44
@@ -1597,9 +1546,9 @@ fn main() {
     assert::is_maybe_transmutable::<&'static [u8; 0], &'static [u16; 0]>(); //~ ERROR `&[u8; 0]` cannot be safely transmuted into `&[u16; 0]`
 }
 "#;
-    let input = &[Group::with_title(Level::ERROR
+    let input = &[Level::ERROR
         .primary_title("`&[u8; 0]` cannot be safely transmuted into `&[u16; 0]`")
-        .id("E027s7")).element(
+        .id("E027s7").element(
                 Snippet::source(source)
                     .line_start(1)
 
@@ -1673,32 +1622,29 @@ fn g() {
 }
 fn main() {}
 "#;
-    let input = &[Group::with_title(
-        Level::ERROR
+    let input =
+        &[Level::ERROR
             .primary_title("expected function, found `{integer}`")
-            .id("E0618"),
-    )
-    .element(
-        Snippet::source(source)
-            .line_start(1)
-            .path("$DIR/missing-semicolon.rs")
-            .annotation(
-                AnnotationKind::Context
-                    .span(108..144)
-                    .label("call expression requires function"),
-            )
-            .annotation(
-                AnnotationKind::Context
-                    .span(89..90)
-                    .label("`x` has type `{integer}`"),
-            )
-            .annotation(
-                AnnotationKind::Context
-                    .span(109..109)
-                    .label("help: consider using a semicolon here to finish the statement: `;`"),
-            )
-            .annotation(AnnotationKind::Primary.span(108..109)),
-    )];
+            .id("E0618")
+            .element(
+                Snippet::source(source)
+                    .line_start(1)
+                    .path("$DIR/missing-semicolon.rs")
+                    .annotation(
+                        AnnotationKind::Context
+                            .span(108..144)
+                            .label("call expression requires function"),
+                    )
+                    .annotation(
+                        AnnotationKind::Context
+                            .span(89..90)
+                            .label("`x` has type `{integer}`"),
+                    )
+                    .annotation(AnnotationKind::Context.span(109..109).label(
+                        "help: consider using a semicolon here to finish the statement: `;`",
+                    ))
+                    .annotation(AnnotationKind::Primary.span(108..109)),
+            )];
     let expected_ascii = str![[r#"
 error[E0618]: expected function, found `{integer}`
   --> $DIR/missing-semicolon.rs:5:13
@@ -1782,8 +1728,8 @@ macro_rules! outer_macro {
 outer_macro!(FirstStruct, FirstAttrStruct);
 "#;
     let input =
-           &[ Group::with_title(Level::WARNING
-                .primary_title("non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module"))
+           &[ Level::WARNING
+                .primary_title("non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module")
                 .element(
                     Snippet::source(aux_source)
                         .line_start(1)
@@ -1815,7 +1761,7 @@ outer_macro!(FirstStruct, FirstAttrStruct);
                     Level::NOTE
                         .message("a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute")
                 ),
-            Group::with_title(Level::NOTE.secondary_title("the lint level is defined here"))
+            Level::NOTE.secondary_title("the lint level is defined here")
                 .element(
                     Snippet::source(source)
                         .line_start(1)
@@ -1941,26 +1887,23 @@ macro_rules! inline {
 }
 "#;
     let input = &[
-        Group::with_title(
-            Level::ERROR
-                .primary_title("can't call method `pow` on ambiguous numeric type `{integer}`")
-                .id("E0689"),
-        )
-        .element(
-            Snippet::source(source)
-                .line_start(1)
-                .path("$DIR/method-on-ambiguous-numeric-type.rs")
-                .annotation(AnnotationKind::Primary.span(916..919)),
-        ),
-        Group::with_title(
-            Level::HELP.secondary_title("you must specify a type for this binding, like `i32`"),
-        )
-        .element(
-            Snippet::source(aux_source)
-                .line_start(1)
-                .path("$DIR/auxiliary/macro-in-other-crate.rs")
-                .annotation(AnnotationKind::Context.span(69..69).label(": i32")),
-        ),
+        Level::ERROR
+            .primary_title("can't call method `pow` on ambiguous numeric type `{integer}`")
+            .id("E0689")
+            .element(
+                Snippet::source(source)
+                    .line_start(1)
+                    .path("$DIR/method-on-ambiguous-numeric-type.rs")
+                    .annotation(AnnotationKind::Primary.span(916..919)),
+            ),
+        Level::HELP
+            .secondary_title("you must specify a type for this binding, like `i32`")
+            .element(
+                Snippet::source(aux_source)
+                    .line_start(1)
+                    .path("$DIR/auxiliary/macro-in-other-crate.rs")
+                    .annotation(AnnotationKind::Context.span(69..69).label(": i32")),
+            ),
     ];
     let expected_ascii = str![[r#"
 error[E0689]: can't call method `pow` on ambiguous numeric type `{integer}`
@@ -2019,12 +1962,9 @@ fn courier_to_des_moines_and_points_west(data: &[u32]) -> String {
 fn main() {}
 "#;
 
-    let input =
-        &[Group::with_title(
-            Level::ERROR
-                .primary_title("type annotations needed")
-                .id("E0282"),
-        )
+    let input = &[Level::ERROR
+        .primary_title("type annotations needed")
+        .id("E0282")
         .element(
             Snippet::source(source)
                 .line_start(1)
@@ -2136,22 +2076,23 @@ fn main() {}
 "##;
 
     let input =
-           &[ Group::with_title( Level::ERROR
+           &[Level::ERROR
                 .primary_title(
                     "non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered"
                 )
-                .id("E0004")).element(
-                Snippet::source(source)
-                    .line_start(1)
-                    .path("$DIR/empty-match.rs")
+                .id("E0004")
+                .element(
+                    Snippet::source(source)
+                        .line_start(1)
+                        .path("$DIR/empty-match.rs")
 
-                    .annotation(
-                        AnnotationKind::Primary
-                            .span(2911..2928)
-                            .label("patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered")
-                    ),
-            ),
-            Group::with_title(Level::NOTE.secondary_title("`NonEmptyEnum5` defined here"))
+                        .annotation(
+                            AnnotationKind::Primary
+                                .span(2911..2928)
+                                .label("patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered")
+                        ),
+                ),
+            Level::NOTE.secondary_title("`NonEmptyEnum5` defined here")
                 .element(
                     Snippet::source(source)
                         .line_start(1)
@@ -2166,19 +2107,16 @@ fn main() {}
                 )
                 .element(Level::NOTE.message("the matched value is of type `NonEmptyEnum5`"))
                 .element(Level::NOTE.message("match arms with guards don't count towards exhaustivity")
-        ),
-            Group::with_title(
-                    Level::HELP
-                        .secondary_title("ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms")
-                )
+            ),
+            Level::HELP
+                .secondary_title("ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms")
                 .element(
                     Snippet::source(source)
                         .line_start(1)
                         .path("$DIR/empty-match.rs")
-
                         .annotation(AnnotationKind::Context.span(485..485).label(",\n                _ => todo!()"))
-
-        )];
+            )
+    ];
     let expected_ascii = str![[r#"
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
   --> $DIR/empty-match.rs:71:24
@@ -2265,9 +2203,9 @@ fn main() {
     //~^ ERROR must be specified
 }
 "#;
-    let input = &[Group::with_title(Level::ERROR
+    let input = &[Level::ERROR
         .primary_title("the trait alias `EqAlias` is not dyn compatible")
-        .id("E0038")).element(
+        .id("E0038").element(
                 Snippet::source(source)
                     .line_start(1)
                     .path("$DIR/object-fail.rs")
@@ -2278,9 +2216,8 @@ fn main() {
                             .label("`EqAlias` is not dyn compatible"),
                     ),
             ),
-            Group::with_title(
                     Level::NOTE
-                        .secondary_title("for a trait to be dyn compatible it needs to allow building a vtable\nfor more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>"))
+                        .secondary_title("for a trait to be dyn compatible it needs to allow building a vtable\nfor more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>")
                 .element(
                     Origin::path("$SRC_DIR/core/src/cmp.rs")
                         .line(334)
@@ -2351,8 +2288,10 @@ const C: u8 = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 
 fn main() {}
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0038")).element(
+    let input = &[Level::ERROR
+        .primary_title("mismatched types")
+        .id("E0038")
+        .element(
             Snippet::source(source)
                 .path("$DIR/long-span.rs")
                 .annotation(
@@ -2360,8 +2299,7 @@ fn main() {}
                         .span(15..5055)
                         .label("expected `u8`, found `[{integer}; 1680]`"),
                 ),
-        ),
-    ];
+        )];
     let expected_ascii = str![[r#"
 error[E0038]: mismatched types
   --> $DIR/long-span.rs:2:15
@@ -2394,8 +2332,10 @@ const C: u8 = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 
 fn main() {}
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0038")).element(
+    let input = &[Level::ERROR
+        .primary_title("mismatched types")
+        .id("E0038")
+        .element(
             Snippet::source(source)
                 .path("$DIR/long-span.rs")
                 .annotation(
@@ -2403,8 +2343,7 @@ fn main() {}
                         .span(15..5055)
                         .label("expected `u8`, found `[{integer}; 1680]`"),
                 ),
-        ),
-    ];
+        )];
     let expected_ascii = str![[r#"
 error[E0038]: mismatched types
    ╭▸ $DIR/long-span.rs:2:15
@@ -2438,8 +2377,10 @@ const C: u8 = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 
 fn main() {}
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0038")).element(
+    let input = &[Level::ERROR
+        .primary_title("mismatched types")
+        .id("E0038")
+        .element(
             Snippet::source(source)
                 .path("$DIR/long-span.rs")
                 .annotation(
@@ -2447,8 +2388,7 @@ fn main() {}
                         .span(15..5055)
                         .label("expected `u8`, found `[{integer}; 1680]`"),
                 ),
-        ),
-    ];
+        )];
     let expected_ascii = str![[r#"
 error[E0038]: mismatched types
    ╭▸ $DIR/long-span.rs:2:15
@@ -2482,8 +2422,10 @@ const C: u8 = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 
 fn main() {}
 "#;
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0038")).element(
+    let input = &[Level::ERROR
+        .primary_title("mismatched types")
+        .id("E0038")
+        .element(
             Snippet::source(source)
                 .path("$DIR/long-span.rs")
                 .annotation(
@@ -2491,8 +2433,7 @@ fn main() {}
                         .span(15..5055)
                         .label("expected `u8`, found `[{integer}; 1680]`"),
                 ),
-        ),
-    ];
+        )];
     let expected_ascii = str![[r#"
 error[E0038]: mismatched types
   --> $DIR/long-span.rs:2:15
@@ -2542,8 +2483,8 @@ fn main() {
 }
 "#;
 
-    let input = &[Group::with_title(Level::ERROR
-        .primary_title("`Iterator::map` call that discard the iterator's values"))
+    let input = &[Level::ERROR
+        .primary_title("`Iterator::map` call that discard the iterator's values")
                 .element(
                     Snippet::source(source)
                         .path("$DIR/lint_map_unit_fn.rs")
@@ -2565,7 +2506,7 @@ fn main() {
                 )
                 .element(
                     Level::NOTE.message("`Iterator::map`, like many of the methods on `Iterator`, gets executed lazily, meaning that its effects won't be visible until it is iterated")),
-            Group::with_title(Level::HELP.secondary_title("you might have meant to use `Iterator::for_each`"))
+            Level::HELP.secondary_title("you might have meant to use `Iterator::for_each`")
                 .element(
                     Snippet::source(source)
                         .path("$DIR/lint_map_unit_fn.rs")
@@ -2660,13 +2601,14 @@ fn main() {
 "#;
 
     let input = &[
-        Group::with_title(Level::ERROR.primary_title("character constant must be escaped: `\\n`"))
+        Level::ERROR
+            .primary_title("character constant must be escaped: `\\n`")
             .element(
                 Snippet::source(source)
                     .path("$DIR/bad-char-literals.rs")
                     .annotation(AnnotationKind::Primary.span(204..205)),
             ),
-        Group::with_title(Level::HELP.secondary_title("escape the character")).element(
+        Level::HELP.secondary_title("escape the character").element(
             Snippet::source(source)
                 .path("$DIR/bad-char-literals.rs")
                 .line_start(1)
@@ -2725,12 +2667,13 @@ fn main() {}
 "#;
 
     let input = &[
-        Group::with_title(Level::ERROR.primary_title("unclosed frontmatter")).element(
+        Level::ERROR.primary_title("unclosed frontmatter").element(
             Snippet::source(source)
                 .path("$DIR/unclosed-1.rs")
                 .annotation(AnnotationKind::Primary.span(0..221)),
         ),
-        Group::with_title(Level::NOTE.secondary_title("frontmatter opening here was not closed"))
+        Level::NOTE
+            .secondary_title("frontmatter opening here was not closed")
             .element(
                 Snippet::source(source)
                     .path("$DIR/unclosed-1.rs")
@@ -2796,12 +2739,13 @@ fn foo() -> &str {
 "#;
 
     let input = &[
-        Group::with_title(Level::ERROR.primary_title("unclosed frontmatter")).element(
+        Level::ERROR.primary_title("unclosed frontmatter").element(
             Snippet::source(source)
                 .path("$DIR/unclosed-2.rs")
                 .annotation(AnnotationKind::Primary.span(0..377)),
         ),
-        Group::with_title(Level::NOTE.secondary_title("frontmatter opening here was not closed"))
+        Level::NOTE
+            .secondary_title("frontmatter opening here was not closed")
             .element(
                 Snippet::source(source)
                     .path("$DIR/unclosed-2.rs")
@@ -2870,22 +2814,20 @@ fn foo(x: i32) -> i32 {
 "#;
 
     let input = &[
-        Group::with_title(
-            Level::ERROR.primary_title("invalid preceding whitespace for frontmatter close"),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/unclosed-3.rs")
-                .annotation(AnnotationKind::Primary.span(302..310)),
-        ),
-        Group::with_title(
-            Level::NOTE.secondary_title("frontmatter close should not be preceded by whitespace"),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/unclosed-3.rs")
-                .annotation(AnnotationKind::Primary.span(302..306)),
-        ),
+        Level::ERROR
+            .primary_title("invalid preceding whitespace for frontmatter close")
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/unclosed-3.rs")
+                    .annotation(AnnotationKind::Primary.span(302..310)),
+            ),
+        Level::NOTE
+            .secondary_title("frontmatter close should not be preceded by whitespace")
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/unclosed-3.rs")
+                    .annotation(AnnotationKind::Primary.span(302..306)),
+            ),
     ];
     let expected_ascii = str![[r#"
 error: invalid preceding whitespace for frontmatter close
@@ -2936,12 +2878,13 @@ fn main() {}
 "#;
 
     let input = &[
-        Group::with_title(Level::ERROR.primary_title("unclosed frontmatter")).element(
+        Level::ERROR.primary_title("unclosed frontmatter").element(
             Snippet::source(source)
                 .path("$DIR/unclosed-4.rs")
                 .annotation(AnnotationKind::Primary.span(0..43)),
         ),
-        Group::with_title(Level::NOTE.secondary_title("frontmatter opening here was not closed"))
+        Level::NOTE
+            .secondary_title("frontmatter opening here was not closed")
             .element(
                 Snippet::source(source)
                     .path("$DIR/unclosed-4.rs")
@@ -3002,12 +2945,13 @@ fn main() {}
 "#;
 
     let input = &[
-        Group::with_title(Level::ERROR.primary_title("unclosed frontmatter")).element(
+        Level::ERROR.primary_title("unclosed frontmatter").element(
             Snippet::source(source)
                 .path("$DIR/unclosed-5.rs")
                 .annotation(AnnotationKind::Primary.span(0..176)),
         ),
-        Group::with_title(Level::NOTE.secondary_title("frontmatter opening here was not closed"))
+        Level::NOTE
+            .secondary_title("frontmatter opening here was not closed")
             .element(
                 Snippet::source(source)
                     .path("$DIR/unclosed-5.rs")
@@ -3137,41 +3081,39 @@ pub enum E2 {
 "#;
 
     let input = &[
-        Group::with_title(
-            Level::ERROR
-                .primary_title(
-                    "expected unit struct, unit variant or constant, found tuple variant `E1::Z1`",
-                )
-                .id(r#"E0532"#),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/pat-tuple-field-count-cross.rs")
-                .annotation(AnnotationKind::Primary.span(1760..1766)),
-        )
-        .element(
-            Snippet::source(source1)
-                .path("$DIR/auxiliary/declarations-for-tuple-field-count-errors.rs")
-                .annotation(
-                    AnnotationKind::Context
-                        .span(143..145)
-                        .label("`E1::Z1` defined here"),
-                )
-                .annotation(
-                    AnnotationKind::Context
-                        .span(139..141)
-                        .label("similarly named unit variant `Z0` defined here"),
-                ),
-        ),
-        Group::with_title(
-            Level::HELP.secondary_title("use the tuple variant pattern syntax instead"),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/pat-tuple-field-count-cross.rs")
-                .patch(Patch::new(1760..1766, r#"E1::Z1()"#)),
-        ),
-        Group::with_title(Level::HELP.secondary_title("a unit variant with a similar name exists"))
+        Level::ERROR
+            .primary_title(
+                "expected unit struct, unit variant or constant, found tuple variant `E1::Z1`",
+            )
+            .id(r#"E0532"#)
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/pat-tuple-field-count-cross.rs")
+                    .annotation(AnnotationKind::Primary.span(1760..1766)),
+            )
+            .element(
+                Snippet::source(source1)
+                    .path("$DIR/auxiliary/declarations-for-tuple-field-count-errors.rs")
+                    .annotation(
+                        AnnotationKind::Context
+                            .span(143..145)
+                            .label("`E1::Z1` defined here"),
+                    )
+                    .annotation(
+                        AnnotationKind::Context
+                            .span(139..141)
+                            .label("similarly named unit variant `Z0` defined here"),
+                    ),
+            ),
+        Level::HELP
+            .secondary_title("use the tuple variant pattern syntax instead")
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/pat-tuple-field-count-cross.rs")
+                    .patch(Patch::new(1760..1766, r#"E1::Z1()"#)),
+            ),
+        Level::HELP
+            .secondary_title("a unit variant with a similar name exists")
             .element(
                 Snippet::source(source)
                     .path("$DIR/pat-tuple-field-count-cross.rs")
@@ -3243,29 +3185,27 @@ fn unterminated_nested_comment() {
 */
 "#;
 
-    let input = &[Group::with_title(
-        Level::ERROR
-            .primary_title("unterminated block comment")
-            .id("E0758"),
-    )
-    .element(
-        Snippet::source(source)
-            .path("$DIR/unterminated-nested-comment.rs")
-            .annotation(
-                AnnotationKind::Context
-                    .span(0..2)
-                    .label("unterminated block comment"),
-            )
-            .annotation(AnnotationKind::Context.span(25..27).label(
-                "...as last nested comment starts here, maybe you want to close this instead?",
-            ))
-            .annotation(
-                AnnotationKind::Context
-                    .span(28..30)
-                    .label("...and last nested comment terminates here."),
-            )
-            .annotation(AnnotationKind::Primary.span(0..31)),
-    )];
+    let input = &[Level::ERROR
+        .primary_title("unterminated block comment")
+        .id("E0758")
+        .element(
+            Snippet::source(source)
+                .path("$DIR/unterminated-nested-comment.rs")
+                .annotation(
+                    AnnotationKind::Context
+                        .span(0..2)
+                        .label("unterminated block comment"),
+                )
+                .annotation(AnnotationKind::Context.span(25..27).label(
+                    "...as last nested comment starts here, maybe you want to close this instead?",
+                ))
+                .annotation(
+                    AnnotationKind::Context
+                        .span(28..30)
+                        .label("...and last nested comment terminates here."),
+                )
+                .annotation(AnnotationKind::Primary.span(0..31)),
+        )];
 
     let expected_ascii = str![[r#"
 error[E0758]: unterminated block comment
@@ -3323,37 +3263,36 @@ fn mismatched_types1() {
     let s: &str = include_bytes!("file.txt");   //~ ERROR mismatched types
 }"#;
 
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308"))
-            .element(
-                Snippet::source(file_txt_source)
-                    .line_start(3)
-                    .path("$DIR/file.txt")
-                    .annotation(
-                        AnnotationKind::Primary
-                            .span(0..0)
-                            .label("expected `&[u8]`, found `&str`"),
-                    ),
-            )
-            .element(
-                Snippet::source(rust_source)
-                    .path("$DIR/mismatched-types.rs")
-                    .annotation(
-                        AnnotationKind::Context
-                            .span(23..28)
-                            .label("expected due to this"),
-                    )
-                    .annotation(
-                        AnnotationKind::Context
-                            .span(31..55)
-                            .label("in this macro invocation"),
-                    ),
-            )
-            .element(
-                Level::NOTE
-                    .message("expected reference `&[u8]`\n   found reference `&'static str`"),
-            ),
-    ];
+    let input = &[Level::ERROR
+        .primary_title("mismatched types")
+        .id("E0308")
+        .element(
+            Snippet::source(file_txt_source)
+                .line_start(3)
+                .path("$DIR/file.txt")
+                .annotation(
+                    AnnotationKind::Primary
+                        .span(0..0)
+                        .label("expected `&[u8]`, found `&str`"),
+                ),
+        )
+        .element(
+            Snippet::source(rust_source)
+                .path("$DIR/mismatched-types.rs")
+                .annotation(
+                    AnnotationKind::Context
+                        .span(23..28)
+                        .label("expected due to this"),
+                )
+                .annotation(
+                    AnnotationKind::Context
+                        .span(31..55)
+                        .label("in this macro invocation"),
+                ),
+        )
+        .element(
+            Level::NOTE.message("expected reference `&[u8]`\n   found reference `&'static str`"),
+        )];
 
     let expected_ascii = str![[r#"
 error[E0308]: mismatched types
@@ -3405,27 +3344,26 @@ fn mismatched_types2() {
     let s: &str = include_bytes!("file.txt");   //~ ERROR mismatched types
 }"#;
 
-    let input = &[
-        Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308"))
-            .element(
-                Snippet::source(source)
-                    .path("$DIR/mismatched-types.rs")
-                    .annotation(
-                        AnnotationKind::Primary
-                            .span(105..131)
-                            .label("expected `&str`, found `&[u8; 0]`"),
-                    )
-                    .annotation(
-                        AnnotationKind::Context
-                            .span(98..102)
-                            .label("expected due to this"),
-                    ),
-            )
-            .element(
-                Level::NOTE
-                    .message("expected reference `&str`\n   found reference `&'static [u8; 0]`"),
-            ),
-    ];
+    let input = &[Level::ERROR
+        .primary_title("mismatched types")
+        .id("E0308")
+        .element(
+            Snippet::source(source)
+                .path("$DIR/mismatched-types.rs")
+                .annotation(
+                    AnnotationKind::Primary
+                        .span(105..131)
+                        .label("expected `&str`, found `&[u8; 0]`"),
+                )
+                .annotation(
+                    AnnotationKind::Context
+                        .span(98..102)
+                        .label("expected due to this"),
+                ),
+        )
+        .element(
+            Level::NOTE.message("expected reference `&str`\n   found reference `&'static [u8; 0]`"),
+        )];
 
     let expected_ascii = str![[r#"
 error[E0308]: mismatched types
@@ -3474,26 +3412,31 @@ fn main() {
 "#;
 
     let input = &[
-        Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308")).element(
-            Snippet::source(source)
-                .path("$DIR/short-error-format.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(80..100)
-                        .label("expected `u32`, found `String`"),
-                )
-                .annotation(
-                    AnnotationKind::Context
-                        .span(76..79)
-                        .label("arguments to this function are incorrect"),
-                ),
-        ),
-        Group::with_title(Level::NOTE.secondary_title("function defined here")).element(
-            Snippet::source(source)
-                .path("$DIR/short-error-format.rs")
-                .annotation(AnnotationKind::Context.span(48..54).label(""))
-                .annotation(AnnotationKind::Primary.span(44..47)),
-        ),
+        Level::ERROR
+            .primary_title("mismatched types")
+            .id("E0308")
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/short-error-format.rs")
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(80..100)
+                            .label("expected `u32`, found `String`"),
+                    )
+                    .annotation(
+                        AnnotationKind::Context
+                            .span(76..79)
+                            .label("arguments to this function are incorrect"),
+                    ),
+            ),
+        Level::NOTE
+            .secondary_title("function defined here")
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/short-error-format.rs")
+                    .annotation(AnnotationKind::Context.span(48..54).label(""))
+                    .annotation(AnnotationKind::Primary.span(44..47)),
+            ),
     ];
 
     let expected_ascii = str![[r#"
@@ -3524,20 +3467,18 @@ fn main() {
 }
 "#;
 
-    let input = &[Group::with_title(
-        Level::ERROR
-            .primary_title("no method named `salut` found for type `u32` in the current scope")
-            .id("E0599"),
-    )
-    .element(
-        Snippet::source(source)
-            .path("$DIR/short-error-format.rs")
-            .annotation(
-                AnnotationKind::Primary
-                    .span(127..132)
-                    .label("method not found in `u32`"),
-            ),
-    )];
+    let input = &[Level::ERROR
+        .primary_title("no method named `salut` found for type `u32` in the current scope")
+        .id("E0599")
+        .element(
+            Snippet::source(source)
+                .path("$DIR/short-error-format.rs")
+                .annotation(
+                    AnnotationKind::Primary
+                        .span(127..132)
+                        .label("method not found in `u32`"),
+                ),
+        )];
 
     let expected_ascii = str![[r#"
 $DIR/short-error-format.rs:8:7: error[E0599]: no method named `salut` found for type `u32` in the current scope: method not found in `u32`
@@ -3566,7 +3507,8 @@ pub struct Foo; //~^ ERROR
 "#;
 
     let input = &[
-        Group::with_title(Level::ERROR.primary_title("this URL is not a hyperlink"))
+        Level::ERROR
+            .primary_title("this URL is not a hyperlink")
             .element(
                 Snippet::source(source_0)
                     .path("$DIR/diagnostic-width.rs")
@@ -3575,18 +3517,22 @@ pub struct Foo; //~^ ERROR
             .element(
                 Level::NOTE.message("bare URLs are not automatically turned into clickable links"),
             ),
-        Group::with_title(Level::NOTE.secondary_title("the lint level is defined here")).element(
-            Snippet::source(source_0)
-                .path("$DIR/diagnostic-width.rs")
-                .annotation(AnnotationKind::Primary.span(49..67)),
-        ),
-        Group::with_title(Level::HELP.secondary_title("use an automatic link instead")).element(
-            Snippet::source(source_1)
-                .path("$DIR/diagnostic-width.rs")
-                .line_start(4)
-                .patch(Patch::new(40..40, "<"))
-                .patch(Patch::new(55..55, ">")),
-        ),
+        Level::NOTE
+            .secondary_title("the lint level is defined here")
+            .element(
+                Snippet::source(source_0)
+                    .path("$DIR/diagnostic-width.rs")
+                    .annotation(AnnotationKind::Primary.span(49..67)),
+            ),
+        Level::HELP
+            .secondary_title("use an automatic link instead")
+            .element(
+                Snippet::source(source_1)
+                    .path("$DIR/diagnostic-width.rs")
+                    .line_start(4)
+                    .patch(Patch::new(40..40, "<"))
+                    .patch(Patch::new(55..55, ">")),
+            ),
     ];
 
     let expected_ascii = str![[r#"
@@ -3649,7 +3595,8 @@ fn main() {
     let long_title3 = "or use `IntoIterator::into_iter(..)` instead of `.into_iter()` to explicitly iterate by value";
 
     let input = &[
-        Group::with_title(Level::WARNING.primary_title(long_title1))
+        Level::WARNING
+            .primary_title(long_title1)
             .element(
                 Snippet::source(source1)
                     .path("lint_example.rs")
@@ -3658,17 +3605,15 @@ fn main() {
             .element(Level::WARNING.message("this changes meaning in Rust 2021"))
             .element(Level::NOTE.message(long_title2))
             .element(Level::NOTE.message("`#[warn(array_into_iter)]` on by default")),
-        Group::with_title(
-            Level::HELP
-                .secondary_title("use `.iter()` instead of `.into_iter()` to avoid ambiguity"),
-        )
-        .element(
-            Snippet::source(source2)
-                .path("lint_example.rs")
-                .line_start(3)
-                .patch(Patch::new(10..19, "iter")),
-        ),
-        Group::with_title(Level::HELP.secondary_title(long_title3)).element(
+        Level::HELP
+            .secondary_title("use `.iter()` instead of `.into_iter()` to avoid ambiguity")
+            .element(
+                Snippet::source(source2)
+                    .path("lint_example.rs")
+                    .line_start(3)
+                    .patch(Patch::new(10..19, "iter")),
+            ),
+        Level::HELP.secondary_title(long_title3).element(
             Snippet::source(source2)
                 .path("lint_example.rs")
                 .line_start(3)
@@ -3767,34 +3712,30 @@ fn main() {
 }
 "#;
     let input = &[
-        Group::with_title(
-            Level::ERROR
-                .primary_title("cannot add `Box<isize>` to `Box<isize>`")
-                .id("E0369"),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/autoderef-box-no-add.rs")
-                .annotation(AnnotationKind::Context.span(583..586).label("Box<isize>"))
-                .annotation(AnnotationKind::Context.span(589..592).label("Box<isize>"))
-                .annotation(AnnotationKind::Primary.span(587..588)),
-        ),
-        Group::with_title(
-            Level::NOTE
-                .secondary_title("the foreign item type `Box<isize>` doesn't implement `Add`"),
-        )
-        .element(
-            Origin::path("$SRC_DIR/alloc/src/boxed.rs")
-                .line(231)
-                .char_column(0),
-        )
-        .element(
-            Origin::path("$SRC_DIR/alloc/src/boxed.rs")
-                .line(234)
-                .char_column(1),
-        )
-        .element(Padding)
-        .element(Level::NOTE.message("not implement `Add`")),
+        Level::ERROR
+            .primary_title("cannot add `Box<isize>` to `Box<isize>`")
+            .id("E0369")
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/autoderef-box-no-add.rs")
+                    .annotation(AnnotationKind::Context.span(583..586).label("Box<isize>"))
+                    .annotation(AnnotationKind::Context.span(589..592).label("Box<isize>"))
+                    .annotation(AnnotationKind::Primary.span(587..588)),
+            ),
+        Level::NOTE
+            .secondary_title("the foreign item type `Box<isize>` doesn't implement `Add`")
+            .element(
+                Origin::path("$SRC_DIR/alloc/src/boxed.rs")
+                    .line(231)
+                    .char_column(0),
+            )
+            .element(
+                Origin::path("$SRC_DIR/alloc/src/boxed.rs")
+                    .line(234)
+                    .char_column(1),
+            )
+            .element(Padding)
+            .element(Level::NOTE.message("not implement `Add`")),
     ];
 
     let expected_ascii = str![[r#"
@@ -3897,7 +3838,7 @@ fn main() {
     let title_1 = "trait `Future` which provides `poll` is implemented but not in scope; perhaps you want to import it";
 
     let input = &[
-        Group::with_title(Level::ERROR.primary_title(title_0).id("E0599")).element(
+        Level::ERROR.primary_title(title_0).id("E0599").element(
             Snippet::source(source)
                 .path("$DIR/dont-project-to-specializable-projection.rs")
                 .annotation(
@@ -3922,7 +3863,7 @@ fn main() {
             .element(
                 Level::HELP.message("items from traits can only be used if the trait is in scope"),
             ),
-        Group::with_title(Level::HELP.secondary_title(title_1)).element(
+        Level::HELP.secondary_title(title_1).element(
             Snippet::source("struct MyStruct;\n")
                 .path("$DIR/dont-project-to-specializable-projection.rs")
                 .line_start(6)
@@ -4000,7 +3941,7 @@ fn main() {
         "the foreign item types don't implement required traits for this operation to be valid";
 
     let input = &[
-        Group::with_title(Level::ERROR.primary_title(title_0).id("E0369")).element(
+        Level::ERROR.primary_title(title_0).id("E0369").element(
             Snippet::source(source)
                 .path("$DIR/binary-op-not-allowed-issue-125631.rs")
                 .annotation(
@@ -4015,7 +3956,8 @@ fn main() {
                 )
                 .annotation(AnnotationKind::Primary.span(309..311)),
         ),
-        Group::with_title(Level::NOTE.secondary_title(title_1))
+        Level::NOTE
+            .secondary_title(title_1)
             .element(
                 Origin::path("$SRC_DIR/std/src/io/error.rs")
                     .line(65)
@@ -4087,18 +4029,17 @@ pub fn main() {}
 "#;
 
     let input = &[
-        Group::with_title(
-            Level::ERROR.primary_title("cannot find derive macro `Eqr` in this scope"),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/deriving-meta-unknown-trait.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(9..12)
-                        .label("help: a derive macro with a similar name exists: `Eq`"),
-                ),
-        ),
+        Level::ERROR
+            .primary_title("cannot find derive macro `Eqr` in this scope")
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/deriving-meta-unknown-trait.rs")
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(9..12)
+                            .label("help: a derive macro with a similar name exists: `Eq`"),
+                    ),
+            ),
         Group::with_level(Level::ERROR)
             .element(
                 Origin::path("$SRC_DIR/core/src/cmp.rs")
@@ -4177,7 +4118,9 @@ which is required by `Ipv4Addr: proc_macro::ext::RepToTokensExt`
 which is required by `&mut Ipv4Addr: proc_macro::ext::RepIteratorExt`"#;
 
     let input = &[
-        Group::with_title(Level::ERROR.primary_title(title_0).id("E0599"))
+        Level::ERROR
+            .primary_title(title_0)
+            .id("E0599")
             .element(
                 Snippet::source(source)
                     .path("$DIR/not-repeatable.rs")
@@ -4187,14 +4130,13 @@ which is required by `&mut Ipv4Addr: proc_macro::ext::RepIteratorExt`"#;
                     .annotation(AnnotationKind::Context.span(81..96).label(label_0)),
             )
             .element(Level::NOTE.message(title_1)),
-        Group::with_title(
-            Level::NOTE.secondary_title("the traits `Iterator` and `ToTokens` must be implemented"),
-        )
-        .element(
-            Origin::path("$SRC_DIR/proc_macro/src/to_tokens.rs")
-                .line(11)
-                .char_column(0),
-        ),
+        Level::NOTE
+            .secondary_title("the traits `Iterator` and `ToTokens` must be implemented")
+            .element(
+                Origin::path("$SRC_DIR/proc_macro/src/to_tokens.rs")
+                    .line(11)
+                    .char_column(0),
+            ),
         Group::with_level(Level::NOTE).element(
             Origin::path("$SRC_DIR/core/src/iter/traits/iterator.rs")
                 .line(39)
@@ -4291,26 +4233,24 @@ fn main() {
 }
 "#;
 
-    let input = &[Group::with_title(
-        Level::ERROR
-            .primary_title("associated type `Pr` not found for `S<bool>` in the current scope")
-            .id("E0220"),
-    )
-    .element(
-        Snippet::source(source)
-            .path("$DIR/not-found-self-type-differs-shadowing-trait-item.rs")
-            .annotation(
-                AnnotationKind::Primary
-                    .span(705..707)
-                    .label("associated item not found in `S<bool>`"),
-            )
-            .annotation(
-                AnnotationKind::Context
-                    .span(532..543)
-                    .label("associated type `Pr` not found for this struct"),
-            ),
-    )
-    .element(Level::NOTE.message("the associated type was found for\n"))];
+    let input = &[Level::ERROR
+        .primary_title("associated type `Pr` not found for `S<bool>` in the current scope")
+        .id("E0220")
+        .element(
+            Snippet::source(source)
+                .path("$DIR/not-found-self-type-differs-shadowing-trait-item.rs")
+                .annotation(
+                    AnnotationKind::Primary
+                        .span(705..707)
+                        .label("associated item not found in `S<bool>`"),
+                )
+                .annotation(
+                    AnnotationKind::Context
+                        .span(532..543)
+                        .label("associated type `Pr` not found for this struct"),
+                ),
+        )
+        .element(Level::NOTE.message("the associated type was found for\n"))];
 
     let expected_ascii = str![[r#"
 error[E0220]: associated type `Pr` not found for `S<bool>` in the current scope
@@ -4374,7 +4314,8 @@ fn main() {}
     let title_1 = "for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-extern.html>";
 
     let input = &[
-        Group::with_title(Level::ERROR.primary_title("extern blocks should be unsafe"))
+        Level::ERROR
+            .primary_title("extern blocks should be unsafe")
             .element(
                 Snippet::source(source)
                     .path("$DIR/unsafe-extern-suggestion.rs")
@@ -4387,11 +4328,13 @@ fn main() {}
             )
             .element(Level::WARNING.message(title_0))
             .element(Level::NOTE.message(title_1)),
-        Group::with_title(Level::NOTE.secondary_title("the lint level is defined here")).element(
-            Snippet::source(source)
-                .path("$DIR/unsafe-extern-suggestion.rs")
-                .annotation(AnnotationKind::Primary.span(25..49)),
-        ),
+        Level::NOTE
+            .secondary_title("the lint level is defined here")
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/unsafe-extern-suggestion.rs")
+                    .annotation(AnnotationKind::Primary.span(25..49)),
+            ),
     ];
 
     let expected_ascii = str![[r#"
@@ -4475,7 +4418,9 @@ fn panic(_: &core::panic::PanicInfo) -> ! { loop {} }
         "`core::alloc::Layout` and `Layout` have similar names, but are actually distinct types";
 
     let input = &[
-        Group::with_title(Level::ERROR.primary_title("mismatched types").id("E0308"))
+        Level::ERROR
+            .primary_title("mismatched types")
+            .id("E0308")
             .element(
                 Snippet::source(source)
                     .path("$DIR/alloc-error-handler-bad-signature-2.rs")
@@ -4496,26 +4441,28 @@ fn panic(_: &core::panic::PanicInfo) -> ! { loop {} }
                     ),
             )
             .element(Level::NOTE.message(title_0)),
-        Group::with_title(
-            Level::NOTE.secondary_title("`core::alloc::Layout` is defined in crate `core`"),
-        )
-        .element(
-            Origin::path("$SRC_DIR/core/src/alloc/layout.rs")
-                .line(40)
-                .char_column(0),
-        ),
-        Group::with_title(Level::NOTE.secondary_title("`Layout` is defined in the current crate"))
+        Level::NOTE
+            .secondary_title("`core::alloc::Layout` is defined in crate `core`")
+            .element(
+                Origin::path("$SRC_DIR/core/src/alloc/layout.rs")
+                    .line(40)
+                    .char_column(0),
+            ),
+        Level::NOTE
+            .secondary_title("`Layout` is defined in the current crate")
             .element(
                 Snippet::source(source)
                     .path("$DIR/alloc-error-handler-bad-signature-2.rs")
                     .annotation(AnnotationKind::Primary.span(91..104)),
             ),
-        Group::with_title(Level::NOTE.secondary_title("function defined here")).element(
-            Snippet::source(source)
-                .path("$DIR/alloc-error-handler-bad-signature-2.rs")
-                .annotation(AnnotationKind::Context.span(142..154).label(""))
-                .annotation(AnnotationKind::Primary.span(133..136)),
-        ),
+        Level::NOTE
+            .secondary_title("function defined here")
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/alloc-error-handler-bad-signature-2.rs")
+                    .annotation(AnnotationKind::Context.span(142..154).label(""))
+                    .annotation(AnnotationKind::Primary.span(133..136)),
+            ),
     ];
     let expected_ascii = str![[r#"
 error[E0308]: mismatched types
@@ -4623,19 +4570,18 @@ fn main() {
 }
 "#;
 
-    let input = &[Group::with_title(
-        Level::WARNING.primary_title(r#"whitespace symbol '\u{a0}' is not skipped"#),
-    )
-    .element(
-        Snippet::source(source)
-            .path("$DIR/str-escape.rs")
-            .annotation(
-                AnnotationKind::Context
-                    .span(203..205)
-                    .label(r#"whitespace symbol '\u{a0}' is not skipped"#),
-            )
-            .annotation(AnnotationKind::Primary.span(199..205)),
-    )];
+    let input = &[Level::WARNING
+        .primary_title(r#"whitespace symbol '\u{a0}' is not skipped"#)
+        .element(
+            Snippet::source(source)
+                .path("$DIR/str-escape.rs")
+                .annotation(
+                    AnnotationKind::Context
+                        .span(203..205)
+                        .label(r#"whitespace symbol '\u{a0}' is not skipped"#),
+                )
+                .annotation(AnnotationKind::Primary.span(199..205)),
+        )];
     let expected_ascii = str![[r#"
 warning: whitespace symbol '\u{a0}' is not skipped
   --> $DIR/str-escape.rs:12:18
@@ -4693,7 +4639,7 @@ fn main() {
     let title_2 = "ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown";
 
     let input = &[
-        Group::with_title(Level::ERROR.primary_title(title_0).id("E0004")).element(
+        Level::ERROR.primary_title(title_0).id("E0004").element(
             Snippet::source(source)
                 .path("$DIR/match-privately-empty.rs")
                 .annotation(
@@ -4702,7 +4648,8 @@ fn main() {
                         .label("pattern `Some(Private { misc: true, .. })` not covered"),
                 ),
         ),
-        Group::with_title(Level::NOTE.secondary_title(title_1))
+        Level::NOTE
+            .secondary_title(title_1)
             .element(
                 Origin::path("$SRC_DIR/core/src/option.rs")
                     .line(593)
@@ -4716,7 +4663,7 @@ fn main() {
             .element(Padding)
             .element(Level::NOTE.message("not covered"))
             .element(Level::NOTE.message("the matched value is of type `Option<Private>`")),
-        Group::with_title(Level::HELP.secondary_title(title_2)).element(
+        Level::HELP.secondary_title(title_2).element(
             Snippet::source(source)
                 .path("$DIR/match-privately-empty.rs")
                 .line_start(17)
@@ -4798,21 +4745,20 @@ fn main() {
 for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>";
 
     let input = &[
-        Group::with_title(
-            Level::ERROR
-                .primary_title("the trait `Ord` is not dyn compatible")
-                .id("E0038"),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/bare-trait-dont-suggest-dyn.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(149..152)
-                        .label("`Ord` is not dyn compatible"),
-                ),
-        ),
-        Group::with_title(Level::NOTE.secondary_title(title_0))
+        Level::ERROR
+            .primary_title("the trait `Ord` is not dyn compatible")
+            .id("E0038")
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/bare-trait-dont-suggest-dyn.rs")
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(149..152)
+                            .label("`Ord` is not dyn compatible"),
+                    ),
+            ),
+        Level::NOTE
+            .secondary_title(title_0)
             .element(
                 Origin::path("$SRC_DIR/core/src/cmp.rs")
                     .line(961)
@@ -4831,7 +4777,8 @@ for more information, visit <https://doc.rust-lang.org/reference/items/traits.ht
             .element(Level::NOTE.message(
                 "the trait is not dyn compatible because it uses `Self` as a type parameter",
             )),
-        Group::with_title(Level::HELP.secondary_title("consider using an opaque type instead"))
+        Level::HELP
+            .secondary_title("consider using an opaque type instead")
             .element(
                 Snippet::source(source)
                     .path("$DIR/bare-trait-dont-suggest-dyn.rs")
@@ -4913,29 +4860,28 @@ fn main() {
         "the foreign item types don't implement required traits for this operation to be valid";
 
     let input = &[
-        Group::with_title(
-            Level::ERROR
-                .primary_title(
-                    "binary operation `==` cannot be applied to type `(std::io::Error, Thread)`",
-                )
-                .id("E0369"),
-        )
-        .element(
-            Snippet::source(source_0)
-                .path("$DIR/binary-op-not-allowed-issue-125631.rs")
-                .annotation(
-                    AnnotationKind::Context
-                        .span(246..300)
-                        .label("(std::io::Error, Thread)"),
-                )
-                .annotation(
-                    AnnotationKind::Context
-                        .span(312..366)
-                        .label("(std::io::Error, Thread)"),
-                )
-                .annotation(AnnotationKind::Primary.span(309..311)),
-        ),
-        Group::with_title(Level::NOTE.secondary_title(title_0))
+        Level::ERROR
+            .primary_title(
+                "binary operation `==` cannot be applied to type `(std::io::Error, Thread)`",
+            )
+            .id("E0369")
+            .element(
+                Snippet::source(source_0)
+                    .path("$DIR/binary-op-not-allowed-issue-125631.rs")
+                    .annotation(
+                        AnnotationKind::Context
+                            .span(246..300)
+                            .label("(std::io::Error, Thread)"),
+                    )
+                    .annotation(
+                        AnnotationKind::Context
+                            .span(312..366)
+                            .label("(std::io::Error, Thread)"),
+                    )
+                    .annotation(AnnotationKind::Primary.span(309..311)),
+            ),
+        Level::NOTE
+            .secondary_title(title_0)
             .element(
                 Origin::path("$SRC_DIR/std/src/io/error.rs")
                     .line(65)
@@ -5034,21 +4980,20 @@ fn main() {}
 "#;
 
     let input = &[
-        Group::with_title(
-            Level::ERROR
-                .primary_title("failed to resolve: use of undeclared type `IntoIter`")
-                .id("E0433"),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/issue-82956.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(502..510)
-                        .label("use of undeclared type `IntoIter`"),
-                ),
-        ),
-        Group::with_title(Level::HELP.secondary_title("consider importing one of these structs"))
+        Level::ERROR
+            .primary_title("failed to resolve: use of undeclared type `IntoIter`")
+            .id("E0433")
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/issue-82956.rs")
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(502..510)
+                            .label("use of undeclared type `IntoIter`"),
+                    ),
+            ),
+        Level::HELP
+            .secondary_title("consider importing one of these structs")
             .element(
                 Snippet::source(source)
                     .path("$DIR/issue-82956.rs")
@@ -5155,7 +5100,9 @@ fn main() {
     let title_0 = "expected function, tuple struct or tuple variant, found struct `std::collections::HashMap`";
 
     let input = &[
-        Group::with_title(Level::ERROR.primary_title(title_0).id("E0423"))
+        Level::ERROR
+            .primary_title(title_0)
+            .id("E0423")
             .element(
                 Snippet::source(source)
                     .path("$DIR/multi-suggestion.rs")
@@ -5169,30 +5116,32 @@ fn main() {
             .element(Padding)
             .element(Level::NOTE.message("`std::collections::HashMap` defined here"))
             .element(Padding),
-        Group::with_title(Level::HELP.secondary_title(
-            "you might have meant to use an associated function to build this type",
-        ))
-        .element(
-            Snippet::source(source)
-                .path("$DIR/multi-suggestion.rs")
-                .patch(Patch::new(421..423, "::new()")),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/multi-suggestion.rs")
-                .patch(Patch::new(421..423, "::with_capacity(_)")),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/multi-suggestion.rs")
-                .patch(Patch::new(421..423, "::with_hasher(_)")),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/multi-suggestion.rs")
-                .patch(Patch::new(421..423, "::with_capacity_and_hasher(_, _)")),
-        ),
-        Group::with_title(Level::HELP.secondary_title("consider using the `Default` trait"))
+        Level::HELP
+            .secondary_title(
+                "you might have meant to use an associated function to build this type",
+            )
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/multi-suggestion.rs")
+                    .patch(Patch::new(421..423, "::new()")),
+            )
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/multi-suggestion.rs")
+                    .patch(Patch::new(421..423, "::with_capacity(_)")),
+            )
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/multi-suggestion.rs")
+                    .patch(Patch::new(421..423, "::with_hasher(_)")),
+            )
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/multi-suggestion.rs")
+                    .patch(Patch::new(421..423, "::with_capacity_and_hasher(_, _)")),
+            ),
+        Level::HELP
+            .secondary_title("consider using the `Default` trait")
             .element(
                 Snippet::source(source)
                     .path("$DIR/multi-suggestion.rs")
@@ -5295,53 +5244,52 @@ fn main() {
 "#;
 
     let input = &[
-        Group::with_title(
-            Level::ERROR
-                .primary_title("cannot initialize a tuple struct which contains private fields")
-                .id("E0423"),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/suggest-box-new.rs")
-                .annotation(AnnotationKind::Primary.span(220..223)),
-        ),
-        Group::with_title(
-            Level::NOTE.secondary_title("constructor is not visible here due to private fields"),
-        )
-        .element(
-            Origin::path("$SRC_DIR/alloc/src/boxed.rs")
-                .line(234)
-                .char_column(2),
-        )
-        .element(Padding)
-        .element(Level::NOTE.message("private field"))
-        .element(Padding)
-        .element(Level::NOTE.message("private field")),
-        Group::with_title(Level::HELP.secondary_title(
-            "you might have meant to use an associated function to build this type",
-        ))
-        .element(
-            Snippet::source(source)
-                .path("$DIR/suggest-box-new.rs")
-                .patch(Patch::new(223..280, "::new(_)")),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/suggest-box-new.rs")
-                .patch(Patch::new(223..280, "::new_uninit()")),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/suggest-box-new.rs")
-                .patch(Patch::new(223..280, "::new_zeroed()")),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/suggest-box-new.rs")
-                .patch(Patch::new(223..280, "::new_in(_, _)")),
-        )
-        .element(Level::NOTE.no_name().message("and 12 other candidates")),
-        Group::with_title(Level::HELP.secondary_title("consider using the `Default` trait"))
+        Level::ERROR
+            .primary_title("cannot initialize a tuple struct which contains private fields")
+            .id("E0423")
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/suggest-box-new.rs")
+                    .annotation(AnnotationKind::Primary.span(220..223)),
+            ),
+        Level::NOTE
+            .secondary_title("constructor is not visible here due to private fields")
+            .element(
+                Origin::path("$SRC_DIR/alloc/src/boxed.rs")
+                    .line(234)
+                    .char_column(2),
+            )
+            .element(Padding)
+            .element(Level::NOTE.message("private field"))
+            .element(Padding)
+            .element(Level::NOTE.message("private field")),
+        Level::HELP
+            .secondary_title(
+                "you might have meant to use an associated function to build this type",
+            )
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/suggest-box-new.rs")
+                    .patch(Patch::new(223..280, "::new(_)")),
+            )
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/suggest-box-new.rs")
+                    .patch(Patch::new(223..280, "::new_uninit()")),
+            )
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/suggest-box-new.rs")
+                    .patch(Patch::new(223..280, "::new_zeroed()")),
+            )
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/suggest-box-new.rs")
+                    .patch(Patch::new(223..280, "::new_in(_, _)")),
+            )
+            .element(Level::NOTE.no_name().message("and 12 other candidates")),
+        Level::HELP
+            .secondary_title("consider using the `Default` trait")
             .element(
                 Snippet::source(source)
                     .path("$DIR/suggest-box-new.rs")
@@ -5487,52 +5435,46 @@ fn main() {}
 "#;
 
     let input = &[
-        Group::with_title(
-            Level::ERROR
-                .primary_title(
-                    "no method named `bar` found for struct `Thing` in the current scope",
-                )
-                .id("E0599"),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/too-many-field-suggestions.rs")
-                .annotation(
-                    AnnotationKind::Primary
-                        .span(257..260)
-                        .label("method not found in `Thing`"),
-                )
-                .annotation(
-                    AnnotationKind::Context
-                        .span(0..12)
-                        .label("method `bar` not found for this struct"),
-                ),
-        ),
-        Group::with_title(
-            Level::HELP
-                .secondary_title("some of the expressions' fields have a method of the same name"),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/too-many-field-suggestions.rs")
-                .patch(Patch::new(257..257, "a0.")),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/too-many-field-suggestions.rs")
-                .patch(Patch::new(257..257, "a1.")),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/too-many-field-suggestions.rs")
-                .patch(Patch::new(257..257, "a2.")),
-        )
-        .element(
-            Snippet::source(source)
-                .path("$DIR/too-many-field-suggestions.rs")
-                .patch(Patch::new(257..257, "a3.")),
-        )
-        .element(Level::NOTE.no_name().message("and 6 other candidates")),
+        Level::ERROR
+            .primary_title("no method named `bar` found for struct `Thing` in the current scope")
+            .id("E0599")
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/too-many-field-suggestions.rs")
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(257..260)
+                            .label("method not found in `Thing`"),
+                    )
+                    .annotation(
+                        AnnotationKind::Context
+                            .span(0..12)
+                            .label("method `bar` not found for this struct"),
+                    ),
+            ),
+        Level::HELP
+            .secondary_title("some of the expressions' fields have a method of the same name")
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/too-many-field-suggestions.rs")
+                    .patch(Patch::new(257..257, "a0.")),
+            )
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/too-many-field-suggestions.rs")
+                    .patch(Patch::new(257..257, "a1.")),
+            )
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/too-many-field-suggestions.rs")
+                    .patch(Patch::new(257..257, "a2.")),
+            )
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/too-many-field-suggestions.rs")
+                    .patch(Patch::new(257..257, "a3.")),
+            )
+            .element(Level::NOTE.no_name().message("and 6 other candidates")),
     ];
 
     let expected_ascii = str![[r#"
@@ -5589,17 +5531,15 @@ LL │     t.a3.bar();
 #[test]
 fn invalid_arguments_unterminated() {
     // tests/ui/check-cfg/invalid-arguments.unterminated.rs
-    let input = &[Group::with_title(
-        Level::ERROR.primary_title("invalid `--check-cfg` argument: `cfg(`"),
-    )
-    .element(
-        Level::NOTE.message(r#"expected `cfg(name, values("value1", "value2", ... "valueN"))`"#),
-    )
-    .element(
-        Level::NOTE.message(
+    let input = &[Level::ERROR
+        .primary_title("invalid `--check-cfg` argument: `cfg(`")
+        .element(
+            Level::NOTE
+                .message(r#"expected `cfg(name, values("value1", "value2", ... "valueN"))`"#),
+        )
+        .element(Level::NOTE.message(
             "visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details",
-        ),
-    )];
+        ))];
     let expected_ascii = str![[r#"
 error: invalid `--check-cfg` argument: `cfg(`
    |
@@ -5656,14 +5596,16 @@ If your compilation actually takes a long time, you can safely allow the lint.";
     let title_1 = "this error originates in the macro `uint_impl` (in Nightly builds, run with -Z macro-backtrace for more info)";
 
     let input = &[
-        Group::with_title(Level::ERROR.primary_title("constant evaluation is taking a long time"))
+        Level::ERROR
+            .primary_title("constant evaluation is taking a long time")
             .element(
                 Origin::path("$SRC_DIR/core/src/num/mod.rs")
                     .line(1151)
                     .char_column(4),
             )
             .element(Level::NOTE.message(title_0)),
-        Group::with_title(Level::HELP.secondary_title("the constant being evaluated"))
+        Level::HELP
+            .secondary_title("the constant being evaluated")
             .element(
                 Snippet::source(source)
                     .path("$DIR/timeout.rs")


### PR DESCRIPTION
In using annotate-snippets, I was getting annoyed with the redundancy of `Group::with_title(... primary_title())` and figured we could allow people to bypass that.  With rustfmt, I also feel like the code more closely virtually matches the output.

We could also put `fn element` on a `Level` as a shortcut for `Group::with_level` but I figured that was an uncommon enough of a case to not provide a shortcut for so we don't accidentally steer users in the wrong direction.

The main downside is that this shortcut only works if there are elements.  I have mixed feelings about what approach to take for title-only groups.