### PR TITLE
Fix & test for correct highlighting of strings with shared prefix

### DIFF
--- a/src/renderer/source_map.rs
+++ b/src/renderer/source_map.rs
@@ -779,6 +779,19 @@ pub(crate) fn as_substr<'a>(
     original: &'a str,
     suggestion: &'a str,
 ) -> Option<(usize, &'a str, usize)> {
+    // Case for import paths where the suggestion shares a prefix with the original.
+    // Without this, suggesting `std::sync` for `sync` would incorrectly highlight `td::s`
+    // instead of `std::` because of the common 's' prefix. See https://github.com/rust-lang/rust/issues/148070.
+    if suggestion.contains("::")
+        && suggestion.ends_with(original)
+        && suggestion.len() > original.len()
+    {
+        let prefix = &suggestion[..suggestion.len() - original.len()];
+        if prefix.ends_with("::") && suggestion.chars().next() == original.chars().next() {
+            return Some((0, prefix, original.len()));
+        }
+    }
+
     let common_prefix = original
         .chars()
         .zip(suggestion.chars())


### PR DESCRIPTION
Applies here the fix suggested in [this PR](https://github.com/rust-lang/rust/pull/148061).

[Original issue](https://github.com/rust-lang/rust/issues/148070).