### PR TITLE
fix(highlight_source): Apply styling to multiline annotations

### DIFF
--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -876,6 +876,39 @@ fn render_source_line(
         return vec![];
     }
 
+    // Apply `highlight_source` styling for multiline annotations here, before the fast paths
+    // below (the "short start" case just below, and the "only connector lines" case further
+    // down) get a chance to return without ever reaching the per-annotation styling logic that
+    // handles it for single-line annotations. Even when those fast paths aren't taken, the
+    // per-annotation styling logic matches on `MultilineStart`/`MultilineEnd` first to draw the
+    // horizontal connector, which made the `highlight_source` arm structurally unreachable for
+    // multiline annotations (see issue #427: `highlight_source` was silently ignored on them).
+    for ann in &line_info.annotations {
+        if !ann.highlight_source {
+            continue;
+        }
+        let (start_char, end_char) = match ann.annotation_type {
+            LineAnnotationType::Singleline => continue,
+            // The span starts partway through this line and runs to the end of it.
+            LineAnnotationType::MultilineStart(_) => {
+                let rest_of_line = line_info.line[ann.start.byte..].chars().count();
+                (ann.start.char, ann.start.char + rest_of_line)
+            }
+            // The span runs from the start of this line up to `end`.
+            LineAnnotationType::MultilineEnd(_) => (0, ann.end.char),
+            // The span fully covers this line.
+            LineAnnotationType::MultilineLine(_) => (0, line_info.line.chars().count()),
+        };
+        let underline = renderer.decor_style.underline(ann.is_primary());
+        buffer.set_style_range(
+            line_offset,
+            (code_offset + start_char).saturating_sub(left),
+            (code_offset + end_char).saturating_sub(left),
+            underline.style,
+            ann.is_primary(),
+        );
+    }
+
     // Special case when there's only one annotation involved, it is the start of a multiline
     // span and there's no text at the beginning of the code line. Instead of doing the whole
     // graph:

--- a/tests/color/ann_multiline_highlight_source.ascii.term.svg
+++ b/tests/color/ann_multiline_highlight_source.ascii.term.svg
@@ -1,0 +1,40 @@
+<svg width="740px" height="164px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error[E0027]</tspan><tspan class="bold">: pattern does not mention fields `lineno`, `content`</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>   </tspan><tspan class="fg-bright-blue bold">--&gt; </tspan><tspan>src/display_list.rs:139:32</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>    </tspan><tspan class="fg-bright-blue bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">139</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>                           if let DisplayLine::Source {</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>    </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-red bold"> ________________________________^</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">140</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>                             ref mut inline_marks,</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-blue bold">141</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>                         } = body[body_idx]</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>    </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|_________________________^</tspan><tspan> </tspan><tspan class="fg-bright-red bold">missing fields `lineno`, `content`</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/ann_multiline_highlight_source.ascii.term.svg
+++ b/tests/color/ann_multiline_highlight_source.ascii.term.svg
@@ -25,13 +25,13 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan>    </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">139</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>                           if let DisplayLine::Source {</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">139</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan>                           if let </tspan><tspan class="fg-bright-red bold">DisplayLine::Source {</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan>    </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-red bold"> ________________________________^</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">140</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>                             ref mut inline_marks,</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">140</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan> </tspan><tspan class="fg-bright-red bold">                            ref mut inline_marks,</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-bright-blue bold">141</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan>                         } = body[body_idx]</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-blue bold">141</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|</tspan><tspan> </tspan><tspan class="fg-bright-red bold">                        }</tspan><tspan> = body[body_idx]</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>    </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-red bold">|_________________________^</tspan><tspan> </tspan><tspan class="fg-bright-red bold">missing fields `lineno`, `content`</tspan>
 </tspan>

--- a/tests/color/ann_multiline_highlight_source.rs
+++ b/tests/color/ann_multiline_highlight_source.rs
@@ -1,0 +1,37 @@
+use annotate_snippets::{AnnotationKind, Level, Renderer, Snippet, renderer::DecorStyle};
+
+use snapbox::{assert_data_eq, file};
+
+// Regression test for https://github.com/rust-lang/annotate-snippets-rs/issues/427:
+// `highlight_source(true)` had no effect on multiline annotations.
+#[test]
+fn case() {
+    let source = r#"                        if let DisplayLine::Source {
+                            ref mut inline_marks,
+                        } = body[body_idx]
+"#;
+
+    let input = &[Level::ERROR
+        .primary_title("pattern does not mention fields `lineno`, `content`")
+        .id("E0027")
+        .element(
+            Snippet::source(source)
+                .path("src/display_list.rs")
+                .line_start(139)
+                .fold(false)
+                .annotation(
+                    AnnotationKind::Primary
+                        .span(31..128)
+                        .label("missing fields `lineno`, `content`")
+                        .highlight_source(true),
+                ),
+        )];
+
+    let expected_ascii = file!["ann_multiline_highlight_source.ascii.term.svg": TermSvg];
+    let renderer = Renderer::styled();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    let expected_unicode = file!["ann_multiline_highlight_source.unicode.term.svg": TermSvg];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+}

--- a/tests/color/ann_multiline_highlight_source.unicode.term.svg
+++ b/tests/color/ann_multiline_highlight_source.unicode.term.svg
@@ -1,0 +1,40 @@
+<svg width="740px" height="164px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error[E0027]</tspan><tspan class="bold">: pattern does not mention fields `lineno`, `content`</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>   </tspan><tspan class="fg-bright-blue bold"> ╭▸ </tspan><tspan>src/display_list.rs:139:32</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>    </tspan><tspan class="fg-bright-blue bold">│</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">139</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan>                           if let DisplayLine::Source {</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>    </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan> </tspan><tspan class="fg-bright-red bold">┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">140</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan> </tspan><tspan class="fg-bright-red bold">┃</tspan><tspan>                             ref mut inline_marks,</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-blue bold">141</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan> </tspan><tspan class="fg-bright-red bold">┃</tspan><tspan>                         } = body[body_idx]</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>    </tspan><tspan class="fg-bright-blue bold">╰╴</tspan><tspan class="fg-bright-red bold">┗━━━━━━━━━━━━━━━━━━━━━━━━━┛</tspan><tspan> </tspan><tspan class="fg-bright-red bold">missing fields `lineno`, `content`</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/ann_multiline_highlight_source.unicode.term.svg
+++ b/tests/color/ann_multiline_highlight_source.unicode.term.svg
@@ -25,13 +25,13 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan>    </tspan><tspan class="fg-bright-blue bold">│</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">139</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan>                           if let DisplayLine::Source {</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">139</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan>                           if let </tspan><tspan class="fg-bright-red bold">DisplayLine::Source {</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan>    </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan> </tspan><tspan class="fg-bright-red bold">┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">140</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan> </tspan><tspan class="fg-bright-red bold">┃</tspan><tspan>                             ref mut inline_marks,</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">140</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan> </tspan><tspan class="fg-bright-red bold">┃</tspan><tspan> </tspan><tspan class="fg-bright-red bold">                            ref mut inline_marks,</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-bright-blue bold">141</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan> </tspan><tspan class="fg-bright-red bold">┃</tspan><tspan>                         } = body[body_idx]</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-blue bold">141</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">│</tspan><tspan> </tspan><tspan class="fg-bright-red bold">┃</tspan><tspan> </tspan><tspan class="fg-bright-red bold">                        }</tspan><tspan> = body[body_idx]</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>    </tspan><tspan class="fg-bright-blue bold">╰╴</tspan><tspan class="fg-bright-red bold">┗━━━━━━━━━━━━━━━━━━━━━━━━━┛</tspan><tspan> </tspan><tspan class="fg-bright-red bold">missing fields `lineno`, `content`</tspan>
 </tspan>

--- a/tests/color/main.rs
+++ b/tests/color/main.rs
@@ -2,6 +2,7 @@ mod ann_eof;
 mod ann_insertion;
 mod ann_multiline;
 mod ann_multiline2;
+mod ann_multiline_highlight_source;
 mod ann_removed_nl;
 mod ensure_emoji_highlight_width;
 mod first_snippet_is_primary;


### PR DESCRIPTION
Fixes #427.

highlight_source was silently ignored on multiline annotations
(MultilineStart/MultilineLine/MultilineEnd). Two things conspired to
cause this:

- render_source_line has a couple of fast paths (the "short start with
  no leading text" case, and the "only connector lines, nothing to
  show" case) that can return before the per-annotation styling logic
  ever runs.
- Even when those aren't hit, the per-annotation match arm that
  applies highlight_source is placed after the arm that draws the
  MultilineStart/MultilineEnd connector, so it never matches for those
  variants, since Rust match arms are first-match-wins.

Styling multiline annotations up front, before any of that, sidesteps
both issues instead of trying to thread a fix through three separate
spots.

Added a regression test (ascii + unicode goldens) using the repro from
the issue.
