### PR TITLE
Unicode renderer: Use vertical ellipsis rather than double-dagger

### DIFF
--- a/examples/expected_type.svg
+++ b/examples/expected_type.svg
@@ -29,7 +29,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan>   </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan>                                   </tspan><tspan class="fg-bright-blue bold">────────────────</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">while parsing this struct</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>   </tspan><tspan class="fg-bright-blue bold">‡</tspan>
+    <tspan x="10px" y="118px"><tspan>   </tspan><tspan class="fg-bright-blue bold">⋮</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan class="fg-bright-blue bold">29</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan>                 range: &lt;22, 25&gt;,</tspan>
 </tspan>

--- a/examples/struct_name_as_context.svg
+++ b/examples/struct_name_as_context.svg
@@ -27,7 +27,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">1</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan> struct S {</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-bright-blue bold">‡</tspan>
+    <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-bright-blue bold">⋮</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">6</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan>     fn foo() {},</tspan>
 </tspan>

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -2229,7 +2229,7 @@ fn draw_note_separator(
 fn draw_line_separator(renderer: &Renderer, buffer: &mut StyledBuffer, line: usize, col: usize) {
     let (column, dots) = match renderer.decor_style {
         DecorStyle::Ascii => (0, "..."),
-        DecorStyle::Unicode => (col - 2, "‡"),
+        DecorStyle::Unicode => (col - 2, "⋮"),
     };
     buffer.puts(line, column, dots, ElementStyle::LineNumber);
 }

--- a/tests/color/fold_ann_multiline.unicode.term.svg
+++ b/tests/color/fold_ann_multiline.unicode.term.svg
@@ -37,7 +37,7 @@
 </tspan>
     <tspan x="10px" y="172px"><tspan class="fg-bright-blue bold">55</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan> </tspan><tspan class="fg-bright-red bold">┃</tspan><tspan>             (Some(start), Some(end)) if start &gt; end_index || end &lt; start_index =&gt; continue,</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>   </tspan><tspan class="fg-bright-blue bold">‡</tspan><tspan> </tspan><tspan class="fg-bright-red bold">┃</tspan>
+    <tspan x="10px" y="190px"><tspan>   </tspan><tspan class="fg-bright-blue bold">⋮</tspan><tspan> </tspan><tspan class="fg-bright-red bold">┃</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan class="fg-bright-blue bold">72</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan> </tspan><tspan class="fg-bright-red bold">┃</tspan><tspan>     }</tspan>
 </tspan>

--- a/tests/color/highlight_duplicated_diff_lines.unicode.term.svg
+++ b/tests/color/highlight_duplicated_diff_lines.unicode.term.svg
@@ -31,7 +31,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan>   </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan>               </tspan><tspan class="fg-bright-red bold">━━━━━━━━━━━━</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>   </tspan><tspan class="fg-bright-blue bold">‡</tspan>
+    <tspan x="10px" y="118px"><tspan>   </tspan><tspan class="fg-bright-blue bold">⋮</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan class="fg-bright-blue bold">24</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan>         String::from(""),</tspan>
 </tspan>

--- a/tests/color/highlight_source.unicode.term.svg
+++ b/tests/color/highlight_source.unicode.term.svg
@@ -27,7 +27,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">2</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan> [workspace.lints.rust]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-bright-blue bold">‡</tspan>
+    <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-bright-blue bold">⋮</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">9</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unused_qualifications</tspan><tspan> = </tspan><tspan class="fg-bright-blue bold">"warn"</tspan>
 </tspan>

--- a/tests/color/issue_9.unicode.term.svg
+++ b/tests/color/issue_9.unicode.term.svg
@@ -29,7 +29,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan>     </tspan><tspan class="fg-bright-blue bold">─</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">move occurs because `x` has type `std::vec::Vec&lt;i32&gt;`, which does not implement the `Copy` trait</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-blue bold">‡</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-blue bold">⋮</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan class="fg-bright-blue bold">7</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan> let y = x;</tspan>
 </tspan>

--- a/tests/color/multiple_highlight_duplicated.unicode.term.svg
+++ b/tests/color/multiple_highlight_duplicated.unicode.term.svg
@@ -31,7 +31,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan>   </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan>               </tspan><tspan class="fg-bright-red bold">━━━━━━━━━━━━</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>   </tspan><tspan class="fg-bright-blue bold">‡</tspan>
+    <tspan x="10px" y="118px"><tspan>   </tspan><tspan class="fg-bright-blue bold">⋮</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan class="fg-bright-blue bold">24</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan>         String::from(""),</tspan>
 </tspan>

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -1700,7 +1700,7 @@ error[E0599]: no method named `pick` found for struct `Chaenomeles` in the curre
    ╭▸ 
 LL │     pub struct Chaenomeles;
    │     ────────────────────── method `pick` not found for this struct
-   ‡
+   ⋮
 LL │     banana::Chaenomeles.pick()
    │                         ━━━━ method not found in `Chaenomeles`
    ╰╴
@@ -2487,7 +2487,7 @@ LL │ ┏     Box::new(
 LL │ ┃         Ok::<_, ()>(
 LL │ ┃             Err::<(), _>(
 LL │ ┃                 Ok::<_, ()>(
-   ‡ ┃
+   ⋮ ┃
 LL │ ┃     )
    │ ┗━━━━━┛ type mismatch resolving `<Result<Result<(), Result<Result<(), ...>, ...>>, ...> as Future>::Error == Foo`
    ╰╴
@@ -2600,7 +2600,7 @@ LL │ ┏     Box::new(
 LL │ ┃         Ok::<_, ()>(
 LL │ ┃             Err::<(), _>(
 LL │ ┃                 Ok::<_, ()>(
-   ‡ ┃
+   ⋮ ┃
 LL │ ┃     )
    │ ┗━━━━━┛ type mismatch resolving `<Result<Result<(), Result<Result<(), ...>, ...>>, ...> as Future>::Error == Foo`
    ╰╴
@@ -2785,7 +2785,7 @@ LL │        let x: Atype<
 LL │ │        Btype<
 LL │ │          Ctype<
 LL │ │            Atype<
-   ‡ │
+   ⋮ │
 LL │ │        i32
 LL │ │      > = Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(O…
    │ │┏━━━━━│━━━┛
@@ -4309,7 +4309,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
    ╭▸ 
 12 │ cargo
    │ ━━━━━
-   ‡
+   ⋮
 18 │ zappy
    ╰╴
 "#]];
@@ -4800,7 +4800,7 @@ error: consider adding a `;` to the last statement for consistent formatting
  5 │ ┃         if *x > 0 {
  6 │ ┃             println!("Positive number");
  7 │ ┃         } else {
-   ‡ ┃
+   ⋮ ┃
 10 │ ┃     })
    │ ┗━━━━━━┛
    ╰╴

--- a/tests/rustc_tests.rs
+++ b/tests/rustc_tests.rs
@@ -77,7 +77,7 @@ error: foo
   │
 2 │   fn foo() {
   │ ┏━━━━━━━━━━┛
-  ‡ ┃
+  ⋮ ┃
 5 │ ┃   }
   ╰╴┗━━━┛ test
 "#]];
@@ -1029,7 +1029,7 @@ error: foo
  5 │  │ 1
  6 │  │ 2
  7 │  │ 3
-   ‡  │
+   ⋮  │
 15 │  │   X2 Y2 Z2
 16 │  │   X3 Y3 Z3
    ╰╴ └──────────┘ `Y` is a good letter too
@@ -1113,7 +1113,7 @@ error: foo
 10 │ ┃│ 6
 11 │ ┃│   X2 Y2 Z2
    │ ┃└──────────┘ `Z` is a good letter too
-   ‡ ┃
+   ⋮ ┃
 15 │ ┃  10
 16 │ ┃    X3 Y3 Z3
    ╰╴┗━━━━━━━━┛ `Y` is a good letter
@@ -1512,7 +1512,7 @@ LL │           Dst: TransmuteFrom<Src, {
 LL │ ┃             Assume {
 LL │ ┃                 alignment: true,
 LL │ ┃                 lifetimes: true,
-   ‡ ┃
+   ⋮ ┃
 LL │ ┃         }>
    ╰╴┗━━━━━━━━━━┛ required by this bound in `is_transmutable`
 "#]];
@@ -1806,7 +1806,7 @@ warning: non-local `macro_rules!` definition, `#[macro_export]` macro should be 
    │
 LL │   macro_rules! outer_macro {
    │   ──────────────────────── in this expansion of `nested_macro_rules::outer_macro!`
-   ‡
+   ⋮
 LL │ ┏         macro_rules! inner_macro {
 LL │ ┃             ($bang_macro:ident, $attr_macro:ident) => {
 LL │ ┃                 $bang_macro!($name);
@@ -2703,7 +2703,7 @@ error: unclosed frontmatter
    ╭▸ $DIR/unclosed-1.rs:1:1
    │
 LL │ ┏ ----cargo
-   ‡ ┃
+   ⋮ ┃
 LL │ ┃
    │ ┗━┛
    ╰╴
@@ -2776,7 +2776,7 @@ error: unclosed frontmatter
    ╭▸ $DIR/unclosed-2.rs:1:1
    │
 LL │ ┏ ----cargo
-   ‡ ┃
+   ⋮ ┃
 LL │ ┃     "----"
 LL │ ┃ }
    │ ┗━━┛
@@ -2982,7 +2982,7 @@ error: unclosed frontmatter
    ╭▸ $DIR/unclosed-5.rs:1:1
    │
 LL │ ┏ ----cargo
-   ‡ ┃
+   ⋮ ┃
 LL │ ┃
    │ ┗━┛
    ╰╴
@@ -4175,7 +4175,7 @@ error[E0599]: the method `quote_into_iter` exists for struct `Ipv4Addr`, but its
    │
 LL │ struct Ipv4Addr;
    │ ─────────────── method `quote_into_iter` not found for this struct because it doesn't satisfy `Ipv4Addr: Iterator`, `Ipv4Addr: ToTokens`, `Ipv4Addr: proc_macro::ext::RepIteratorExt` or `Ipv4Addr: proc_macro::ext::RepToTokensExt`
-   ‡
+   ⋮
 LL │     let _ = quote! { $($ip)* }; //~ ERROR the method `quote_into_iter` exists for struct `Ipv4Addr`, but its trait bounds were not sat…
    │             ━━━━━━━━━━━━━━━━━━ method cannot be called on `Ipv4Addr` due to unsatisfied trait bounds
    │
@@ -4274,7 +4274,7 @@ error[E0220]: associated type `Pr` not found for `S<bool>` in the current scope
    │
 LL │ struct S<T>(T);
    │ ─────────── associated type `Pr` not found for this struct
-   ‡
+   ⋮
 LL │     let _: S::<bool>::Pr = ();
    │                       ━━ associated item not found in `S<bool>`
    │
@@ -5508,7 +5508,7 @@ error[E0599]: no method named `bar` found for struct `Thing` in the current scop
    │
 LL │ struct Thing {
    │ ──────────── method `bar` not found for this struct
-   ‡
+   ⋮
 LL │     t.bar();
    │       ━━━ method not found in `Thing`
    ╰╴


### PR DESCRIPTION
The Unicode renderer used "‡", the double-dagger symbol, to ellipsize
the vertical bar to indicate elided lines.

Use a vertical ellipsis instead.
