### PR TITLE
chore: Address clippy::explicit_counter_loop

### DIFF
--- a/src/renderer/styled_buffer.rs
+++ b/src/renderer/styled_buffer.rs
@@ -82,10 +82,8 @@ impl StyledBuffer {
     /// If `line` does not exist in our buffer, adds empty lines up to the given
     /// and fills the last line with unstyled whitespace.
     pub(crate) fn puts(&mut self, line: usize, col: usize, string: &str, style: ElementStyle) {
-        let mut n = col;
-        for c in string.chars() {
-            self.putc(line, n, c, style);
-            n += 1;
+        for (offset, c) in string.chars().enumerate() {
+            self.putc(line, col + offset, c, style);
         }
     }
 


### PR DESCRIPTION
I update the nightly version of Rust that I use and encountered a new clippy warning, this addresses it.

```
warning: the variable `n` is used as a loop counter
  --> src/renderer/styled_buffer.rs:86:9
   |
86 |         for c in string.chars() {
   |         ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `for (n, c) in (col..).zip(string.chars())`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_counter_loop
   = note: `#[warn(clippy::explicit_counter_loop)]` on by default
```