### PR TITLE
perf: Optimize rendering

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ mod snippet;
 /// This is important for untrusted input, as it can contain
 /// invalid unicode sequences.
 pub fn normalize_untrusted_str(s: &str) -> String {
-    renderer::normalize_whitespace(s)
+    renderer::normalize_whitespace(s).into_owned()
 }
 
 #[doc(inline)]

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -225,9 +225,7 @@ pub(crate) fn render(renderer: &Renderer, groups: Report<'_>) -> String {
                 .render(&level, &renderer.stylesheet, &mut out_string)
                 .unwrap();
             if g != group_len - 1 {
-                use core::fmt::Write;
-
-                writeln!(out_string).unwrap();
+                out_string.push('\n');
             }
         }
         out_string

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -1,6 +1,6 @@
 // Most of this file is adapted from https://github.com/rust-lang/rust/blob/160905b6253f42967ed4aef4b98002944c7df24c/compiler/rustc_errors/src/emitter.rs
 
-use alloc::borrow::{Cow, ToOwned};
+use alloc::borrow::Cow;
 use alloc::collections::BTreeMap;
 use alloc::string::{String, ToString};
 use alloc::{format, vec, vec::Vec};
@@ -399,7 +399,7 @@ fn render_title(
     });
 
     let (title_str, style) = if title.allows_styling() {
-        (title.text().to_owned(), ElementStyle::NoStyle)
+        (Cow::Borrowed(title.text()), ElementStyle::NoStyle)
     } else {
         (normalize_whitespace(title.text()), title_element_style)
     };
@@ -2511,17 +2511,25 @@ const OUTPUT_REPLACEMENTS: &[(char, &str)] = &[
     ('\u{2069}', "�"),
 ];
 
-pub(crate) fn normalize_whitespace(s: &str) -> String {
+pub(crate) fn normalize_whitespace(s: &str) -> Cow<'_, str> {
+    if !s
+        .chars()
+        .any(|user| OUTPUT_REPLACEMENTS.iter().any(|(bad, _)| user == *bad))
+    {
+        return Cow::Borrowed(s);
+    }
+
     // Scan the input string for a character in the ordered table above.
     // If it's present, replace it with its alternative string (it can be more than 1 char!).
     // Otherwise, retain the input char.
-    s.chars().fold(String::with_capacity(s.len()), |mut s, c| {
+    let normalized = s.chars().fold(String::with_capacity(s.len()), |mut s, c| {
         match OUTPUT_REPLACEMENTS.binary_search_by_key(&c, |(k, _)| *k) {
             Ok(i) => s.push_str(OUTPUT_REPLACEMENTS[i].1),
             _ => s.push(c),
         }
         s
-    })
+    });
+    Cow::Owned(normalized)
 }
 
 #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq)]

--- a/src/renderer/styled_buffer.rs
+++ b/src/renderer/styled_buffer.rs
@@ -85,9 +85,9 @@ impl StyledBuffer {
     /// If `line` does not exist in our buffer, adds empty lines up to the given
     /// and fills the last line with unstyled whitespace.
     pub(crate) fn puts(&mut self, line: usize, col: usize, string: &str, style: ElementStyle) {
+        self.ensure_lines(line);
         for (offset, chr) in string.chars().enumerate() {
             let col = col + offset;
-            self.ensure_lines(line);
             if col >= self.lines[line].len() {
                 self.lines[line].resize(col + 1, StyledChar::SPACE);
             }

--- a/src/renderer/styled_buffer.rs
+++ b/src/renderer/styled_buffer.rs
@@ -57,11 +57,11 @@ impl StyledBuffer {
                     current_style = ch_style;
                     write!(str, "{current_style}")?;
                 }
-                write!(str, "{ch}")?;
+                str.push(*ch);
             }
             write!(str, "{current_style:#}")?;
             if i != self.lines.len() - 1 {
-                writeln!(str)?;
+                str.push('\n');
             }
         }
         Ok(())

--- a/src/renderer/styled_buffer.rs
+++ b/src/renderer/styled_buffer.rs
@@ -85,8 +85,9 @@ impl StyledBuffer {
     /// If `line` does not exist in our buffer, adds empty lines up to the given
     /// and fills the last line with unstyled whitespace.
     pub(crate) fn puts(&mut self, line: usize, col: usize, string: &str, style: ElementStyle) {
-        for (offset, c) in string.chars().enumerate() {
-            self.putc(line, col + offset, c, style);
+        for (offset, chr) in string.chars().enumerate() {
+            let col = col + offset;
+            self.putc(line, col, chr, style);
         }
     }
 

--- a/src/renderer/styled_buffer.rs
+++ b/src/renderer/styled_buffer.rs
@@ -86,12 +86,13 @@ impl StyledBuffer {
     /// and fills the last line with unstyled whitespace.
     pub(crate) fn puts(&mut self, line: usize, col: usize, string: &str, style: ElementStyle) {
         self.ensure_lines(line);
+        let line = &mut self.lines[line];
         for (offset, chr) in string.chars().enumerate() {
             let col = col + offset;
-            if col >= self.lines[line].len() {
-                self.lines[line].resize(col + 1, StyledChar::SPACE);
+            if col >= line.len() {
+                line.resize(col + 1, StyledChar::SPACE);
             }
-            self.lines[line][col] = StyledChar::new(chr, style);
+            line[col] = StyledChar::new(chr, style);
         }
     }
 

--- a/src/renderer/styled_buffer.rs
+++ b/src/renderer/styled_buffer.rs
@@ -87,7 +87,11 @@ impl StyledBuffer {
     pub(crate) fn puts(&mut self, line: usize, col: usize, string: &str, style: ElementStyle) {
         for (offset, chr) in string.chars().enumerate() {
             let col = col + offset;
-            self.putc(line, col, chr, style);
+            self.ensure_lines(line);
+            if col >= self.lines[line].len() {
+                self.lines[line].resize(col + 1, StyledChar::SPACE);
+            }
+            self.lines[line][col] = StyledChar::new(chr, style);
         }
     }
 

--- a/src/renderer/styled_buffer.rs
+++ b/src/renderer/styled_buffer.rs
@@ -46,6 +46,9 @@ impl StyledBuffer {
         stylesheet: &Stylesheet,
         str: &mut String,
     ) -> Result<(), fmt::Error> {
+        let capacity = self.lines.iter().map(|line| line.len()).sum();
+        str.reserve(capacity);
+
         for (i, line) in self.lines.iter().enumerate() {
             let mut current_style = stylesheet.none;
             for StyledChar { ch, style } in line {


### PR DESCRIPTION
This is a port of https://github.com/astral-sh/ruff/pull/24146

On my system, this took the `simple` benchmark from 7.041us to 5.166us. Having a benchmark longer than the `us` ranger would be a help for getting better numbers through these changes. Some were harder to tell if they made improvements with the amount of jitter I saw. That is partly why I left off a short circuit for `puts` on empty strings. I was unsure about the correctness of skipping adding a blank line and I saw almost no change in this benchmark.

Hoisting the line resizing would take this to 4.582us but there are some boundary conditions to examine as the raw change causes extra whitespace.