### PR TITLE
Fix removal highlighting for multiple indented lines

### DIFF
--- a/src/renderer/source_map.rs
+++ b/src/renderer/source_map.rs
@@ -556,10 +556,8 @@ impl<'a> SourceMap<'a> {
                 }
             }
         }
-        // remove trailing newlines
-        while buf.ends_with('\n') {
-            buf.pop();
-        }
+        // remove trailing whitespace
+        buf.truncate(buf.trim_end().len());
         if highlights.iter().all(|parts| parts.is_empty()) {
             None
         } else {

--- a/tests/color/main.rs
+++ b/tests/color/main.rs
@@ -16,6 +16,7 @@ mod highlight_source;
 mod highlight_source_multi_width_chars;
 mod highlight_source_zero_width_chars;
 mod issue_9;
+mod multiline_removal_indent;
 mod multiline_removal_last_line_tabs;
 mod multiline_removal_suggestion;
 mod multiple_annotations;

--- a/tests/color/multiline_removal_indent.ascii.term.svg
+++ b/tests/color/multiline_removal_indent.ascii.term.svg
@@ -1,0 +1,34 @@
+<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-blue bold">2</tspan><tspan> </tspan><tspan class="fg-bright-red">-   local function f()</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">3</tspan><tspan> </tspan><tspan class="fg-bright-red">-     print()</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">4</tspan><tspan> </tspan><tspan class="fg-bright-red">-   end</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/multiline_removal_indent.rs
+++ b/tests/color/multiline_removal_indent.rs
@@ -1,0 +1,19 @@
+use annotate_snippets::{Group, Level, Patch, Renderer, Snippet, renderer::DecorStyle};
+
+use snapbox::{assert_data_eq, file};
+
+#[test]
+fn test() {
+    let report = &[Group::with_level(Level::ERROR).element(
+        Snippet::source("do\n  local function f()\n    print()\n  end\nend\n")
+            .patch(Patch::new(5..41, "")),
+    )];
+
+    let expected_ascii = file!["multiline_removal_indent.ascii.term.svg": TermSvg];
+    let renderer = Renderer::styled();
+    assert_data_eq!(renderer.render(report), expected_ascii);
+
+    let expected_unicode = file!["multiline_removal_indent.unicode.term.svg": TermSvg];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(report), expected_unicode);
+}

--- a/tests/color/multiline_removal_indent.unicode.term.svg
+++ b/tests/color/multiline_removal_indent.unicode.term.svg
@@ -1,0 +1,34 @@
+<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>  </tspan><tspan class="fg-bright-blue bold">╭╴</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-blue bold">2</tspan><tspan> </tspan><tspan class="fg-bright-red">-   local function f()</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">3</tspan><tspan> </tspan><tspan class="fg-bright-red">-     print()</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">4</tspan><tspan> </tspan><tspan class="fg-bright-red">-   end</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-bright-blue bold">╰╴</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/multiple_highlight_duplicated.ascii.term.svg
+++ b/tests/color/multiple_highlight_duplicated.ascii.term.svg
@@ -65,7 +65,7 @@
 </tspan>
     <tspan x="10px" y="406px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan class="fg-bright-blue bold">23</tspan><tspan> </tspan><tspan class="fg-bright-red">- </tspan><tspan>        </tspan><tspan class="fg-bright-red">String::from(""),</tspan>
+    <tspan x="10px" y="424px"><tspan class="fg-bright-blue bold">23</tspan><tspan> </tspan><tspan class="fg-bright-red">-         String::from(""),</tspan>
 </tspan>
     <tspan x="10px" y="442px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>

--- a/tests/color/multiple_highlight_duplicated.unicode.term.svg
+++ b/tests/color/multiple_highlight_duplicated.unicode.term.svg
@@ -65,7 +65,7 @@
 </tspan>
     <tspan x="10px" y="406px"><tspan>   </tspan><tspan class="fg-bright-blue bold">├╴</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan class="fg-bright-blue bold">23</tspan><tspan> </tspan><tspan class="fg-bright-red">- </tspan><tspan>        </tspan><tspan class="fg-bright-red">String::from(""),</tspan>
+    <tspan x="10px" y="424px"><tspan class="fg-bright-blue bold">23</tspan><tspan> </tspan><tspan class="fg-bright-red">-         String::from(""),</tspan>
 </tspan>
     <tspan x="10px" y="442px"><tspan>   </tspan><tspan class="fg-bright-blue bold">├╴</tspan>
 </tspan>


### PR DESCRIPTION
Fix for #405.

I think this change should cause partially removed lines, where only whitespace characters remain, to be treated like completely removed lines.

All tests pass except for `multiple_highlight_duplicated`, which does however not show any visual changes. The only difference is that previously some whitespace characters where not highlighted in red.