### PR TITLE
chore: Use origin rendering code for suggestions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 repository = "https://github.com/rust-lang/annotate-snippets-rs"
 license = "MIT OR Apache-2.0"
 edition = "2024"
-rust-version = "1.85.0"  # MSRV
+rust-version = "1.88.0"  # MSRV
 include = [
   "build.rs",
   "src/**/*",

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -1098,27 +1098,26 @@ fn render_source_line(
     if annotations_position
         .iter()
         .all(|(_, ann)| matches!(ann.annotation_type, LineAnnotationType::MultilineStart(_)))
+        && let Some(max_pos) = annotations_position.iter().map(|(pos, _)| *pos).max()
     {
-        if let Some(max_pos) = annotations_position.iter().map(|(pos, _)| *pos).max() {
-            // Special case the following, so that we minimize overlapping multiline spans.
-            //
-            // 3 │       X0 Y0 Z0
-            //   │ ┏━━━━━┛  │  │     < We are writing these lines
-            //   │ ┃┌───────┘  │     < by reverting the "depth" of
-            //   │ ┃│┌─────────┘     < their multiline spans.
-            // 4 │ ┃││   X1 Y1 Z1
-            // 5 │ ┃││   X2 Y2 Z2
-            //   │ ┃│└────╿──│──┘ `Z` label
-            //   │ ┃└─────│──┤
-            //   │ ┗━━━━━━┥  `Y` is a good letter too
-            //   ╰╴       `X` is a good letter
-            for (pos, _) in &mut annotations_position {
-                *pos = max_pos - *pos;
-            }
-            // We know then that we don't need an additional line for the span label, saving us
-            // one line of vertical space.
-            line_len = line_len.saturating_sub(1);
+        // Special case the following, so that we minimize overlapping multiline spans.
+        //
+        // 3 │       X0 Y0 Z0
+        //   │ ┏━━━━━┛  │  │     < We are writing these lines
+        //   │ ┃┌───────┘  │     < by reverting the "depth" of
+        //   │ ┃│┌─────────┘     < their multiline spans.
+        // 4 │ ┃││   X1 Y1 Z1
+        // 5 │ ┃││   X2 Y2 Z2
+        //   │ ┃│└────╿──│──┘ `Z` label
+        //   │ ┃└─────│──┤
+        //   │ ┗━━━━━━┥  `Y` is a good letter too
+        //   ╰╴       `X` is a good letter
+        for (pos, _) in &mut annotations_position {
+            *pos = max_pos - *pos;
         }
+        // We know then that we don't need an additional line for the span label, saving us
+        // one line of vertical space.
+        line_len = line_len.saturating_sub(1);
     }
 
     // Write the column separator.
@@ -1447,40 +1446,37 @@ fn emit_suggestion_default(
     let (complete, parts, highlights) = spliced_lines;
     let is_multiline = complete.lines().count() > 1;
 
-    match suggestion.path.as_ref() {
-        Some(path) if suggestion.path.as_ref() != primary_path && !matches_previous_suggestion => {
-            let (loc, _) = sm.span_to_locations(parts[0].span.clone());
-            let origin = Origin::path(path.as_ref())
-                .line(loc.line)
-                .char_column(loc.char + 1);
+    if suggestion.path.as_ref() != primary_path
+        && let Some(path) = suggestion.path.as_ref()
+        && !matches_previous_suggestion
+    {
+        let (loc, _) = sm.span_to_locations(parts[0].span.clone());
+        let origin = Origin::path(path.as_ref())
+            .line(loc.line)
+            .char_column(loc.char + 1);
 
-            render_origin(
-                renderer,
-                buffer,
-                max_line_num_len,
-                &origin,
-                true,
-                is_first,
-                !is_cont,
-                row_num - 1,
-            );
-            row_num += 1;
+        render_origin(
+            renderer,
+            buffer,
+            max_line_num_len,
+            &origin,
+            true,
+            is_first,
+            !is_cont,
+            row_num - 1,
+        );
+        row_num += 1;
 
-            draw_col_separator_no_space(renderer, buffer, row_num - 1, max_line_num_len + 1);
-        }
-
-        _ if matches_previous_suggestion => {
-            buffer.puts(
-                row_num - 1,
-                max_line_num_len + 1,
-                renderer.decor_style.multi_suggestion_separator(),
-                ElementStyle::LineNumber,
-            );
-        }
-
-        _ => {
-            draw_col_separator_start(renderer, buffer, row_num - 1, max_line_num_len + 1);
-        }
+        draw_col_separator_no_space(renderer, buffer, row_num - 1, max_line_num_len + 1);
+    } else if matches_previous_suggestion {
+        buffer.puts(
+            row_num - 1,
+            max_line_num_len + 1,
+            renderer.decor_style.multi_suggestion_separator(),
+            ElementStyle::LineNumber,
+        );
+    } else {
+        draw_col_separator_start(renderer, buffer, row_num - 1, max_line_num_len + 1);
     }
 
     if let DisplaySuggestion::Diff = show_code_change {

--- a/src/renderer/styled_buffer.rs
+++ b/src/renderer/styled_buffer.rs
@@ -159,12 +159,11 @@ impl StyledBuffer {
         style: ElementStyle,
         overwrite: bool,
     ) {
-        if let Some(ref mut line) = self.lines.get_mut(line) {
-            if let Some(StyledChar { style: s, .. }) = line.get_mut(col) {
-                if overwrite || matches!(s, ElementStyle::NoStyle | ElementStyle::Quotation) {
-                    *s = style;
-                }
-            }
+        if let Some(ref mut line) = self.lines.get_mut(line)
+            && let Some(StyledChar { style: s, .. }) = line.get_mut(col)
+            && (overwrite || matches!(s, ElementStyle::NoStyle | ElementStyle::Quotation))
+        {
+            *s = style;
         }
     }
 }


### PR DESCRIPTION
it turns out `emit_suggestion_default` has its own code to display the origin at which a suggestion should be applied.

i think this is not optimal because some code is duplicated, and keeping it as leads to even more duplication being added as part of my work on #386.

this commit removes the custom origin display code in `emit_suggestion_default` and uses `render_origin` (which AFAIK is used everywhere else in `annotate_snippets`) instead.

i ran `rustc`'s `test/ui` tests against this change and it resulted in no oracle change. while i cannot assert rendering hasn't changed at all, i am reasonably confident that this commit does not break anything.

first commit adds what is described above. second commit uses let chains (which IMO makes the code clearer) and bumps the MSRV to 1.88.0 (released on 26 June, 2025), which is required for let chains. happy to drop the second commit if y'all think this does not warrant an MSRV bump. to be clear, having let chains would help a lot for #386 as well. it's not just this PR.