### PR TITLE
fix: Use correct line num with trimmed suggestions

### DIFF
--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -1511,7 +1511,8 @@ fn emit_suggestion_default(
         }
 
         let file_lines = sm.span_to_lines(parts[0].span.clone());
-        let (line_start, line_end) = sm.span_to_locations(parts[0].span.clone());
+        // We use the original span to get original line_start
+        let (line_start, line_end) = sm.span_to_locations(parts[0].original_span.clone());
         let mut lines = complete.lines();
         if lines.clone().next().is_none() {
             // Account for a suggestion to completely remove a line(s) with whitespace (#94192).

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -4402,10 +4402,10 @@ note: function defined here
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         -------
 help: provide the argument
    |
- 7 |     function_with_lots_of_arguments(
- 8 |         variable_name,
- 9 ~         /* char */,
-10 ~         variable_name,
+ 5 |     function_with_lots_of_arguments(
+ 6 |         variable_name,
+ 7 ~         /* char */,
+ 8 ~         variable_name,
    |
 "#]];
     let renderer_ascii = Renderer::plain();
@@ -4428,10 +4428,10 @@ note: function defined here
    ╰╴   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━         ───────
 help: provide the argument
    ╭╴
- 7 │     function_with_lots_of_arguments(
- 8 │         variable_name,
- 9 ±         /* char */,
-10 ±         variable_name,
+ 5 │     function_with_lots_of_arguments(
+ 6 │         variable_name,
+ 7 ±         /* char */,
+ 8 ±         variable_name,
    ╰╴
 "#]];
     let renderer_unicode = renderer_ascii.decor_style(DecorStyle::Unicode);
@@ -4504,10 +4504,10 @@ note: the lint level is defined here
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: add a `;` here
    |
-10 |     nums.iter().for_each(|x| {
+ 4 |     nums.iter().for_each(|x| {
 ...
-15 |         }
-16 ~     });
+ 9 |         }
+10 ~     });
    |
 "#]];
     let renderer_ascii = Renderer::plain();
@@ -4532,10 +4532,10 @@ note: the lint level is defined here
    ╰╴        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 help: add a `;` here
    ╭╴
-10 │     nums.iter().for_each(|x| {
+ 4 │     nums.iter().for_each(|x| {
  …
-15 │         }
-16 ±     });
+ 9 │         }
+10 ±     });
    ╰╴
 "#]];
     let renderer_unicode = renderer_ascii.decor_style(DecorStyle::Unicode);


### PR DESCRIPTION
I came across rust-lang/rust-clippy#15883, which reported incorrect line numbers for a multi-line suggestion. I realized the incorrect line numbers were coming from `rustc`, which made me realize that `annotate-snippets` also had this problem. 

The root cause of the problems comes from the [process of trimming `Patch`'s replacement](https://github.com/rust-lang/annotate-snippets-rs/blob/5a632cdfadb5902bf063722f80b37fcb50da0416/src/snippet.rs#L473-L487) to be a [substring](https://github.com/rust-lang/annotate-snippets-rs/blob/5a632cdfadb5902bf063722f80b37fcb50da0416/src/snippet.rs#L591-L595) of the original. During this process, the span also gets adjusted to match the trimmed replacement. We later use this span to get the [`line_start`](https://github.com/rust-lang/annotate-snippets-rs/blob/5a632cdfadb5902bf063722f80b37fcb50da0416/src/renderer/render.rs#L1514) when rendering the suggestion. This is where the bug happens: if the adjusted span's `line_start` does not match the original span's `line_start`, we would show incorrect line numbers.

To fix this, I made it so we track both the original span and trimmed span for `Patch`s, and use the original span for `line_start`.
