### PR TITLE
fix: Correctly format suggestion paths when DecorStyle::Unicode

### DIFF
--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -1469,7 +1469,7 @@ fn emit_suggestion_default(
                 let arrow = renderer.decor_style.file_start(is_first, false);
                 buffer.puts(row_num - 1, 0, arrow, ElementStyle::LineNumber);
                 let message = format!("{}:{}:{}", path, loc.line, loc.char + 1);
-                let col = usize::max(max_line_num_len + 1, arrow.len());
+                let col = usize::max(max_line_num_len + 1, str_width(arrow));
                 buffer.puts(row_num - 1, col, &message, ElementStyle::LineAndColumn);
                 for _ in 0..max_line_num_len {
                     buffer.prepend(row_num - 1, " ", ElementStyle::NoStyle);

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -5169,7 +5169,7 @@ error[E0624]: method `five_years` is private
   │    ────────── private method defined here
   ╰╴
 help: consider making `bar` public
-  ╭▸     other.rs:1:1
+  ╭▸ other.rs:1:1
   │
 1 │ pub fn bar(&self) {
   ╰╴+++

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -5103,3 +5103,77 @@ warning: variable does not need to be mutable
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
+
+#[test]
+fn suggestion_different_path_than_primary() {
+    let source = r#"    foo.bar();"#;
+    let secondary_source = r#"fn bar(&self) {"#;
+    let input = &[
+        Level::ERROR
+            .primary_title("method `five_years` is private")
+            .id("E0624")
+            .element(
+                Snippet::source(source)
+                    .path("lib.rs")
+                    .annotation(AnnotationKind::Primary.span(8..13).label("private method")),
+            )
+            .element(
+                Snippet::source(secondary_source)
+                    .path("other.rs")
+                    .annotation(
+                        AnnotationKind::Context
+                            .span(3..13)
+                            .label("private method defined here"),
+                    ),
+            ),
+        Level::HELP
+            .secondary_title("consider making `bar` public")
+            .element(
+                Snippet::source(secondary_source)
+                    .path("other.rs")
+                    .patch(Patch::new(0..0, "pub ")),
+            ),
+    ];
+
+    let expected_ascii = str![[r#"
+error[E0624]: method `five_years` is private
+ --> lib.rs:1:9
+  |
+1 |     foo.bar();
+  |         ^^^^^ private method
+  |
+ ::: other.rs:1:4
+  |
+1 | fn bar(&self) {
+  |    ---------- private method defined here
+  |
+help: consider making `bar` public
+ --> other.rs:1:1
+  |
+1 | pub fn bar(&self) {
+  | +++
+"#]];
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    let expected_unicode = str![[r#"
+error[E0624]: method `five_years` is private
+  ╭▸ lib.rs:1:9
+  │
+1 │     foo.bar();
+  │         ━━━━━ private method
+  │
+  ⸬  other.rs:1:4
+  │
+1 │ fn bar(&self) {
+  │    ────────── private method defined here
+  ╰╴
+help: consider making `bar` public
+  ╭▸     other.rs:1:1
+  │
+1 │ pub fn bar(&self) {
+  ╰╴+++
+"#]];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+}


### PR DESCRIPTION
I caught this while working on #413. The issue was that we were using byte length when we should have been using display length.