### PR TITLE
Correctly highlight multi-line removals that leave only whitespace

### DIFF
--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -1447,7 +1447,7 @@ fn emit_suggestion_default(
 ) {
     let buffer_offset = buffer.num_lines();
     let mut row_num = buffer_offset + usize::from(!matches_previous_suggestion);
-    let (complete, parts, highlights) = spliced_lines;
+    let (complete, parts, highlights, replaced_highlights) = spliced_lines;
     let is_multiline = complete.lines().count() > 1;
 
     if matches_previous_suggestion {
@@ -1621,9 +1621,7 @@ fn emit_suggestion_default(
     if let DisplaySuggestion::Diff | DisplaySuggestion::Underline | DisplaySuggestion::Add =
         show_code_change
     {
-        let mut prev_lines: Option<(usize, usize)> = None;
         for part in parts {
-            let snippet = sm.span_to_snippet(part.span.clone()).unwrap_or_default();
             let (span_start, span_end) = sm.span_to_locations(part.span.clone());
             let span_start_pos = span_start.display;
             let span_end_pos = span_end.display;
@@ -1679,96 +1677,21 @@ fn emit_suggestion_default(
                 }
             }
             if let DisplaySuggestion::Diff = show_code_change {
-                // Colorize removal with red in diff format.
+                let min_row = buffer_offset + usize::from(!matches_previous_suggestion);
 
-                // Below, there's some tricky buffer indexing going on. `row_num` at this
-                // point corresponds to:
-                //
-                //    |
-                // LL | CODE
-                //    | ++++  <- `row_num`
-                //
-                // in the buffer. When we have a diff format output, we end up with
-                //
-                //    |
-                // LL - OLDER   <- row_num - 2
-                // LL + NEWER
-                //    |         <- row_num
-                //
-                // The `row_num - 2` is to select the buffer line that has the "old version
-                // of the diff" at that point. When the removal is a single line, `i` is
-                // `0`, `newlines` is `1` so `(newlines - i - 1)` ends up being `0`, so row
-                // points at `LL - OLDER`. When the removal corresponds to multiple lines,
-                // we end up with `newlines > 1` and `i` being `0..newlines - 1`.
-                //
-                //    |
-                // LL - OLDER   <- row_num - 2 - (newlines - last_i - 1)
-                // LL - CODE
-                // LL - BEING
-                // LL - REMOVED <- row_num - 2 - (newlines - first_i - 1)
-                // LL + NEWER
-                //    |         <- row_num
-
-                let newlines = snippet.lines().count();
-                let offset = match prev_lines {
-                    Some((start, end)) => {
-                        file_lines.len().saturating_sub(end.saturating_sub(start))
-                    }
-                    None => file_lines.len(),
-                };
-                // FIXME: We check the number of rows because in some cases, like in
-                // `tests/ui/lint/invalid-nan-comparison-suggestion.rs`, the rendered
-                // suggestion will only show the first line of code being replaced. The
-                // proper way of doing this would be to change the suggestion rendering
-                // logic to show the whole prior snippet, but the current output is not
-                // too bad to begin with, so we side-step that issue here.
-                for (i, line) in snippet.lines().enumerate() {
-                    let norm_line = normalize_whitespace(line);
-                    // Going lower than buffer_offset (+ 1) would mean
-                    // overwriting existing content in the buffer
-                    let min_row = buffer_offset + usize::from(!matches_previous_suggestion);
-                    let row = (row_num - 2 - (offset - i - 1)).max(min_row);
-                    let (start, end) = match i {
-                        0 if span_start.line == span_end.line => {
-                            // If the removed code fits all in one line, highlight between the
-                            // start and end columns of the part span.
-                            let full_line = sm.get_line(span_start.line).unwrap_or_default();
-                            // We calculate the extra width from tabs for both the start and end of
-                            // the span, as tabs could be present in the middle of the span
-                            (
-                                span_start.char + extra_width_from_tabs(full_line, span_start.char),
-                                span_end.char + extra_width_from_tabs(full_line, span_end.char),
-                            )
-                        }
-                        0 => {
-                            // On the first line, we highlight between the start of the part
-                            // span, and the end of that line.
-                            let full_line = sm.get_line(span_start.line).unwrap_or_default();
-                            let extra_width = extra_width_from_tabs(full_line, span_start.char);
-                            let start = span_start.char + extra_width;
-                            (start, start + norm_line.chars().count())
-                        }
-                        x if x == newlines - 1 => {
-                            // On the last line, we highlight between the start of the line, and
-                            // the column of the part span end.
-                            let extra_width = extra_width_from_tabs(line, span_end.char);
-                            (0, span_end.char + extra_width)
-                        }
-                        _ => {
-                            // On all others, we highlight the whole line.
-                            (0, norm_line.chars().count())
-                        }
-                    };
-                    buffer.set_style_range(
-                        row,
-                        padding + start,
-                        padding + end,
+                for (i, (line_info, parts)) in
+                    file_lines.iter().zip(&replaced_highlights).enumerate()
+                {
+                    let row = (row_num - 2 - (file_lines.len() - i - 1)).max(min_row);
+                    style_substitution_highlights(
+                        parts,
                         ElementStyle::Removal,
-                        true,
+                        row,
+                        line_info.line,
+                        max_line_num_len,
+                        buffer,
                     );
                 }
-
-                prev_lines = Some((span_start.line, span_end.line));
             }
 
             // length of the code after substitution
@@ -2707,7 +2630,7 @@ fn pre_process<'a>(
                 }
                 Element::Suggestion(suggestion) => {
                     let sm = SourceMap::new(&suggestion.source, suggestion.line_start);
-                    if let Some((complete, patches, highlights)) =
+                    if let Some((complete, patches, highlights, replaced_highlights)) =
                         sm.splice_lines(suggestion.markers.clone(), suggestion.fold)
                     {
                         let display_suggestion = DisplaySuggestion::new(&complete, &patches, &sm);
@@ -2740,7 +2663,7 @@ fn pre_process<'a>(
                         elements.push(PreProcessedElement::Suggestion((
                             suggestion,
                             sm,
-                            (complete, patches, highlights),
+                            (complete, patches, highlights, replaced_highlights),
                             display_suggestion,
                         )));
                     }

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -1970,24 +1970,42 @@ fn draw_code_line(
         );
     }
 
-    // Colorize addition/replacements with green.
+    style_substitution_highlights(
+        highlight_parts,
+        ElementStyle::Addition,
+        *row_num,
+        line_to_add,
+        max_line_num_len,
+        buffer,
+    );
+
+    *row_num += 1;
+}
+
+fn style_substitution_highlights(
+    highlight_parts: &[SubstitutionHighlight],
+    style: ElementStyle,
+    row_num: usize,
+    unnormalized_line: &str,
+    max_line_num_len: usize,
+    buffer: &mut StyledBuffer,
+) {
     for &SubstitutionHighlight { start, end } in highlight_parts {
         // This is a no-op for empty ranges
         if start != end {
             // We calculate the extra width from tabs for both the start and end
             // of the span, as tabs could be present in the middle of the span
-            let extra_width_start: usize = extra_width_from_tabs(line_to_add, start);
-            let extra_width_end: usize = extra_width_from_tabs(line_to_add, end);
+            let extra_width_start: usize = extra_width_from_tabs(unnormalized_line, start);
+            let extra_width_end: usize = extra_width_from_tabs(unnormalized_line, end);
             buffer.set_style_range(
-                *row_num,
+                row_num,
                 max_line_num_len + 3 + start + extra_width_start,
                 max_line_num_len + 3 + end + extra_width_end,
-                ElementStyle::Addition,
+                style,
                 true,
             );
         }
     }
-    *row_num += 1;
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -1974,12 +1974,14 @@ fn draw_code_line(
     for &SubstitutionHighlight { start, end } in highlight_parts {
         // This is a no-op for empty ranges
         if start != end {
-            // Account for tabs when highlighting (#87972).
-            let extra_width: usize = extra_width_from_tabs(line_to_add, start);
+            // We calculate the extra width from tabs for both the start and end
+            // of the span, as tabs could be present in the middle of the span
+            let extra_width_start: usize = extra_width_from_tabs(line_to_add, start);
+            let extra_width_end: usize = extra_width_from_tabs(line_to_add, end);
             buffer.set_style_range(
                 *row_num,
-                max_line_num_len + 3 + start + extra_width,
-                max_line_num_len + 3 + end + extra_width,
+                max_line_num_len + 3 + start + extra_width_start,
+                max_line_num_len + 3 + end + extra_width_end,
                 ElementStyle::Addition,
                 true,
             );

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -1539,6 +1539,7 @@ fn emit_suggestion_default(
                     buffer,
                     &mut row_num,
                     &[],
+                    &[],
                     p + line_start.line,
                     l,
                     show_code_change,
@@ -1563,6 +1564,7 @@ fn emit_suggestion_default(
                         renderer,
                         buffer,
                         &mut row_num,
+                        &[],
                         &[],
                         p + line_start.line,
                         l,
@@ -1589,6 +1591,7 @@ fn emit_suggestion_default(
                         buffer,
                         &mut row_num,
                         &[],
+                        &[],
                         p + line_start.line,
                         l,
                         show_code_change,
@@ -1604,6 +1607,7 @@ fn emit_suggestion_default(
             buffer,
             &mut row_num,
             &highlight_parts,
+            &replaced_highlights,
             line_pos + line_start.line,
             line,
             show_code_change,
@@ -1676,23 +1680,6 @@ fn emit_suggestion_default(
                     );
                 }
             }
-            if let DisplaySuggestion::Diff = show_code_change {
-                let min_row = buffer_offset + usize::from(!matches_previous_suggestion);
-
-                for (i, (line_info, parts)) in
-                    file_lines.iter().zip(&replaced_highlights).enumerate()
-                {
-                    let row = (row_num - 2 - (file_lines.len() - i - 1)).max(min_row);
-                    style_substitution_highlights(
-                        parts,
-                        ElementStyle::Removal,
-                        row,
-                        line_info.line,
-                        max_line_num_len,
-                        buffer,
-                    );
-                }
-            }
 
             // length of the code after substitution
             let full_sub_len = str_width(&part.replacement) as isize;
@@ -1738,6 +1725,7 @@ fn draw_code_line(
     buffer: &mut StyledBuffer,
     row_num: &mut usize,
     highlight_parts: &[SubstitutionHighlight],
+    replaced_parts: &[Vec<SubstitutionHighlight>],
     line_num: usize,
     line_to_add: &str,
     show_code_change: DisplaySuggestion,
@@ -1749,7 +1737,7 @@ fn draw_code_line(
         // We need to print more than one line if the span we need to remove is multiline.
         // For more info: https://github.com/rust-lang/rust/issues/92741
         let lines_to_remove = file_lines.iter().take(file_lines.len() - 1);
-        for (index, line_to_remove) in lines_to_remove.enumerate() {
+        for (index, (line_to_remove, parts)) in lines_to_remove.zip(replaced_parts).enumerate() {
             buffer.puts(
                 *row_num - 1,
                 0,
@@ -1769,6 +1757,14 @@ fn draw_code_line(
                 &line,
                 ElementStyle::NoStyle,
             );
+            style_substitution_highlights(
+                parts,
+                ElementStyle::Removal,
+                *row_num - 1,
+                line_to_remove.line,
+                max_line_num_len,
+                buffer,
+            );
             *row_num += 1;
         }
         // If the last line is exactly equal to the line we need to add, we can skip both of
@@ -1780,6 +1776,16 @@ fn draw_code_line(
         let last_line = &file_lines.last().unwrap();
         if last_line.line == line_to_add {
             *row_num -= 2;
+            // The last original line collapses into the previous drawn row, so
+            // fold its replaced-code highlights onto that row too.
+            style_substitution_highlights(
+                replaced_parts.last().unwrap(),
+                ElementStyle::Removal,
+                *row_num,
+                last_line.line,
+                max_line_num_len,
+                buffer,
+            );
         } else {
             buffer.puts(
                 *row_num - 1,
@@ -1799,6 +1805,15 @@ fn draw_code_line(
                 &normalize_whitespace(last_line.line),
                 ElementStyle::NoStyle,
             );
+            style_substitution_highlights(
+                replaced_parts.last().unwrap(),
+                ElementStyle::Removal,
+                *row_num - 1,
+                last_line.line,
+                max_line_num_len,
+                buffer,
+            );
+
             if line_to_add.trim().is_empty() {
                 *row_num -= 1;
             } else {

--- a/src/renderer/source_map.rs
+++ b/src/renderer/source_map.rs
@@ -380,13 +380,7 @@ impl<'a> SourceMap<'a> {
         mut patches: Vec<Patch<'b>>,
         fold: bool,
     ) -> Option<SplicedLines<'b>> {
-        fn push_trailing(
-            buf: &mut String,
-            line_opt: Option<&str>,
-            lo: &Loc,
-            hi_opt: Option<&Loc>,
-        ) -> usize {
-            let mut line_count = 0;
+        fn push_trailing(buf: &mut String, line_opt: Option<&str>, lo: &Loc, hi_opt: Option<&Loc>) {
             // Convert CharPos to Usize, as CharPose is character offset
             // Extract low index and high index
             let (lo, hi_opt) = (lo.char, hi_opt.map(|hi| hi.char));
@@ -396,18 +390,10 @@ impl<'a> SourceMap<'a> {
                     let hi_opt = hi_opt.and_then(|hi| line.char_indices().map(|(i, _)| i).nth(hi));
                     match hi_opt {
                         // If high index exist, take string from low to high index
-                        Some(hi) if hi > lo => {
-                            // count how many '\n' exist
-                            line_count = line[lo..hi].matches('\n').count();
-                            buf.push_str(&line[lo..hi]);
-                        }
+                        Some(hi) if hi > lo => buf.push_str(&line[lo..hi]),
                         Some(_) => (),
                         // If high index absence, take string from low index till end string.len
-                        None => {
-                            // count how many '\n' exist
-                            line_count = line[lo..].matches('\n').count();
-                            buf.push_str(&line[lo..]);
-                        }
+                        None => buf.push_str(&line[lo..]),
                     }
                 }
                 // If high index is None
@@ -415,7 +401,6 @@ impl<'a> SourceMap<'a> {
                     buf.push('\n');
                 }
             }
-            line_count
         }
 
         let source_len = self.source.len();
@@ -474,20 +459,11 @@ impl<'a> SourceMap<'a> {
         for part in &trimmed_patches {
             let (cur_lo, cur_hi) = self.span_to_locations(part.span.clone());
             if prev_hi.line == cur_lo.line {
-                let mut count = push_trailing(&mut buf, prev_line, &prev_hi, Some(&cur_lo));
-                while count > 0 {
-                    highlights.push(core::mem::take(&mut line_highlight));
-                    acc = 0;
-                    count -= 1;
-                }
+                push_trailing(&mut buf, prev_line, &prev_hi, Some(&cur_lo));
             } else {
                 acc = 0;
                 highlights.push(core::mem::take(&mut line_highlight));
-                let mut count = push_trailing(&mut buf, prev_line, &prev_hi, None);
-                while count > 0 {
-                    highlights.push(core::mem::take(&mut line_highlight));
-                    count -= 1;
-                }
+                push_trailing(&mut buf, prev_line, &prev_hi, None);
                 // push lines between the previous and current span (if any)
                 for idx in prev_hi.line + 1..(cur_lo.line) {
                     if let Some(line) = self.get_line(idx) {

--- a/src/renderer/source_map.rs
+++ b/src/renderer/source_map.rs
@@ -536,10 +536,28 @@ impl<'a> SourceMap<'a> {
         while buf.ends_with('\n') {
             buf.pop();
         }
+
+        let (bounding_lo, bounding_hi) = self.span_to_locations(lo..hi);
+        let line_count = bounding_hi.line.saturating_sub(bounding_lo.line) + 1;
+        let mut replaced_highlights: Vec<Vec<SubstitutionHighlight>> = vec![Vec::new(); line_count];
+        for part in &trimmed_patches {
+            let (cur_lo, cur_hi) = self.span_to_locations(part.span.clone());
+            for line in cur_lo.line..=cur_hi.line {
+                let start = if line == cur_lo.line { cur_lo.char } else { 0 };
+                let end = if line == cur_hi.line {
+                    cur_hi.char
+                } else {
+                    self.get_line(line).unwrap_or_default().chars().count()
+                };
+                replaced_highlights[line - bounding_lo.line]
+                    .push(SubstitutionHighlight { start, end });
+            }
+        }
+
         if highlights.iter().all(|parts| parts.is_empty()) {
             None
         } else {
-            Some((buf, trimmed_patches, highlights))
+            Some((buf, trimmed_patches, highlights, replaced_highlights))
         }
     }
 }
@@ -699,6 +717,10 @@ impl<'a> Iterator for CursorLines<'a> {
 pub(crate) type SplicedLines<'a> = (
     String,
     Vec<TrimmedPatch<'a>>,
+    // Char spans to highlight per line of the post-substitution output.
+    Vec<Vec<SubstitutionHighlight>>,
+    // Char spans of the replaced (original) code, per original line in the
+    // bounding range covered by the splice.
     Vec<Vec<SubstitutionHighlight>>,
 );
 

--- a/tests/color/main.rs
+++ b/tests/color/main.rs
@@ -16,6 +16,7 @@ mod highlight_source;
 mod highlight_source_multi_width_chars;
 mod highlight_source_zero_width_chars;
 mod issue_9;
+mod multiline_removal_indent;
 mod multiline_removal_last_line_tabs;
 mod multiline_removal_suggestion;
 mod multiple_annotations;

--- a/tests/color/multiline_removal_indent.ascii.term.svg
+++ b/tests/color/multiline_removal_indent.ascii.term.svg
@@ -21,11 +21,11 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-blue bold">2</tspan><tspan> </tspan><tspan class="fg-bright-red">-   local function f()</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-blue bold">2</tspan><tspan> </tspan><tspan class="fg-bright-red">- </tspan><tspan>  </tspan><tspan class="fg-bright-red">local function f()</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">3</tspan><tspan> </tspan><tspan class="fg-bright-red">-     p</tspan><tspan>rint()</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">3</tspan><tspan> </tspan><tspan class="fg-bright-red">-     print()</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">4</tspan><tspan> </tspan><tspan class="fg-bright-red">- </tspan><tspan>  end</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">4</tspan><tspan> </tspan><tspan class="fg-bright-red">-   end</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>

--- a/tests/color/multiline_removal_indent.ascii.term.svg
+++ b/tests/color/multiline_removal_indent.ascii.term.svg
@@ -1,0 +1,34 @@
+<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-blue bold">2</tspan><tspan> </tspan><tspan class="fg-bright-red">-   local function f()</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">3</tspan><tspan> </tspan><tspan class="fg-bright-red">-     p</tspan><tspan>rint()</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">4</tspan><tspan> </tspan><tspan class="fg-bright-red">- </tspan><tspan>  end</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/multiline_removal_indent.rs
+++ b/tests/color/multiline_removal_indent.rs
@@ -1,0 +1,19 @@
+use annotate_snippets::{Group, Level, Patch, Renderer, Snippet, renderer::DecorStyle};
+
+use snapbox::{assert_data_eq, file};
+
+#[test]
+fn test() {
+    let report = &[Group::with_level(Level::ERROR).element(
+        Snippet::source("do\n  local function f()\n    print()\n  end\nend\n")
+            .patch(Patch::new(5..41, "")),
+    )];
+
+    let expected_ascii = file!["multiline_removal_indent.ascii.term.svg": TermSvg];
+    let renderer = Renderer::styled();
+    assert_data_eq!(renderer.render(report), expected_ascii);
+
+    let expected_unicode = file!["multiline_removal_indent.unicode.term.svg": TermSvg];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(report), expected_unicode);
+}

--- a/tests/color/multiline_removal_indent.unicode.term.svg
+++ b/tests/color/multiline_removal_indent.unicode.term.svg
@@ -21,11 +21,11 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan>  </tspan><tspan class="fg-bright-blue bold">╭╴</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-blue bold">2</tspan><tspan> </tspan><tspan class="fg-bright-red">-   local function f()</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-blue bold">2</tspan><tspan> </tspan><tspan class="fg-bright-red">- </tspan><tspan>  </tspan><tspan class="fg-bright-red">local function f()</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">3</tspan><tspan> </tspan><tspan class="fg-bright-red">-     p</tspan><tspan>rint()</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">3</tspan><tspan> </tspan><tspan class="fg-bright-red">-     print()</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">4</tspan><tspan> </tspan><tspan class="fg-bright-red">- </tspan><tspan>  end</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">4</tspan><tspan> </tspan><tspan class="fg-bright-red">-   end</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-bright-blue bold">╰╴</tspan>
 </tspan>

--- a/tests/color/multiline_removal_indent.unicode.term.svg
+++ b/tests/color/multiline_removal_indent.unicode.term.svg
@@ -1,0 +1,34 @@
+<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>  </tspan><tspan class="fg-bright-blue bold">╭╴</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-blue bold">2</tspan><tspan> </tspan><tspan class="fg-bright-red">-   local function f()</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">3</tspan><tspan> </tspan><tspan class="fg-bright-red">-     p</tspan><tspan>rint()</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">4</tspan><tspan> </tspan><tspan class="fg-bright-red">- </tspan><tspan>  end</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-bright-blue bold">╰╴</tspan>
+</tspan>
+  </text>
+
+</svg>


### PR DESCRIPTION
I spent the last few nights investigating the root cause of #405 and trying to come up with a solution, and I finally succeeded. The root cause was that the diff lines were written and highlighted in two different places, leading to differences in how each place got/calculated the `row_num` for a given line. To address this, I made it so that diff lines are written and highlighted in the same location.

fixes #405 


