### PR TITLE
test: Highlight source on all AnnotationKind

### DIFF
--- a/tests/color/highlight_source.ascii.term.svg
+++ b/tests/color/highlight_source.ascii.term.svg
@@ -1,0 +1,38 @@
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">: all annotation kinds have a highlighted source</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> </tspan><tspan class="fg-bright-blue bold">--&gt; </tspan><tspan>Cargo.toml:9:1</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">2</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> [workspace.lints.rust]</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-blue bold">...</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">9</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unused_qualifications</tspan><tspan> = </tspan><tspan class="fg-bright-blue bold">"warn"</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-red bold">^^^^^^^^^^^^^^^^^^^^^</tspan><tspan>   </tspan><tspan class="fg-bright-blue bold">------</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/highlight_source.rs
+++ b/tests/color/highlight_source.rs
@@ -1,0 +1,43 @@
+use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+
+use snapbox::{assert_data_eq, file};
+
+#[test]
+fn case() {
+    let source = r#"
+[workspace.lints.rust]
+rust_2018_idioms = { level = "warn", priority = -1 }
+unnameable_types = "warn"
+unreachable_pub = "warn"
+unsafe_op_in_unsafe_fn = "warn"
+unused_lifetimes = "warn"
+unused_macro_rules = "warn"
+unused_qualifications = "warn"
+"#;
+
+    let input = &[Level::ERROR
+        .primary_title("all annotation kinds have a highlighted source")
+        .element(
+            Snippet::source(source)
+                .path("Cargo.toml")
+                .annotation(
+                    AnnotationKind::Primary
+                        .span(214..235)
+                        .highlight_source(true),
+                )
+                .annotation(
+                    AnnotationKind::Context
+                        .span(238..244)
+                        .highlight_source(true),
+                )
+                .annotation(AnnotationKind::Visible.span(2..22).highlight_source(true)),
+        )];
+
+    let expected_ascii = file!["highlight_source.ascii.term.svg": TermSvg];
+    let renderer = Renderer::styled();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    let expected_unicode = file!["highlight_source.unicode.term.svg": TermSvg];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+}

--- a/tests/color/highlight_source.unicode.term.svg
+++ b/tests/color/highlight_source.unicode.term.svg
@@ -1,0 +1,38 @@
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">: all annotation kinds have a highlighted source</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> </tspan><tspan class="fg-bright-blue bold"> ╭▸ </tspan><tspan>Cargo.toml:9:1</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-bright-blue bold">│</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">2</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan> [workspace.lints.rust]</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-bright-blue bold">‡</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">9</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unused_qualifications</tspan><tspan> = </tspan><tspan class="fg-bright-blue bold">"warn"</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">╰╴</tspan><tspan class="fg-bright-red bold">━━━━━━━━━━━━━━━━━━━━━</tspan><tspan>   </tspan><tspan class="fg-bright-blue bold">──────</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/main.rs
+++ b/tests/color/main.rs
@@ -9,6 +9,7 @@ mod fold_ann_multiline;
 mod fold_bad_origin_line;
 mod fold_leading;
 mod fold_trailing;
+mod highlight_source;
 mod issue_9;
 mod multiline_removal_suggestion;
 mod multiple_annotations;


### PR DESCRIPTION
This PR adds a test showing how each `AnnotationKind` gets colored by `highlight_source`. This should hopefully help us catch any unwanted changes to how they are colored.