### PR TITLE
test: Match anstyle-svg background color fix

### DIFF
--- a/examples/custom_error.svg
+++ b/examples/custom_error.svg
@@ -1,7 +1,7 @@
 <svg width="751px" height="128px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/examples/custom_level.svg
+++ b/examples/custom_level.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="344px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }

--- a/examples/elide_header.svg
+++ b/examples/elide_header.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="200px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-green { fill: #55FF55 }
     .container {

--- a/examples/expected_type.svg
+++ b/examples/expected_type.svg
@@ -1,7 +1,7 @@
 <svg width="860px" height="182px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/examples/footer.svg
+++ b/examples/footer.svg
@@ -1,7 +1,7 @@
 <svg width="844px" height="182px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-green { fill: #55FF55 }
     .fg-bright-red { fill: #FF5555 }

--- a/examples/format.svg
+++ b/examples/format.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="524px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/examples/highlight_message.svg
+++ b/examples/highlight_message.svg
@@ -1,7 +1,7 @@
 <svg width="785px" height="362px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-green { fill: #55FF55 }
     .fg-bright-red { fill: #FF5555 }

--- a/examples/highlight_source.svg
+++ b/examples/highlight_source.svg
@@ -1,7 +1,7 @@
 <svg width="953px" height="164px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/examples/id_hyperlink.svg
+++ b/examples/id_hyperlink.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="164px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/examples/multi_suggestion.svg
+++ b/examples/multi_suggestion.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="524px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }

--- a/examples/multislice.svg
+++ b/examples/multislice.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="200px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/examples/struct_name_as_context.svg
+++ b/examples/struct_name_as_context.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="200px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/ann_eof.ascii.term.svg
+++ b/tests/color/ann_eof.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/ann_eof.unicode.term.svg
+++ b/tests/color/ann_eof.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/ann_insertion.ascii.term.svg
+++ b/tests/color/ann_insertion.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/ann_insertion.unicode.term.svg
+++ b/tests/color/ann_insertion.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/ann_multiline.ascii.term.svg
+++ b/tests/color/ann_multiline.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="164px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/ann_multiline.unicode.term.svg
+++ b/tests/color/ann_multiline.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="164px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/ann_multiline2.ascii.term.svg
+++ b/tests/color/ann_multiline2.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="182px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/ann_multiline2.unicode.term.svg
+++ b/tests/color/ann_multiline2.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="182px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/ann_removed_nl.ascii.term.svg
+++ b/tests/color/ann_removed_nl.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/ann_removed_nl.unicode.term.svg
+++ b/tests/color/ann_removed_nl.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/ensure_emoji_highlight_width.ascii.term.svg
+++ b/tests/color/ensure_emoji_highlight_width.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="1356px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/ensure_emoji_highlight_width.unicode.term.svg
+++ b/tests/color/ensure_emoji_highlight_width.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="1356px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/first_snippet_is_primary.ascii.term.svg
+++ b/tests/color/first_snippet_is_primary.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="290px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/first_snippet_is_primary.unicode.term.svg
+++ b/tests/color/first_snippet_is_primary.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="290px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/fold_ann_multiline.ascii.term.svg
+++ b/tests/color/fold_ann_multiline.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="869px" height="236px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/fold_ann_multiline.unicode.term.svg
+++ b/tests/color/fold_ann_multiline.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="869px" height="236px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/fold_bad_origin_line.ascii.term.svg
+++ b/tests/color/fold_bad_origin_line.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/fold_bad_origin_line.unicode.term.svg
+++ b/tests/color/fold_bad_origin_line.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/fold_leading.ascii.term.svg
+++ b/tests/color/fold_leading.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/fold_leading.unicode.term.svg
+++ b/tests/color/fold_leading.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/fold_trailing.ascii.term.svg
+++ b/tests/color/fold_trailing.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/fold_trailing.unicode.term.svg
+++ b/tests/color/fold_trailing.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/highlight_duplicated_diff_lines.ascii.term.svg
+++ b/tests/color/highlight_duplicated_diff_lines.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="344px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }

--- a/tests/color/highlight_duplicated_diff_lines.unicode.term.svg
+++ b/tests/color/highlight_duplicated_diff_lines.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="344px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }

--- a/tests/color/highlight_source.ascii.term.svg
+++ b/tests/color/highlight_source.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/highlight_source.unicode.term.svg
+++ b/tests/color/highlight_source.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/issue_9.ascii.term.svg
+++ b/tests/color/issue_9.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="911px" height="218px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/issue_9.unicode.term.svg
+++ b/tests/color/issue_9.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="911px" height="218px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/multiline_removal_suggestion.ascii.term.svg
+++ b/tests/color/multiline_removal_suggestion.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="1398px" height="398px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }

--- a/tests/color/multiline_removal_suggestion.unicode.term.svg
+++ b/tests/color/multiline_removal_suggestion.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="1398px" height="398px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }

--- a/tests/color/multiple_annotations.ascii.term.svg
+++ b/tests/color/multiple_annotations.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="768px" height="290px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/multiple_annotations.unicode.term.svg
+++ b/tests/color/multiple_annotations.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="768px" height="290px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/multiple_highlight_duplicated.ascii.term.svg
+++ b/tests/color/multiple_highlight_duplicated.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="488px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }

--- a/tests/color/multiple_highlight_duplicated.unicode.term.svg
+++ b/tests/color/multiple_highlight_duplicated.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="488px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }

--- a/tests/color/multiple_multiline_removal.ascii.term.svg
+++ b/tests/color/multiple_multiline_removal.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="866px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }

--- a/tests/color/multiple_multiline_removal.unicode.term.svg
+++ b/tests/color/multiple_multiline_removal.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="866px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }

--- a/tests/color/primary_title_second_group.ascii.term.svg
+++ b/tests/color/primary_title_second_group.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="844px" height="164px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-green { fill: #55FF55 }
     .fg-bright-red { fill: #FF5555 }

--- a/tests/color/primary_title_second_group.unicode.term.svg
+++ b/tests/color/primary_title_second_group.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="844px" height="164px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-green { fill: #55FF55 }
     .fg-bright-red { fill: #FF5555 }

--- a/tests/color/simple.ascii.term.svg
+++ b/tests/color/simple.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="182px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/simple.unicode.term.svg
+++ b/tests/color/simple.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="182px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/strip_line.ascii.term.svg
+++ b/tests/color/strip_line.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/strip_line.unicode.term.svg
+++ b/tests/color/strip_line.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/strip_line_char.ascii.term.svg
+++ b/tests/color/strip_line_char.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/strip_line_char.unicode.term.svg
+++ b/tests/color/strip_line_char.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/strip_line_non_ws.ascii.term.svg
+++ b/tests/color/strip_line_non_ws.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="1196px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/strip_line_non_ws.unicode.term.svg
+++ b/tests/color/strip_line_non_ws.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="1196px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-red { fill: #FF5555 }
     .container {

--- a/tests/color/styled_title.ascii.term.svg
+++ b/tests/color/styled_title.ascii.term.svg
@@ -1,7 +1,7 @@
 <svg width="944px" height="290px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-red { fill: #FF5555 }

--- a/tests/color/styled_title.unicode.term.svg
+++ b/tests/color/styled_title.unicode.term.svg
@@ -1,7 +1,7 @@
 <svg width="944px" height="290px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-red { fill: #FF5555 }


### PR DESCRIPTION
[`anstyle-svg@0.1.11`](https://github.com/rust-cli/anstyle/blob/main/crates/anstyle-svg/CHANGELOG.md#0111---2025-09-17) fixed an issue with the background color not applying by switching from `.bg { background: <color> }` to `.bg { fill: <color> }` when specifying the background color. For some reason, this change did not cause the SVG tests to fail, and only shows up when an SVG test's output gets updated. This behaviour means that any change to an SVG test's output would include this unrelated change, muddying the git history. To address this issue, I switched all SVG tests to use the new background format.