### PR TITLE
fix: Prefer exact prefix/suffix matches when trimming replacements

### DIFF
--- a/src/renderer/source_map.rs
+++ b/src/renderer/source_map.rs
@@ -779,18 +779,24 @@ pub(crate) fn as_substr<'a>(
     original: &'a str,
     suggestion: &'a str,
 ) -> Option<(usize, &'a str, usize)> {
-    let common_prefix = original
-        .chars()
-        .zip(suggestion.chars())
-        .take_while(|(c1, c2)| c1 == c2)
-        .map(|(c, _)| c.len_utf8())
-        .sum();
-    let original = &original[common_prefix..];
-    let suggestion = &suggestion[common_prefix..];
-    if let Some(stripped) = suggestion.strip_suffix(original) {
-        let common_suffix = original.len();
-        Some((common_prefix, stripped, common_suffix))
+    if let Some(stripped) = suggestion.strip_prefix(original) {
+        Some((original.len(), stripped, 0))
+    } else if let Some(stripped) = suggestion.strip_suffix(original) {
+        Some((0, stripped, original.len()))
     } else {
-        None
+        let common_prefix = original
+            .chars()
+            .zip(suggestion.chars())
+            .take_while(|(c1, c2)| c1 == c2)
+            .map(|(c, _)| c.len_utf8())
+            .sum();
+        let original = &original[common_prefix..];
+        let suggestion = &suggestion[common_prefix..];
+        if let Some(stripped) = suggestion.strip_suffix(original) {
+            let common_suffix = original.len();
+            Some((common_prefix, stripped, common_suffix))
+        } else {
+            None
+        }
     }
 }

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -5045,7 +5045,7 @@ fn original_matches_replacement_suffix() {
 help: consider importing this module instead
   |
 1 | use std::sync;
-  |      +++++
+  |     +++++
 "#]];
     let renderer = Renderer::plain();
     assert_data_eq!(renderer.render(input), expected_ascii);
@@ -5059,7 +5059,7 @@ help: consider importing this module instead
 help: consider importing this module instead
   ╭╴
 1 │ use std::sync;
-  ╰╴     +++++
+  ╰╴    +++++
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);


### PR DESCRIPTION
`annotate-snippets` currently tries to minify replacements by comparing the replacement to the original and "removing" any common prefix, then checks if the original's remaining `char` match the end of the replacement. This works for most simple cases, but can produce odd results when the end of the replacement matches all of the original, and the replacement also shares some matching prefix with the original. This PR tries to address that edge case by first trying to strip all of the original from the replacement's prefix or suffix and returning the stripped string if it can.

#### Code Example
```rust
use annotate_snippets::{Group, Level, Patch, Renderer, Snippet};

fn main() {
    let source = r#"use sync"#;

    let report = &[Group::with_level(Level::HELP)
        .element(Snippet::source(source).patch(Patch::new(4..8, "std::sync")))];

    let renderer = Renderer::plain();
    println!("{}", renderer.render(report));
}
```
Before:
```
  |
1 | use std::sync;
  |      +++++
```
After:
```
  |
1 | use std::sync
  |     +++++
```
#### Written
original: `sync`
replacement: `std::sync`
before: `td::s`
after: `std::`


[Original `rust-lang/rust` issue](https://github.com/rust-lang/rust/issues/148070)

Closes #343