### PR TITLE
fix: Use straight arrows for standalone Origin

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -297,9 +297,10 @@ impl DecorStyle {
         }
     }
 
-    fn file_start(&self, is_first: bool) -> &'static str {
+    fn file_start(&self, is_first: bool, alone: bool) -> &'static str {
         match self {
             DecorStyle::Ascii => "--> ",
+            DecorStyle::Unicode if is_first && alone => " ─▸ ",
             DecorStyle::Unicode if is_first => " ╭▸ ",
             DecorStyle::Unicode => " ├▸ ",
         }

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -186,6 +186,7 @@ pub(crate) fn render(renderer: &Renderer, groups: Report<'_>) -> String {
                             origin,
                             is_primary,
                             is_first,
+                            peek.is_none(),
                             buffer_msg_line_offset,
                         );
                         let current_line = buffer.num_lines();
@@ -286,7 +287,7 @@ fn render_short_message(renderer: &Renderer, groups: &[Group<'_>]) -> Result<Str
                 }
             }
 
-            render_origin(renderer, &mut buffer, 0, &origin, true, true, 0);
+            render_origin(renderer, &mut buffer, 0, &origin, true, true, true, 0);
             buffer.append(0, ": ", ElementStyle::LineAndColumn);
         }
     }
@@ -432,6 +433,7 @@ fn render_title(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_origin(
     renderer: &Renderer,
     buffer: &mut StyledBuffer,
@@ -439,12 +441,13 @@ fn render_origin(
     origin: &Origin<'_>,
     is_primary: bool,
     is_first: bool,
+    alone: bool,
     buffer_msg_line_offset: usize,
 ) {
     if is_primary && !renderer.short_message {
         buffer.prepend(
             buffer_msg_line_offset,
-            renderer.decor_style.file_start(is_first),
+            renderer.decor_style.file_start(is_first, alone),
             ElementStyle::LineNumber,
         );
     } else if !renderer.short_message {
@@ -558,6 +561,7 @@ fn render_snippet_annotations(
             &origin,
             is_primary,
             is_first,
+            false,
             buffer_msg_line_offset,
         );
         // Put in the spacer between the location and annotated source
@@ -574,7 +578,7 @@ fn render_snippet_annotations(
                 buffer.puts(
                     buffer_msg_line_offset,
                     max_line_num_len,
-                    renderer.decor_style.file_start(is_first),
+                    renderer.decor_style.file_start(is_first, false),
                     ElementStyle::LineNumber,
                 );
             } else {
@@ -1462,7 +1466,7 @@ fn emit_suggestion_default(
                 let (loc, _) = sm.span_to_locations(parts[0].span.clone());
                 // --> file.rs:line:col
                 //  |
-                let arrow = renderer.decor_style.file_start(is_first);
+                let arrow = renderer.decor_style.file_start(is_first, false);
                 buffer.puts(row_num - 1, 0, arrow, ElementStyle::LineNumber);
                 let message = format!("{}:{}:{}", path, loc.line, loc.char + 1);
                 let col = usize::max(max_line_num_len + 1, arrow.len());

--- a/tests/color/multiline_removal_suggestion.unicode.term.svg
+++ b/tests/color/multiline_removal_suggestion.unicode.term.svg
@@ -39,7 +39,7 @@
 </tspan>
     <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">note</tspan><tspan>: required by a bound in `flatten`</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-blue bold"> ╭▸ </tspan><tspan>/rustc/FAKE_PREFIX/library/core/src/iter/traits/iterator.rs:1556:4</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-blue bold"> ─▸ </tspan><tspan>/rustc/FAKE_PREFIX/library/core/src/iter/traits/iterator.rs:1556:4</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: consider removing this method call, as the receiver has type `std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;` and `std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;: Iterator` trivially holds</tspan>
 </tspan>

--- a/tests/rustc_tests.rs
+++ b/tests/rustc_tests.rs
@@ -4189,8 +4189,8 @@ LL │     let _ = quote! { $($ip)* }; //~ ERROR the method `quote_into_iter` ex
            `&mut Ipv4Addr: Iterator`
            which is required by `&mut Ipv4Addr: proc_macro::ext::RepIteratorExt`
 note: the traits `Iterator` and `ToTokens` must be implemented
-   ╭▸ $SRC_DIR/proc_macro/src/to_tokens.rs:11:0
-   ╭▸ $SRC_DIR/core/src/iter/traits/iterator.rs:39:0
+   ─▸ $SRC_DIR/proc_macro/src/to_tokens.rs:11:0
+   ─▸ $SRC_DIR/core/src/iter/traits/iterator.rs:39:0
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
@@ -4513,7 +4513,7 @@ LL │ ┃  }
    │
    ╰ note: `core::alloc::Layout` and `Layout` have similar names, but are actually distinct types
 note: `core::alloc::Layout` is defined in crate `core`
-   ╭▸ $SRC_DIR/core/src/alloc/layout.rs:40:0
+   ─▸ $SRC_DIR/core/src/alloc/layout.rs:40:0
 note: `Layout` is defined in the current crate
    ╭▸ $DIR/alloc-error-handler-bad-signature-2.rs:7:1
    │


### PR DESCRIPTION
Using `╭▸` for an `Origin` with nothing in a `Group` following it made the output confusing, as the "code window" would never get closed. To address this, I made it so `annotate-snippets` would use `─▸` when an `Origin` has nothing following.