### PR TITLE
fix: Show multiple line removals in Diff format

### DIFF
--- a/tests/color/multiple_multiline_removal.ascii.term.svg
+++ b/tests/color/multiple_multiline_removal.ascii.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="812px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="866px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -103,11 +103,17 @@
 </tspan>
     <tspan x="10px" y="748px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan class="fg-bright-blue bold"> 8</tspan><tspan> </tspan><tspan class="fg-bright-red">- </tspan><tspan>        wtf: Some(Box(U {</tspan>
+    <tspan x="10px" y="766px"><tspan class="fg-bright-blue bold"> 8</tspan><tspan> </tspan><tspan class="fg-bright-red">- </tspan><tspan>        wtf: Some(Box</tspan><tspan class="fg-bright-red">(U {</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan class="fg-bright-blue bold"> 8</tspan><tspan> </tspan><tspan class="fg-bright-green">+ </tspan><tspan>        wtf: Some(</tspan><tspan class="fg-bright-green">&lt;</tspan><tspan>Box</tspan><tspan class="fg-bright-green"> as std::default::Default&gt;::default()</tspan><tspan>),</tspan>
+    <tspan x="10px" y="784px"><tspan class="fg-bright-blue bold"> 9</tspan><tspan> </tspan><tspan class="fg-bright-red">-             wtf: None,</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan>
+    <tspan x="10px" y="802px"><tspan class="fg-bright-blue bold">10</tspan><tspan> </tspan><tspan class="fg-bright-red">-             x: (),</tspan>
+</tspan>
+    <tspan x="10px" y="820px"><tspan class="fg-bright-blue bold">11</tspan><tspan> </tspan><tspan class="fg-bright-red">-         })</tspan><tspan>),</tspan>
+</tspan>
+    <tspan x="10px" y="838px"><tspan class="fg-bright-blue bold"> 8</tspan><tspan> </tspan><tspan class="fg-bright-green">+ </tspan><tspan>        wtf: Some(</tspan><tspan class="fg-bright-green">&lt;</tspan><tspan>Box</tspan><tspan class="fg-bright-green"> as std::default::Default&gt;::default()</tspan><tspan>),</tspan>
+</tspan>
+    <tspan x="10px" y="856px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>
   </text>
 

--- a/tests/color/multiple_multiline_removal.unicode.term.svg
+++ b/tests/color/multiple_multiline_removal.unicode.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="812px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="866px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -103,11 +103,17 @@
 </tspan>
     <tspan x="10px" y="748px"><tspan>   </tspan><tspan class="fg-bright-blue bold">╭╴</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan class="fg-bright-blue bold"> 8</tspan><tspan> </tspan><tspan class="fg-bright-red">- </tspan><tspan>        wtf: Some(Box(U {</tspan>
+    <tspan x="10px" y="766px"><tspan class="fg-bright-blue bold"> 8</tspan><tspan> </tspan><tspan class="fg-bright-red">- </tspan><tspan>        wtf: Some(Box</tspan><tspan class="fg-bright-red">(U {</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan class="fg-bright-blue bold"> 8</tspan><tspan> </tspan><tspan class="fg-bright-green">+ </tspan><tspan>        wtf: Some(</tspan><tspan class="fg-bright-green">&lt;</tspan><tspan>Box</tspan><tspan class="fg-bright-green"> as std::default::Default&gt;::default()</tspan><tspan>),</tspan>
+    <tspan x="10px" y="784px"><tspan class="fg-bright-blue bold"> 9</tspan><tspan> </tspan><tspan class="fg-bright-red">-             wtf: None,</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>   </tspan><tspan class="fg-bright-blue bold">╰╴</tspan>
+    <tspan x="10px" y="802px"><tspan class="fg-bright-blue bold">10</tspan><tspan> </tspan><tspan class="fg-bright-red">-             x: (),</tspan>
+</tspan>
+    <tspan x="10px" y="820px"><tspan class="fg-bright-blue bold">11</tspan><tspan> </tspan><tspan class="fg-bright-red">-         })</tspan><tspan>),</tspan>
+</tspan>
+    <tspan x="10px" y="838px"><tspan class="fg-bright-blue bold"> 8</tspan><tspan> </tspan><tspan class="fg-bright-green">+ </tspan><tspan>        wtf: Some(</tspan><tspan class="fg-bright-green">&lt;</tspan><tspan>Box</tspan><tspan class="fg-bright-green"> as std::default::Default&gt;::default()</tspan><tspan>),</tspan>
+</tspan>
+    <tspan x="10px" y="856px"><tspan>   </tspan><tspan class="fg-bright-blue bold">╰╴</tspan>
 </tspan>
   </text>
 

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -2371,6 +2371,9 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
  9 - fuzzy
 10 - pizza
 11 - jumps
+12 - crazy
+13 - quack
+14 - zappy
  8 + campy
    |
 "#]];
@@ -2386,6 +2389,9 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
  9 - fuzzy
 10 - pizza
 11 - jumps
+12 - crazy
+13 - quack
+14 - zappy
  8 + campy
    ╰╴
 "#]];

--- a/tests/rustc_tests.rs
+++ b/tests/rustc_tests.rs
@@ -5325,6 +5325,9 @@ help: you might have meant to use an associated function to build this type
 help: consider using the `Default` trait
    |
 11 -         wtf: Some(Box(U {
+12 -             wtf: None,
+13 -             x: (),
+14 -         })),
 11 +         wtf: Some(<Box as std::default::Default>::default()),
    |
 "#]];
@@ -5374,6 +5377,9 @@ help: you might have meant to use an associated function to build this type
 help: consider using the `Default` trait
    ╭╴
 11 -         wtf: Some(Box(U {
+12 -             wtf: None,
+13 -             x: (),
+14 -         })),
 11 +         wtf: Some(<Box as std::default::Default>::default()),
    ╰╴
 "#]];
@@ -5775,6 +5781,10 @@ note: associated function defined here
 help: remove the extra arguments
   |
 4 -     generate_setter,
+5 -     r#"
+6 - pub(crate) struct Person<T: Clone> {}
+7 - "#,
+8 -      r#""#,
 4 +     /* usize */,
   |
 "##]];
@@ -5807,6 +5817,10 @@ note: associated function defined here
 help: remove the extra arguments
   ╭╴
 4 -     generate_setter,
+5 -     r#"
+6 - pub(crate) struct Person<T: Clone> {}
+7 - "#,
+8 -      r#""#,
 4 +     /* usize */,
   ╰╴
 "##]];
@@ -5867,7 +5881,6 @@ help: otherwise remove the non-wildcard arms
    |
 20 -         2 => 'b',
 21 -         3 => 'b',
-20 +         _ => 'b',
    |
 "#]];
     let renderer_ascii = Renderer::plain();
@@ -5889,7 +5902,6 @@ help: otherwise remove the non-wildcard arms
    ╭╴
 20 -         2 => 'b',
 21 -         3 => 'b',
-20 +         _ => 'b',
    ╰╴
 "#]];
     let renderer_unicode = renderer_ascii.decor_style(DecorStyle::Unicode);


### PR DESCRIPTION
When displaying multiple line removals in the `Diff` suggestion format, `annotate-snippets` would fail to render all of the removed lines, this PR fixes that.