### PR TITLE
fix: Use correct offset when trimming unicode char

### DIFF
--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -2965,7 +2965,7 @@ fn trim_unicode_annotate_ascii_end_with_label() {
     let expected_ascii = str![[r#"
   |
 1 | ... 的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。*/?
-  |                                                              ^ expected item
+  |                                                             ^ expected item
 "#]];
 
     let renderer = Renderer::plain();
@@ -2974,7 +2974,7 @@ fn trim_unicode_annotate_ascii_end_with_label() {
     let expected_unicode = str![[r#"
   ╭▸ 
 1 │ … 宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。*/?
-  ╰╴                                                             ━ expected item
+  ╰╴                                                            ━ expected item
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
@@ -2988,8 +2988,8 @@ fn trim_unicode_annotate_ascii_end_no_label() {
 
     let expected_ascii = str![[r#"
   |
-1 | ... 。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。*/
-  |                                                                     ^
+1 | ... 这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。*/?
+  |                                                                   ^
 "#]];
 
     let renderer = Renderer::plain();
@@ -2997,8 +2997,8 @@ fn trim_unicode_annotate_ascii_end_no_label() {
 
     let expected_unicode = str![[r#"
   ╭▸ 
-1 │ … 的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。*/
-  ╰╴                                                                    ━
+1 │ … 。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。*/?
+  ╰╴                                                                  ━
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
@@ -3018,7 +3018,7 @@ fn trim_unicode_annotate_unicode_end_with_label() {
     let expected_ascii = str![[r#"
   |
 1 | ... 的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。*/好
-  |                                                              ^^ expected item
+  |                                                             ^^ expected item
 "#]];
 
     let renderer = Renderer::plain();
@@ -3027,7 +3027,7 @@ fn trim_unicode_annotate_unicode_end_with_label() {
     let expected_unicode = str![[r#"
   ╭▸ 
 1 │ … 宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。*/好
-  ╰╴                                                             ━━ expected item
+  ╰╴                                                            ━━ expected item
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
@@ -3041,8 +3041,8 @@ fn trim_unicode_annotate_unicode_end_no_label() {
 
     let expected_ascii = str![[r#"
   |
-1 | ... 。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。*/
-  |                                                                     ^^
+1 | ... 这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。*/好
+  |                                                                   ^^
 "#]];
 
     let renderer = Renderer::plain();
@@ -3050,8 +3050,8 @@ fn trim_unicode_annotate_unicode_end_no_label() {
 
     let expected_unicode = str![[r#"
   ╭▸ 
-1 │ … 的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。*/
-  ╰╴                                                                    ━━
+1 │ … 。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。*/好
+  ╰╴                                                                  ━━
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
@@ -3070,8 +3070,8 @@ fn trim_unicode_annotate_unicode_middle_with_label() {
 
     let expected_ascii = str![[r#"
   |
-1 | ... 。这是宽的。这是宽的。这是宽的...
-  |             ^^ expected item
+1 | ... 这是宽的。这是宽的。这是宽的。...
+  |           ^^ expected item
 "#]];
 
     let renderer = Renderer::plain().term_width(43);
@@ -3079,8 +3079,8 @@ fn trim_unicode_annotate_unicode_middle_with_label() {
 
     let expected_unicode = str![[r#"
   ╭▸ 
-1 │ … 的。这是宽的。这是宽的。这是宽的。…
-  ╰╴            ━━ expected item
+1 │ … 。这是宽的。这是宽的。这是宽的。这…
+  ╰╴          ━━ expected item
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
@@ -3095,7 +3095,7 @@ fn trim_unicode_annotate_unicode_middle_no_label() {
     let expected_ascii = str![[r#"
   |
 1 | ... 是宽的。这是宽的。这是宽的。这...
-  |                    ^^
+  |                   ^^
 "#]];
 
     let renderer = Renderer::plain().term_width(43);
@@ -3104,7 +3104,7 @@ fn trim_unicode_annotate_unicode_middle_no_label() {
     let expected_unicode = str![[r#"
   ╭▸ 
 1 │ … 这是宽的。这是宽的。这是宽的。这是…
-  ╰╴                   ━━
+  ╰╴                  ━━
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);


### PR DESCRIPTION
#330 showed a few cases where `annotate-snippets` would annotate a line incorrectly when it tried to trim unicode characters. Two things caused this: 
- Not adjusting the [`left`](https://github.com/rust-lang/annotate-snippets-rs/blob/fd61af931f81936dcd4af9359c1ce961dbf564f3/src/renderer/render.rs#L1996) padding if it didn't match [`skipped`](https://github.com/rust-lang/annotate-snippets-rs/blob/fd61af931f81936dcd4af9359c1ce961dbf564f3/src/renderer/render.rs#L2001)
- Not skipping multi-byte chars when their width + `skipped` exceeded `left`.

This PR addresses both of those issues.

Before:
<img width="1152" height="710" alt="Screenshot From 2025-10-24 11-43-21" src="https://github.com/user-attachments/assets/f432565a-1495-44ae-b832-c5477672815d" />

After:
<img width="1152" height="710" alt="Screenshot From 2025-10-24 11-42-53" src="https://github.com/user-attachments/assets/faa40bc3-d916-434f-a055-64847291aebd" />


<details>
  <summary>Test Script</summary>
  
  ```rust
  use annotate_snippets::{AnnotationKind, Group, Level, Renderer, Snippet};
  
  fn main() {
      /***** (A): ASCII only *****/
      let ascii_only_end = (
          "(A): ASCII only",
          "/*aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa*/?",
          "?",
      );
  
      /***** (B): non-ASCII prefix, ASCII highlight *****/
      let non_ascii_pre_ascii_highlight_end = (
          "(B): non-ASCII prefix, ASCII highlight",
          "/*这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。*/?",
          "?",
      );
  
      /***** (C): non-ASCII everything *****/
      let non_ascii_end = (
          "(C): non-ASCII everything",
          "/*这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。*/好",
          "好",
      );
  
      /***** (D): non-ASCII everything, annotate middle *****/
      let non_ascii_middle = (
          "(D): non-ASCII everything, annotate middle",
          "/*这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽好。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。这是宽的。*/?",
          "好",
      );
      for (desc, source, highlight) in [
          ascii_only_end,
          non_ascii_pre_ascii_highlight_end,
          non_ascii_end,
          non_ascii_middle,
      ] {
          //println!("\n");
          let renderer = Renderer::styled();
  
          let start = source.find(highlight).unwrap();
          let range = start..start + highlight.len();
          let annotation = AnnotationKind::Primary.span(range.clone());
  
          let group_with_label = Group::with_level(Level::ERROR)
              .element(Snippet::source(source).annotation(annotation.clone().label("label")));
          println!("{desc}\n{}\n", renderer.render(&[group_with_label]));
  
          let group_no_label =
              Group::with_level(Level::ERROR).element(Snippet::source(source).annotation(annotation));
  
          println!("{}\n", renderer.render(&[group_no_label]));
      }
  }

  ```
  
</details>

fixes #330