### PR TITLE
perf: Hoist resize within puts

### DIFF
--- a/src/renderer/styled_buffer.rs
+++ b/src/renderer/styled_buffer.rs
@@ -88,10 +88,10 @@ impl StyledBuffer {
         self.ensure_lines(line);
         let line = &mut self.lines[line];
 
-        let last_col = string.chars().count().checked_sub(1).map(|i| col + i);
-        if let Some(last_col) = last_col {
-            if last_col >= line.len() {
-                line.resize(last_col + 1, StyledChar::SPACE);
+        if !string.is_empty() {
+            let new_len = col + string.chars().count();
+            if new_len > line.len() {
+                line.resize(new_len, StyledChar::SPACE);
             }
         }
 

--- a/src/renderer/styled_buffer.rs
+++ b/src/renderer/styled_buffer.rs
@@ -85,14 +85,17 @@ impl StyledBuffer {
     /// If `line` does not exist in our buffer, adds empty lines up to the given
     /// and fills the last line with unstyled whitespace.
     pub(crate) fn puts(&mut self, line: usize, col: usize, string: &str, style: ElementStyle) {
+        if string.is_empty() {
+            // don't add trailing whitespace (from column offset) for blank strings
+            return;
+        }
+
         self.ensure_lines(line);
         let line = &mut self.lines[line];
 
-        if !string.is_empty() {
-            let new_len = col + string.chars().count();
-            if new_len > line.len() {
-                line.resize(new_len, StyledChar::SPACE);
-            }
+        let new_len = col + string.chars().count();
+        if new_len > line.len() {
+            line.resize(new_len, StyledChar::SPACE);
         }
 
         for (offset, chr) in string.chars().enumerate() {

--- a/src/renderer/styled_buffer.rs
+++ b/src/renderer/styled_buffer.rs
@@ -87,11 +87,16 @@ impl StyledBuffer {
     pub(crate) fn puts(&mut self, line: usize, col: usize, string: &str, style: ElementStyle) {
         self.ensure_lines(line);
         let line = &mut self.lines[line];
+
+        let last_col = string.chars().enumerate().last().map(|(i, _)| col + i);
+        if let Some(last_col) = last_col {
+            if last_col >= line.len() {
+                line.resize(last_col + 1, StyledChar::SPACE);
+            }
+        }
+
         for (offset, chr) in string.chars().enumerate() {
             let col = col + offset;
-            if col >= line.len() {
-                line.resize(col + 1, StyledChar::SPACE);
-            }
             line[col] = StyledChar::new(chr, style);
         }
     }

--- a/src/renderer/styled_buffer.rs
+++ b/src/renderer/styled_buffer.rs
@@ -88,7 +88,7 @@ impl StyledBuffer {
         self.ensure_lines(line);
         let line = &mut self.lines[line];
 
-        let last_col = string.chars().enumerate().last().map(|(i, _)| col + i);
+        let last_col = string.chars().count().checked_sub(1).map(|i| col + i);
         if let Some(last_col) = last_col {
             if last_col >= line.len() {
                 line.resize(last_col + 1, StyledChar::SPACE);


### PR DESCRIPTION
This causes the `simple` benchmark to take about 8% less time.

This was the change deferred out of #437. I hadn't noticed that ruff's empty string check was load bearing.