### PR TITLE
fix: prevent panic in StyledBuffer::replace when term_width <= 10

### DIFF
--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -1392,24 +1392,28 @@ fn render_source_line(
             continue;
         };
         let width = annotation.end.display - annotation.start.display;
-        if width > margin.term_width * 2 && width > 10 {
+        if margin.term_width > 0 && width > margin.term_width * 2 && width > 10 {
             // If the terminal is *too* small, we keep at least a tiny bit of the span for
             // display.
             let pad = max(margin.term_width / 3, 5);
-            // Code line
-            buffer.replace(
-                line_offset,
-                annotation.start.display + pad,
-                annotation.end.display - pad,
-                renderer.decor_style.margin(),
-            );
-            // Underline line
-            buffer.replace(
-                line_offset + 1,
-                annotation.start.display + pad,
-                annotation.end.display - pad,
-                renderer.decor_style.margin(),
-            );
+            let replace_start = annotation.start.display + pad;
+            let replace_end = annotation.end.display.saturating_sub(pad);
+            if replace_start < replace_end {
+                // Code line
+                buffer.replace(
+                    line_offset,
+                    replace_start,
+                    replace_end,
+                    renderer.decor_style.margin(),
+                );
+                // Underline line
+                buffer.replace(
+                    line_offset + 1,
+                    replace_start,
+                    replace_end,
+                    renderer.decor_style.margin(),
+                );
+            }
         }
     }
     annotations_position

--- a/src/renderer/styled_buffer.rs
+++ b/src/renderer/styled_buffer.rs
@@ -99,7 +99,7 @@ impl StyledBuffer {
     }
 
     pub(crate) fn replace(&mut self, line: usize, start: usize, end: usize, string: &str) {
-        if start == end {
+        if start >= end {
             return;
         }
         // If the replacement range would be out of bounds, do nothing, as we
@@ -107,9 +107,16 @@ impl StyledBuffer {
         if start > self.lines[line].len() || end > self.lines[line].len() {
             return;
         }
-        let _ = self.lines[line].drain(start..(end - string.chars().count()));
+        let char_count = string.chars().count();
+        let drain_end = end.saturating_sub(char_count);
+        if drain_end <= start {
+            return;
+        }
+        let _ = self.lines[line].drain(start..drain_end);
         for (i, c) in string.chars().enumerate() {
-            self.lines[line][start + i] = StyledChar::new(c, ElementStyle::LineNumber);
+            if start + i < self.lines[line].len() {
+                self.lines[line][start + i] = StyledChar::new(c, ElementStyle::LineNumber);
+            }
         }
     }
 

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -5070,3 +5070,52 @@ help: consider importing this module instead
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
+
+#[test]
+fn narrow_term_width_no_panic() {
+    // Regression test: term_width <= 10 caused a panic in StyledBuffer::replace
+    // when rendering an annotation whose display width exceeds 10 columns.
+    //
+    // The span-trimming logic computes pad = max(term_width / 3, 5), then calls
+    // replace(start + pad, end - pad, "..."). When term_width is 0, pad = 5,
+    // and for a span of width 11-12, start + 5 > end - 5, producing an inverted
+    // range that panics in Vec::drain.
+    //
+    // Reproduces in rustc 1.94.0+ with:
+    //   echo 'pub fn f() { let mut foo_bar = 0; }' > ice.rs
+    //   rustc --diagnostic-width=0 --crate-type lib ice.rs
+    //
+    // https://github.com/furkanmamuk/rustc-ice-diagnostic-width-panic
+
+    // Simulate the unused_mut diagnostic: annotation over "mut foo_bar"
+    // Span columns 17..29 = 12 display columns (just over the width>10 threshold)
+    let source = "pub fn f() { let mut foo_bar = 0; }";
+    let input = &[Level::WARNING
+        .primary_title("variable does not need to be mutable")
+        .element(
+            Snippet::source(source).path("ice.rs").annotation(
+                AnnotationKind::Primary
+                    .span(17..29)
+                    .label("help: remove this `mut`"),
+            ),
+        )];
+
+    // Must not panic at any width, including 0
+    for w in 0..=20 {
+        let renderer = Renderer::plain().term_width(w);
+        let _ = renderer.render(input);
+    }
+
+    // Also test with a very wide annotation (the original trimming use case)
+    let wide_source = "let x = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];";
+    let wide_input = &[Level::ERROR.primary_title("type mismatch").element(
+        Snippet::source(wide_source)
+            .path("test.rs")
+            .annotation(AnnotationKind::Primary.span(8..68).label("expected &[u8]")),
+    )];
+
+    for w in 0..=20 {
+        let renderer = Renderer::plain().term_width(w);
+        let _ = renderer.render(wide_input);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #391

`StyledBuffer::replace` panics with "slice index starts at 13 but ends at 11" when `term_width` is 10 or less and an annotation's display width exceeds 10 columns. This causes an ICE in rustc 1.94.0+ (https://github.com/rust-lang/rust/issues/154258).

## Root cause

The span-trimming logic computes `pad = max(term_width / 3, 5)` then calls `replace(start + pad, end - pad, "...")`. When `term_width` is 0, `pad` is 5, and for annotations with display width between 11 and `2 * pad`, `start + pad > end - pad`, producing an inverted range that panics in `Vec::drain`.

## Changes

**`src/renderer/render.rs`**
- Skip the trimming path when `term_width == 0` (no terminal = don't try to fit)
- Use `saturating_sub` for the end calculation
- Guard `replace_start < replace_end` before calling `replace`

**`src/renderer/styled_buffer.rs`**
- `start >= end` early return (was `start == end`)
- `saturating_sub` for the drain end calculation
- Guard `drain_end <= start`
- Bounds check on the write loop

**`tests/formatter.rs`**
- Regression test: `narrow_term_width_no_panic` covering widths 0-20 with both a narrow annotation (12 columns, the threshold case) and a wide annotation (60 columns, the normal trimming case)

## Reproducer

```bash
echo 'pub fn f() { let mut foo_bar = 0; }' > ice.rs
rustc +1.94.0 --edition=2021 --crate-type lib --diagnostic-width=0 ice.rs
```

https://github.com/furkanmamuk/rustc-ice-diagnostic-width-panic