### PR TITLE
chore: Migrate to Edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 repository = "https://github.com/rust-lang/annotate-snippets-rs"
 license = "MIT OR Apache-2.0"
-edition = "2021"
+edition = "2024"
 rust-version = "1.85.0"  # MSRV
 include = [
   "build.rs",

--- a/examples/elide_header.rs
+++ b/examples/elide_header.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Group, Level, Renderer, Snippet, renderer::DecorStyle};
 
 fn main() {
     let source = r#"# Docstring followed by a newline

--- a/examples/expected_type.rs
+++ b/examples/expected_type.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 fn main() {
     let source = r#"                annotations: vec![SourceAnnotation {

--- a/examples/footer.rs
+++ b/examples/footer.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Group, Level, Renderer, Snippet, renderer::DecorStyle};
 
 fn main() {
     let report = &[

--- a/examples/format.rs
+++ b/examples/format.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 fn main() {
     let source = r#") -> Option<String> {

--- a/examples/highlight_message.rs
+++ b/examples/highlight_message.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 use anstyle::AnsiColor;
 use anstyle::Effects;
 use anstyle::Style;

--- a/examples/highlight_source.rs
+++ b/examples/highlight_source.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 fn main() {
     let source = r#"//@ compile-flags: -Z teach

--- a/examples/multi_suggestion.rs
+++ b/examples/multi_suggestion.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Patch, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Patch, Renderer, Snippet, renderer::DecorStyle};
 
 fn main() {
     let source = r#"

--- a/examples/multislice.rs
+++ b/examples/multislice.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, Annotation, Level, Renderer, Snippet};
+use annotate_snippets::{Annotation, Level, Renderer, Snippet, renderer::DecorStyle};
 
 fn main() {
     let report = &[Level::ERROR

--- a/examples/struct_name_as_context.rs
+++ b/examples/struct_name_as_context.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 fn main() {
     let source = r#"struct S {
     field1: usize,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -29,10 +29,10 @@ use alloc::string::String;
 
 use crate::Report;
 
-pub(crate) use render::normalize_whitespace;
 pub(crate) use render::ElementStyle;
 pub(crate) use render::UnderlineParts;
-pub(crate) use render::{char_width, num_overlap, LineAnnotation, LineAnnotationType};
+pub(crate) use render::normalize_whitespace;
+pub(crate) use render::{LineAnnotation, LineAnnotationType, char_width, num_overlap};
 pub(crate) use stylesheet::Stylesheet;
 
 pub use anstyle::*;

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -4,15 +4,15 @@ use alloc::borrow::{Cow, ToOwned};
 use alloc::collections::BTreeMap;
 use alloc::string::{String, ToString};
 use alloc::{format, vec, vec::Vec};
-use core::cmp::{max, min, Ordering, Reverse};
+use core::cmp::{Ordering, Reverse, max, min};
 use core::fmt;
 
 use anstyle::Style;
 
-use super::margin::Margin;
-use super::stylesheet::Stylesheet;
 use super::DecorStyle;
 use super::Renderer;
+use super::margin::Margin;
+use super::stylesheet::Stylesheet;
 use crate::level::{Level, LevelInner};
 use crate::renderer::source_map::{
     AnnotatedLineInfo, LineInfo, Loc, SourceMap, SplicedLines, SubstitutionHighlight, TrimmedPatch,
@@ -2761,7 +2761,7 @@ fn newline_count(body: &str) -> usize {
 
 #[cfg(test)]
 mod test {
-    use super::{newline_count, OUTPUT_REPLACEMENTS};
+    use super::{OUTPUT_REPLACEMENTS, newline_count};
     use snapbox::IntoData;
 
     fn format_replacements(replacements: Vec<(char, &str)>) -> String {

--- a/src/renderer/source_map.rs
+++ b/src/renderer/source_map.rs
@@ -4,7 +4,7 @@ use alloc::{vec, vec::Vec};
 use core::cmp::{max, min};
 use core::ops::Range;
 
-use crate::renderer::{char_width, num_overlap, LineAnnotation, LineAnnotationType};
+use crate::renderer::{LineAnnotation, LineAnnotationType, char_width, num_overlap};
 use crate::{Annotation, AnnotationKind, Patch};
 
 #[derive(Debug)]

--- a/src/renderer/styled_buffer.rs
+++ b/src/renderer/styled_buffer.rs
@@ -6,9 +6,9 @@ use alloc::string::String;
 use alloc::{vec, vec::Vec};
 use core::fmt::{self, Write};
 
-use crate::renderer::stylesheet::Stylesheet;
-use crate::renderer::ElementStyle;
 use crate::Level;
+use crate::renderer::ElementStyle;
+use crate::renderer::stylesheet::Stylesheet;
 
 #[derive(Debug)]
 pub(crate) struct StyledBuffer {

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -5,8 +5,8 @@ use alloc::string::String;
 use alloc::{vec, vec::Vec};
 use core::ops::Range;
 
-use crate::renderer::source_map::{as_substr, TrimmedPatch};
 use crate::Level;
+use crate::renderer::source_map::{TrimmedPatch, as_substr};
 
 pub(crate) const ERROR_TXT: &str = "error";
 pub(crate) const HELP_TXT: &str = "help";

--- a/tests/color/ann_eof.rs
+++ b/tests/color/ann_eof.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/ann_insertion.rs
+++ b/tests/color/ann_insertion.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/ann_multiline.rs
+++ b/tests/color/ann_multiline.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/ann_multiline2.rs
+++ b/tests/color/ann_multiline2.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/ann_removed_nl.rs
+++ b/tests/color/ann_removed_nl.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/ensure_emoji_highlight_width.rs
+++ b/tests/color/ensure_emoji_highlight_width.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/first_snippet_is_primary.rs
+++ b/tests/color/first_snippet_is_primary.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/fold_ann_multiline.rs
+++ b/tests/color/fold_ann_multiline.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/fold_bad_origin_line.rs
+++ b/tests/color/fold_bad_origin_line.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/fold_leading.rs
+++ b/tests/color/fold_leading.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/fold_trailing.rs
+++ b/tests/color/fold_trailing.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/highlight_diff_line_with_wide_characters.rs
+++ b/tests/color/highlight_diff_line_with_wide_characters.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Patch, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Patch, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/highlight_duplicated_diff_lines.rs
+++ b/tests/color/highlight_duplicated_diff_lines.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Patch, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Patch, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/highlight_source.rs
+++ b/tests/color/highlight_source.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/issue_9.rs
+++ b/tests/color/issue_9.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/multiline_removal_last_line_tabs.rs
+++ b/tests/color/multiline_removal_last_line_tabs.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, Group, Level, Patch, Renderer, Snippet};
+use annotate_snippets::{Group, Level, Patch, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/multiline_removal_suggestion.rs
+++ b/tests/color/multiline_removal_suggestion.rs
@@ -1,5 +1,5 @@
 use annotate_snippets::{
-    renderer::DecorStyle, AnnotationKind, Level, Origin, Patch, Renderer, Snippet,
+    AnnotationKind, Level, Origin, Patch, Renderer, Snippet, renderer::DecorStyle,
 };
 
 use snapbox::{assert_data_eq, file};

--- a/tests/color/multiple_annotations.rs
+++ b/tests/color/multiple_annotations.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/multiple_highlight_duplicated.rs
+++ b/tests/color/multiple_highlight_duplicated.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Patch, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Patch, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/multiple_multiline_removal.rs
+++ b/tests/color/multiple_multiline_removal.rs
@@ -1,5 +1,5 @@
 use annotate_snippets::{
-    renderer::DecorStyle, AnnotationKind, Level, Origin, Padding, Patch, Renderer, Snippet,
+    AnnotationKind, Level, Origin, Padding, Patch, Renderer, Snippet, renderer::DecorStyle,
 };
 
 use snapbox::{assert_data_eq, file};

--- a/tests/color/primary_title_second_group.rs
+++ b/tests/color/primary_title_second_group.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Group, Level, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/simple.rs
+++ b/tests/color/simple.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/strip_line.rs
+++ b/tests/color/strip_line.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/strip_line_char.rs
+++ b/tests/color/strip_line_char.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/strip_line_non_ws.rs
+++ b/tests/color/strip_line_non_ws.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 
 use snapbox::{assert_data_eq, file};
 

--- a/tests/color/styled_title.rs
+++ b/tests/color/styled_title.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{renderer::DecorStyle, AnnotationKind, Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
 use anstyle::{AnsiColor, Effects, Style};
 
 use snapbox::{assert_data_eq, file};
@@ -15,7 +15,9 @@ use c::cnb_runtime;
 "#;
 
     let title_1 = "the trait bound `CustomErrorHandler: ErrorHandler` is not satisfied";
-    let title_2 = format!("{BOLD}there are {BOLD:#}{MAGENTA}multiple different versions{MAGENTA:#}{BOLD} of crate `{BOLD:#}{MAGENTA}c{MAGENTA:#}{BOLD}` in the dependency graph{BOLD:#}");
+    let title_2 = format!(
+        "{BOLD}there are {BOLD:#}{MAGENTA}multiple different versions{MAGENTA:#}{BOLD} of crate `{BOLD:#}{MAGENTA}c{MAGENTA:#}{BOLD}` in the dependency graph{BOLD:#}"
+    );
 
     let label_1 = "the trait `ErrorHandler` is not implemented for `CustomErrorHandler`";
     let label_2 = "required by a bound introduced by this call";

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -3686,7 +3686,7 @@ fn main() {
 }
 "#;
 
-    let long_title1 ="this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021";
+    let long_title1 = "this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021";
     let long_title2 = "for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>";
     let long_title3 = "or use `IntoIterator::into_iter(..)` instead of `.into_iter()` to explicitly iterate by value";
 
@@ -3775,7 +3775,7 @@ fn main() {
     let suggestion_source = r#"[1, 2, 3].into_iter().for_each(|n| { *n; });
 "#;
 
-    let long_title1 ="this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021";
+    let long_title1 = "this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021";
     let long_title2 = "for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>";
     let long_title3 = "or use `IntoIterator::into_iter(..)` instead of `.into_iter()` to explicitly iterate by value";
 
@@ -3867,7 +3867,7 @@ fn main() {
     let suggestion_source = r#"[1, 2, 3].into_iter().for_each(|n| { *n; });
 "#;
 
-    let long_title1 ="this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021";
+    let long_title1 = "this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021";
     let long_title2 = "for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>";
     let long_title3 = "or use `IntoIterator::into_iter(..)` instead of `.into_iter()` to explicitly iterate by value";
 
@@ -3959,7 +3959,7 @@ fn main() {
     let suggestion_source = r#"[1, 2, 3].into_iter().for_each(|n| { *n; });
 "#;
 
-    let long_title1 ="this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021";
+    let long_title1 = "this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021";
     let long_title2 = "for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>";
     let long_title3 = "or use `IntoIterator::into_iter(..)` instead of `.into_iter()` to explicitly iterate by value";
 

--- a/tests/rustc_tests.rs
+++ b/tests/rustc_tests.rs
@@ -5,7 +5,7 @@
 use annotate_snippets::{AnnotationKind, Group, Level, Origin, Padding, Patch, Renderer, Snippet};
 
 use annotate_snippets::renderer::DecorStyle;
-use snapbox::{assert_data_eq, str, IntoData};
+use snapbox::{IntoData, assert_data_eq, str};
 
 #[test]
 fn ends_on_col0() {
@@ -3438,7 +3438,9 @@ $DIR/short-error-format.rs:6:9: error[E0308]: mismatched types: expected `u32`, 
     let renderer = Renderer::plain().short_message(true);
     assert_data_eq!(renderer.render(input), expected_ascii);
 
-    let expected_unicode = str!["$DIR/short-error-format.rs:6:9: error[E0308]: mismatched types: expected `u32`, found `String`"];
+    let expected_unicode = str![
+        "$DIR/short-error-format.rs:6:9: error[E0308]: mismatched types: expected `u32`, found `String`"
+    ];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
@@ -3477,7 +3479,9 @@ $DIR/short-error-format.rs:8:7: error[E0599]: no method named `salut` found for 
     let renderer = Renderer::plain().short_message(true);
     assert_data_eq!(renderer.render(input), expected_ascii);
 
-    let expected_unicode = str!["$DIR/short-error-format.rs:8:7: error[E0599]: no method named `salut` found for type `u32` in the current scope: method not found in `u32`"];
+    let expected_unicode = str![
+        "$DIR/short-error-format.rs:8:7: error[E0599]: no method named `salut` found for type `u32` in the current scope: method not found in `u32`"
+    ];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
@@ -3577,7 +3581,7 @@ fn main() {
     let source2 = r#"[1, 2, 3].into_iter().for_each(|n| { *n; });
 "#;
 
-    let long_title1 ="this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021";
+    let long_title1 = "this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021";
     let long_title2 = "for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>";
     let long_title3 = "or use `IntoIterator::into_iter(..)` instead of `.into_iter()` to explicitly iterate by value";
 


### PR DESCRIPTION
Unsure how the minimal versions job was failing but we also needed an `anstyle` version req bump