### PR TITLE
feat: Add no graphics renderer mode

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -18,6 +18,7 @@
 //! anstream::println!("{output}");
 //! ```
 
+pub(crate) mod no_graphics;
 pub(crate) mod render;
 pub(crate) mod source_map;
 pub(crate) mod stylesheet;
@@ -111,6 +112,7 @@ pub struct Renderer {
     decor_style: DecorStyle,
     stylesheet: Stylesheet,
     short_message: bool,
+    no_graphics: bool,
 }
 
 impl Renderer {
@@ -122,6 +124,7 @@ impl Renderer {
             decor_style: DecorStyle::Ascii,
             stylesheet: Stylesheet::plain(),
             short_message: false,
+            no_graphics: false,
         }
     }
 
@@ -151,6 +154,11 @@ impl Renderer {
             },
             ..Self::plain()
         }
+    }
+
+    pub const fn no_graphics(mut self, no_graphics: bool) -> Self {
+        self.no_graphics = no_graphics;
+        self
     }
 
     /// Abbreviate the message
@@ -195,7 +203,11 @@ impl Renderer {
 impl Renderer {
     /// Render a diagnostic [`Report`]
     pub fn render(&self, groups: Report<'_>) -> String {
-        render::render(self, groups)
+        if self.no_graphics {
+            no_graphics::render_no_graphics(self, groups).unwrap()
+        } else {
+            render::render(self, groups)
+        }
     }
 }
 

--- a/src/renderer/no_graphics.rs
+++ b/src/renderer/no_graphics.rs
@@ -1,0 +1,394 @@
+use alloc::{string::String, vec::Vec};
+use core::cmp::Reverse;
+use core::fmt::{self, Write};
+
+use crate::{
+    Id, Renderer, Report,
+    renderer::{
+        ElementStyle, Stylesheet,
+        render::{MessageOrTitle, PreProcessedElement, PreProcessedGroup, pre_process},
+        source_map,
+    },
+};
+
+/// Print out a file position optimized for the data available.
+///
+/// When the `path` is available, we print `at PATH:LL:CC`, which is detected by terminals and
+/// editors as a path to a specific place in a file. Otherwise, we print`on line LL, column CC`,
+/// for the elements that are available.
+fn render_path(
+    output: &mut String,
+    path: Option<&str>,
+    line: Option<usize>,
+    col: Option<usize>,
+) -> Result<(), fmt::Error> {
+    match (path, line, col) {
+        (Some(path), Some(line), Some(col)) => {
+            // `at $DIR/file.txt:LL:CC`
+            write!(output, "at {path}:{line}:{col}")?;
+        }
+        (Some(path), Some(line), None) => {
+            // `at $DIR/file.txt:LL`
+            write!(output, "at {path}:{line}")?;
+        }
+        (Some(path), None, None) => {
+            // `at $DIR/file.txt`
+            write!(output, "at {path}")?;
+        }
+        (None, Some(line), Some(col)) => {
+            // We are not printing the path, so instead we show
+            // ` on line LL, column CC`.
+            write!(output, "on line {line}, column {col}")?;
+        }
+        (None, Some(line), None) => {
+            // ` on line LL`
+            write!(output, "on line {line}")?;
+        }
+        (None, None, Some(col)) => {
+            // ` on column CC`
+            write!(output, "on column {col}")?;
+        }
+        (Some(path), None, Some(line)) => {
+            // This condition should never have been called.
+            write!(output, "at {path}, line {line}")?;
+        }
+        (None, None, None) => {}
+    }
+    Ok(())
+}
+
+/// Render all errors from a `Report` as text only.
+///
+/// We will render output as follows:
+///
+/// ```text
+/// error EXXXX: main message
+///  at $DIR/file.ext:LL:CC: span label
+///   on line LL, column KK: span label
+/// note: note message
+///  at $DIR/file.ext:LL:CC
+/// help: suggestion message
+///   on line LL, add `suggestion`
+/// ```
+pub(crate) fn render_no_graphics(
+    renderer: &Renderer,
+    groups: Report<'_>,
+) -> Result<String, fmt::Error> {
+    let mut output = String::new();
+    let (_max_line_num, og_primary_path, groups) = pre_process(groups);
+
+    let mut iter = groups.into_iter().peekable();
+    while let Some(PreProcessedGroup {
+        group,
+        elements,
+        primary_path: _,
+        max_depth: _,
+    }) = iter.next()
+    {
+        if let Some(title) = &group.title {
+            render_title(
+                title,
+                &mut output,
+                if title.allows_styling {
+                    ElementStyle::HeaderMsg
+                } else {
+                    ElementStyle::MainHeaderMsg
+                },
+                &renderer.stylesheet,
+            )?;
+            if iter.peek().is_some()
+                || elements
+                    .iter()
+                    .find(|section| !matches!(section, PreProcessedElement::Padding(_)))
+                    .is_some()
+            {
+                // This diagnostic has content, add a newline after the title.
+                writeln!(output)?;
+            }
+        }
+
+        let mut message_iter = elements.into_iter().enumerate().peekable();
+        let mut last_suggestion_path = None;
+        while let Some((_i, section)) = message_iter.next() {
+            let peek = message_iter.peek().map(|(_, s)| s);
+            match section {
+                PreProcessedElement::Message(message) => {
+                    last_suggestion_path = None;
+                    render_title(
+                        message,
+                        &mut output,
+                        ElementStyle::HeaderMsg,
+                        &renderer.stylesheet,
+                    )?;
+                    if peek.is_some() {
+                        writeln!(output)?;
+                    }
+                }
+                PreProcessedElement::Cause((snippet, _, _)) => {
+                    last_suggestion_path = None;
+                    let sm = source_map::SourceMap::new(&snippet.source, snippet.line_start);
+
+                    let mut annotations = snippet.markers.iter().collect::<Vec<_>>();
+                    annotations.sort_by_key(|a| (Reverse(a.kind.is_primary()), a.span.start));
+                    if annotations.is_empty() {
+                        // We have a diagnostic with no span labels, but we should show *some*
+                        // position. We use the snippet start to provide that minimal context.
+                        write!(output, " ")?;
+                        render_path(
+                            &mut output,
+                            snippet.path.as_deref(),
+                            Some(snippet.line_start),
+                            None,
+                        )?;
+                        if peek.is_some() {
+                            writeln!(output)?;
+                        }
+                    }
+
+                    for (i, annotation) in annotations.iter().enumerate() {
+                        let label = annotation.label.as_ref().filter(|s| !s.is_empty());
+                        if i > 0 {
+                            if label.is_none() {
+                                continue;
+                            } else if peek.is_none() {
+                                writeln!(output)?;
+                            }
+                        }
+                        let (lo, hi) =
+                            sm.span_to_locations(annotation.span.start..annotation.span.end);
+                        if i == 0
+                            && let Some(path) = &snippet.path
+                        {
+                            // `at $DIR/file.txt:LL:CC: label`
+                            //  ^^^^^^^^^^^^^^^^^^^^^^
+                            write!(output, " ")?;
+                            render_path(&mut output, Some(path), Some(lo.line), Some(lo.char + 1))?;
+                            if lo.line != hi.line {
+                                // This is a multiline highlight, so we mention both the start and the
+                                // end. `LL:CC to MM:DD`
+                                //            ^^^^^^^^^
+                                write!(output, " to {}:{}", hi.line, hi.char + 1)?;
+                            }
+                        } else {
+                            let col = if let Some(line) = sm.get_line(lo.line)
+                                && let Some(pre) = line.get(..lo.char)
+                                && pre.chars().all(|c| c.is_whitespace())
+                            {
+                                // Everything before the span is whitespace, mentioning the column
+                                // doesn't add information.
+                                None
+                            } else {
+                                Some(lo.char + 1)
+                            };
+                            // On subsequent labels, we don't need to repeat the path. We use
+                            // additional whitespace to imply a nested relationship to the prior
+                            // label.
+                            write!(output, "  ")?;
+                            render_path(&mut output, None, Some(lo.line), col)?;
+                            if lo.line != hi.line {
+                                // This is a multiline highlight, so we mention both the start and the
+                                // end. `line LL, column CC to line MM, column DD`
+                                //                         ^^^^^^^^^^^^^^^^^^^^^^
+                                write!(output, " to line {}", hi.line)?;
+                                if let Some(line) = sm.get_line(hi.line)
+                                    && let Some(post) = line.get(hi.char..)
+                                    && post.chars().all(|c| c.is_whitespace())
+                                {
+                                    // Everything after the span is whitespace, mentioning the
+                                    // column doesn't add information.
+                                } else {
+                                    write!(output, ", column {}", hi.char + 1)?;
+                                }
+                            }
+                        }
+
+                        if let Some(label) = label {
+                            // If the span has a label, we render it to the right of the position
+                            // information.
+                            // `at $DIR/file.txt:LL:CC: this is the label`
+                            //                        ^^^^^^^^^^^^^^^^^^^
+                            write!(output, ": {label}")?;
+                        }
+                        if peek.is_some() {
+                            writeln!(output)?;
+                        }
+                    }
+                }
+                PreProcessedElement::Suggestion((
+                    suggestion,
+                    _source_map,
+                    _spliced_lines,
+                    _display_suggestion,
+                )) => {
+                    let Some(first_patch) = suggestion.markers.first() else {
+                        continue;
+                    };
+                    let sm = source_map::SourceMap::new(&suggestion.source, suggestion.line_start);
+                    let next_is_suggestion =
+                        matches!(peek, Some(PreProcessedElement::Suggestion(_)));
+
+                    let replacement = first_patch.replacement.trim_end_matches('\n');
+                    if last_suggestion_path.is_none() {
+                        let (lo, hi) =
+                            sm.span_to_locations(first_patch.span.start..first_patch.span.end);
+
+                        let col = if lo.line == hi.line
+                            && let Some(line) = sm.get_line(lo.line)
+                            && let Some(pre) = line.get(..lo.char)
+                            && pre.chars().all(|c| c.is_whitespace())
+                            && let Some(post) = line.get(hi.char..)
+                            && (replacement.lines().count() > 1
+                                || post.chars().all(|c| c.is_whitespace()))
+                        {
+                            // We are changing the whole text in the line, no need to mention the
+                            // column.
+                            None
+                        } else {
+                            Some(lo.char.max(1))
+                        };
+                        let path: Option<&str> = match (&suggestion.path, og_primary_path) {
+                            (Some(path), Some(primary)) if path != primary => {
+                                // We only include the file path when it is different to the
+                                // primary file.
+                                //
+                                // `at $DIR/file.txt:LL:CC: label`
+                                //  ^^^^^^^^^^^^^^^^^
+                                Some(path)
+                            }
+                            _ => None,
+                        };
+                        write!(output, " ")?;
+                        render_path(&mut output, path, Some(lo.line), col)?;
+                        let add = if let Some(snippet) =
+                            sm.span_to_snippet(first_patch.span.start..first_patch.span.end)
+                            && snippet.chars().all(|c| c.is_whitespace())
+                        {
+                            "add"
+                        } else {
+                            "replace with"
+                        };
+
+                        if next_is_suggestion {
+                            // We have multiple suggestions. We will render on their own line, first
+                            // the message, then the position, and finally each of the suggestions.
+                            //
+                            // help: suggestion message
+                            //  at line LL, column CC, add one of
+                            //   first suggestion
+                            //   second suggestion
+                            writeln!(output, ", {add} one of")?;
+                        } else {
+                            // We have a single suggestion. We will render first the message, then
+                            // the position followed by the suggestion on the next line.
+                            //
+                            // help: suggestion message
+                            //  on line LL, column CC, add `addition`
+                            if !replacement.trim().is_empty() {
+                                // If it is a removal, we shorten the output.
+                                //
+                                // help: suggestion message to remove something
+                                //  at line LL, column CC
+                                write!(output, ", {add} ")?;
+                            }
+                        }
+                    }
+
+                    let st = ElementStyle::Addition
+                        .color_spec(&crate::Level::NOTE, &renderer.stylesheet);
+                    if next_is_suggestion || last_suggestion_path.is_some() {
+                        // Multiple suggestions.
+                        writeln!(output, "  {st}{replacement}{st:#}")?;
+                    } else if !replacement.trim().is_empty() {
+                        // Single addition suggestion
+                        write!(output, "`{st}{replacement}{st:#}`")?;
+                    }
+
+                    last_suggestion_path = Some(suggestion.path.as_ref());
+                }
+                PreProcessedElement::Origin(origin) => {
+                    last_suggestion_path = None;
+                    write!(output, " ")?;
+                    render_path(
+                        &mut output,
+                        Some(&origin.path),
+                        origin.line,
+                        origin.char_column,
+                    )?;
+                    if peek.is_some() {
+                        writeln!(output)?;
+                    }
+                }
+                PreProcessedElement::Padding(_) => {}
+            }
+        }
+
+        if iter.peek().is_some()
+            && let Some(c) = output.chars().last()
+            && c != '\n'
+        {
+            writeln!(output)?;
+        }
+    }
+
+    Ok(output)
+}
+
+/// Render the main message line for a diagnostic
+///
+/// This will print out:
+///
+/// ```text
+/// LEVEL CODE: message
+/// ```
+/// like the following:
+/// ```text
+/// error E0308: mismatched types
+/// ```
+fn render_title(
+    title: &dyn MessageOrTitle,
+    buffer: &mut String,
+    style: ElementStyle,
+    stylesheet: &Stylesheet,
+) -> Result<(), fmt::Error> {
+    let mut label_width = 0;
+    let st = style.color_spec(title.level(), stylesheet);
+
+    if title.level().name != Some(None) {
+        // error EXXXX: message
+        // ^^^^^
+        write!(
+            buffer,
+            "{}{}{0:#}",
+            ElementStyle::Level(title.level().level).color_spec(&crate::Level::NOTE, stylesheet),
+            title.level().as_str(),
+        )?;
+        label_width += title.level().as_str().len();
+
+        if let Some(Id {
+            id: Some(id),
+            url: _,
+        }) = &title.id()
+        {
+            // error EXXXX: message
+            //       ^^^^^
+            write!(buffer, "{st:#} {id}",)?;
+            label_width += 1 + id.len();
+        }
+        // error EXXXX: message
+        //            ^
+        write!(buffer, ": ")?;
+        label_width += 2;
+    }
+    let padding = " ".repeat(label_width);
+
+    // error EXXXX: message
+    //              ^^^^^^^
+    let title_str = title.text();
+    for (i, text) in title_str.split('\n').enumerate() {
+        if i != 0 {
+            write!(buffer, "\n{padding}")?;
+        }
+        write!(buffer, "{st}{text}{st:#}")?;
+    }
+    Ok(())
+}

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -2224,7 +2224,7 @@ fn draw_line_separator(renderer: &Renderer, buffer: &mut StyledBuffer, line: usi
     buffer.puts(line, column, dots, ElementStyle::LineNumber);
 }
 
-trait MessageOrTitle {
+pub(crate) trait MessageOrTitle {
     fn level(&self) -> &Level<'_>;
     fn id(&self) -> Option<&Id<'_>>;
     fn text(&self) -> &str;
@@ -2593,14 +2593,14 @@ enum TitleStyle {
     Secondary,
 }
 
-struct PreProcessedGroup<'a> {
-    group: &'a Group<'a>,
-    elements: Vec<PreProcessedElement<'a>>,
-    primary_path: Option<&'a Cow<'a, str>>,
-    max_depth: usize,
+pub(crate) struct PreProcessedGroup<'a> {
+    pub(crate) group: &'a Group<'a>,
+    pub(crate) elements: Vec<PreProcessedElement<'a>>,
+    pub(crate) primary_path: Option<&'a Cow<'a, str>>,
+    pub(crate) max_depth: usize,
 }
 
-enum PreProcessedElement<'a> {
+pub(crate) enum PreProcessedElement<'a> {
     Message(&'a Message<'a>),
     Cause(
         (
@@ -2621,7 +2621,7 @@ enum PreProcessedElement<'a> {
     Padding(Padding),
 }
 
-fn pre_process<'a>(
+pub(crate) fn pre_process<'a>(
     groups: &'a [Group<'a>],
 ) -> (usize, Option<&'a Cow<'a, str>>, Vec<PreProcessedGroup<'a>>) {
     let mut max_line_num = 0;

--- a/tests/color/ann_eof.no_graphics.term.svg
+++ b/tests/color/ann_eof.no_graphics.term.svg
@@ -1,0 +1,27 @@
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: </tspan><tspan class="bold">expected `.`, `=`</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at Cargo.toml:1:5</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/ann_eof.rs
+++ b/tests/color/ann_eof.rs
@@ -18,4 +18,8 @@ fn case() {
     let expected_unicode = file!["ann_eof.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = file!["ann_eof.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }

--- a/tests/color/ann_insertion.no_graphics.term.svg
+++ b/tests/color/ann_insertion.no_graphics.term.svg
@@ -1,0 +1,27 @@
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: </tspan><tspan class="bold">expected `.`, `=`</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at Cargo.toml:1:3: 'd' belongs here</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/ann_insertion.rs
+++ b/tests/color/ann_insertion.rs
@@ -18,4 +18,8 @@ fn case() {
     let expected_unicode = file!["ann_insertion.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = file!["ann_insertion.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }

--- a/tests/color/ann_multiline.no_graphics.term.svg
+++ b/tests/color/ann_multiline.no_graphics.term.svg
@@ -1,0 +1,27 @@
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan> E0027: </tspan><tspan class="bold">pattern does not mention fields `lineno`, `content`</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at src/display_list.rs:139:32 to 141:26: missing fields `lineno`, `content`</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/ann_multiline.rs
+++ b/tests/color/ann_multiline.rs
@@ -31,4 +31,8 @@ fn case() {
     let expected_unicode = file!["ann_multiline.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = file!["ann_multiline.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }

--- a/tests/color/ann_multiline2.no_graphics.term.svg
+++ b/tests/color/ann_multiline2.no_graphics.term.svg
@@ -1,0 +1,27 @@
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan> E####: </tspan><tspan class="bold">spacing error found</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at foo.txt:26:12 to 27:1: this should not be on separate lines</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/ann_multiline2.rs
+++ b/tests/color/ann_multiline2.rs
@@ -31,4 +31,8 @@ to exactly one character on next line.
     let expected_unicode = file!["ann_multiline2.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = file!["ann_multiline2.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }

--- a/tests/color/ann_removed_nl.no_graphics.term.svg
+++ b/tests/color/ann_removed_nl.no_graphics.term.svg
@@ -1,0 +1,27 @@
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: </tspan><tspan class="bold">expected `.`, `=`</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at Cargo.toml:1:5</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/ann_removed_nl.rs
+++ b/tests/color/ann_removed_nl.rs
@@ -18,4 +18,8 @@ fn case() {
     let expected_unicode = file!["ann_removed_nl.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = file!["ann_removed_nl.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }

--- a/tests/color/ensure_emoji_highlight_width.no_graphics.term.svg
+++ b/tests/color/ensure_emoji_highlight_width.no_graphics.term.svg
@@ -1,0 +1,27 @@
+<svg width="1356px" height="56px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: </tspan><tspan class="bold">invalid character ` ` in package name: `haha this isn't a valid name 🐛`, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at &lt;file&gt;:7:1</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/ensure_emoji_highlight_width.rs
+++ b/tests/color/ensure_emoji_highlight_width.rs
@@ -22,4 +22,8 @@ fn case() {
     let expected_unicode = file!["ensure_emoji_highlight_width.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = file!["ensure_emoji_highlight_width.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }

--- a/tests/color/first_snippet_is_primary.no_graphics.term.svg
+++ b/tests/color/first_snippet_is_primary.no_graphics.term.svg
@@ -1,0 +1,36 @@
+<svg width="740px" height="128px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan> E0308: </tspan><tspan class="bold">mismatched types</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at $DIR/file.txt:3:1: the macro expands to this string</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan> at $DIR/mismatched-types.rs:2:20: expected `&amp;[u8]`, found `&amp;str`</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan>  on line 2, column 12: expected due to this</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">note</tspan><tspan>: expected reference `&amp;[u8]`</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>         found reference `&amp;'static str`</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/first_snippet_is_primary.rs
+++ b/tests/color/first_snippet_is_primary.rs
@@ -49,4 +49,8 @@ fn case() {
     let expected_unicode = file!["first_snippet_is_primary.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = file!["first_snippet_is_primary.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }

--- a/tests/color/fold_ann_multiline.no_graphics.term.svg
+++ b/tests/color/fold_ann_multiline.no_graphics.term.svg
@@ -1,0 +1,29 @@
+<svg width="844px" height="74px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan> E0308: </tspan><tspan class="bold">mismatched types</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at src/format.rs:52:1 to 72:6: expected enum `std::option::Option`, found ()</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>  on line 51, column 6: expected `std::option::Option&lt;std::string::String&gt;` because of return type</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/fold_ann_multiline.rs
+++ b/tests/color/fold_ann_multiline.rs
@@ -52,4 +52,8 @@ fn case() {
     let expected_unicode = file!["fold_ann_multiline.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = file!["fold_ann_multiline.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }

--- a/tests/color/fold_bad_origin_line.no_graphics.term.svg
+++ b/tests/color/fold_bad_origin_line.no_graphics.term.svg
@@ -1,0 +1,27 @@
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: </tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at path/to/error.rs:3:1: error here</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/fold_bad_origin_line.rs
+++ b/tests/color/fold_bad_origin_line.rs
@@ -23,4 +23,8 @@ invalid syntax
     let expected_unicode = file!["fold_bad_origin_line.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = file!["fold_bad_origin_line.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }

--- a/tests/color/fold_leading.no_graphics.term.svg
+++ b/tests/color/fold_leading.no_graphics.term.svg
@@ -1,0 +1,27 @@
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan> E0308: </tspan><tspan class="bold">invalid type: integer `20`, expected a bool</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at Cargo.toml:11:13</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/fold_leading.rs
+++ b/tests/color/fold_leading.rs
@@ -34,4 +34,8 @@ workspace = 20
     let expected_unicode = file!["fold_leading.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = file!["fold_leading.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }

--- a/tests/color/fold_trailing.no_graphics.term.svg
+++ b/tests/color/fold_trailing.no_graphics.term.svg
@@ -1,0 +1,27 @@
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan> E0308: </tspan><tspan class="bold">invalid type: integer `20`, expected a lints table</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at Cargo.toml:1:9</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/fold_trailing.rs
+++ b/tests/color/fold_trailing.rs
@@ -33,4 +33,8 @@ edition = "2021"
     let expected_unicode = file!["fold_trailing.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = file!["fold_trailing.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }

--- a/tests/color/highlight_diff_line_with_wide_characters.no_graphics.term.svg
+++ b/tests/color/highlight_diff_line_with_wide_characters.no_graphics.term.svg
@@ -1,0 +1,35 @@
+<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan> E0422: </tspan><tspan class="bold">cannot find struct, variant or union type `哈哈哈哈` in this scope</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at $DIR/highlight_diff_line_with_wide_characters.rs:3:18: here</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>  on line 1: similarly named struct `啊啊啊啊` defined here</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: a struct with a similar name exists: `啊啊啊啊`</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan> on line 3, column 17, replace with `</tspan><tspan class="fg-bright-green">啊啊啊啊</tspan><tspan>`</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/highlight_diff_line_with_wide_characters.rs
+++ b/tests/color/highlight_diff_line_with_wide_characters.rs
@@ -41,4 +41,9 @@ const 哦哦: 啊啊啊啊 = 哈哈哈哈 {}; // some comment"#;
         file!["highlight_diff_line_with_wide_characters.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(report), expected_unicode);
+
+    let expected_no_graphics =
+        file!["highlight_diff_line_with_wide_characters.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(report), expected_no_graphics);
 }

--- a/tests/color/highlight_duplicated_diff_lines.no_graphics.term.svg
+++ b/tests/color/highlight_duplicated_diff_lines.no_graphics.term.svg
@@ -1,0 +1,39 @@
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan> E0061: </tspan><tspan class="bold">this function takes 6 arguments but 7 arguments were supplied</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at $DIR/wrong-highlight-span-extra-arguments-147070.rs:17:15</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>  on line 24: unexpected argument #7 of type `String`</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan>: associated function defined here</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan> at $DIR/wrong-highlight-span-extra-arguments-147070.rs:4:19</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: remove the extra argument</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan> on line 23, column 21</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/highlight_duplicated_diff_lines.rs
+++ b/tests/color/highlight_duplicated_diff_lines.rs
@@ -72,4 +72,9 @@ fn main() {
     let expected_unicode = file!["highlight_duplicated_diff_lines.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(report), expected_unicode);
+
+    let expected_no_graphics =
+        file!["highlight_duplicated_diff_lines.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(report), expected_no_graphics);
 }

--- a/tests/color/highlight_first_line_tab_371.no_graphics.term.svg
+++ b/tests/color/highlight_first_line_tab_371.no_graphics.term.svg
@@ -1,0 +1,27 @@
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: </tspan><tspan class="bold">&lt;sample error message&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> on line 6, column 17</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/highlight_first_line_tab_371.rs
+++ b/tests/color/highlight_first_line_tab_371.rs
@@ -18,4 +18,8 @@ fn test() {
     let expected_ascii = file!["highlight_first_line_tab_371.ascii.term.svg": TermSvg];
     let renderer = Renderer::styled();
     assert_data_eq!(renderer.render(report), expected_ascii);
+
+    let expected_no_graphics = file!["highlight_first_line_tab_371.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(report), expected_no_graphics);
 }

--- a/tests/color/highlight_source.no_graphics.term.svg
+++ b/tests/color/highlight_source.no_graphics.term.svg
@@ -1,0 +1,27 @@
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: </tspan><tspan class="bold">all annotation kinds have a highlighted source</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at Cargo.toml:9:1</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/highlight_source.rs
+++ b/tests/color/highlight_source.rs
@@ -40,4 +40,8 @@ unused_qualifications = "warn"
     let expected_unicode = file!["highlight_source.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = file!["highlight_source.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }

--- a/tests/color/highlight_source_multi_width_chars.no_graphics.term.svg
+++ b/tests/color/highlight_source_multi_width_chars.no_graphics.term.svg
@@ -1,0 +1,23 @@
+<svg width="740px" height="38px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>  on line 1, column 15</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/highlight_source_multi_width_chars.rs
+++ b/tests/color/highlight_source_multi_width_chars.rs
@@ -17,4 +17,9 @@ fn case() {
     let expected_unicode = file!["highlight_source_multi_width_chars.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(report), expected_unicode);
+
+    let expected_no_graphics =
+        file!["highlight_source_multi_width_chars.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(report), expected_no_graphics);
 }

--- a/tests/color/highlight_source_zero_width_chars.no_graphics.term.svg
+++ b/tests/color/highlight_source_zero_width_chars.no_graphics.term.svg
@@ -1,0 +1,23 @@
+<svg width="740px" height="38px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>  on line 1, column 2</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/highlight_source_zero_width_chars.rs
+++ b/tests/color/highlight_source_zero_width_chars.rs
@@ -18,4 +18,9 @@ fn case() {
     let expected_unicode = file!["highlight_source_zero_width_chars.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(report), expected_unicode);
+
+    let expected_no_graphics =
+        file!["highlight_source_zero_width_chars.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(report), expected_no_graphics);
 }

--- a/tests/color/issue_9.no_graphics.term.svg
+++ b/tests/color/issue_9.no_graphics.term.svg
@@ -1,0 +1,31 @@
+<svg width="1020px" height="92px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: </tspan><tspan class="bold">expected one of `.`, `;`, `?`, or an operator, found `for`</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at /code/rust/src/test/ui/annotate-snippet/suggestion.rs:9:1: value used here after move</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>  on line 4, column 5: move occurs because `x` has type `std::vec::Vec&lt;i32&gt;`, which does not implement the `Copy` trait</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan>  on line 7, column 9: value moved here</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/issue_9.rs
+++ b/tests/color/issue_9.rs
@@ -30,4 +30,8 @@ x;
     let expected_unicode = file!["issue_9.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = file!["issue_9.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }

--- a/tests/color/multiline_removal_indent.no_graphics.term.svg
+++ b/tests/color/multiline_removal_indent.no_graphics.term.svg
@@ -1,0 +1,23 @@
+<svg width="740px" height="38px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan> on line 2, column 2</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/multiline_removal_indent.rs
+++ b/tests/color/multiline_removal_indent.rs
@@ -16,4 +16,8 @@ fn test() {
     let expected_unicode = file!["multiline_removal_indent.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(report), expected_unicode);
+
+    let expected_no_graphics = file!["multiline_removal_indent.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(report), expected_no_graphics);
 }

--- a/tests/color/multiline_removal_last_line_tabs.no_graphics.term.svg
+++ b/tests/color/multiline_removal_last_line_tabs.no_graphics.term.svg
@@ -1,0 +1,23 @@
+<svg width="740px" height="38px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan> on line 1, column 1</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/multiline_removal_last_line_tabs.rs
+++ b/tests/color/multiline_removal_last_line_tabs.rs
@@ -15,4 +15,9 @@ fn test() {
     let expected_unicode = file!["multiline_removal_last_line_tabs.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(report), expected_unicode);
+
+    let expected_no_graphics =
+        file!["multiline_removal_last_line_tabs.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(report), expected_no_graphics);
 }

--- a/tests/color/multiline_removal_suggestion.no_graphics.term.svg
+++ b/tests/color/multiline_removal_suggestion.no_graphics.term.svg
@@ -1,0 +1,41 @@
+<svg width="1398px" height="164px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan> E0277: </tspan><tspan class="bold">`(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at $DIR/multiline-removal-suggestion.rs:21:8: `(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: the trait `Iterator` is not implemented for `(bool, HashSet&lt;u8&gt;)`</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan>: required for `(bool, HashSet&lt;u8&gt;)` to implement `IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">note</tspan><tspan>: required by a bound in `flatten`</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan> at /rustc/FAKE_PREFIX/library/core/src/iter/traits/iterator.rs:1556:4</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: consider removing this method call, as the receiver has type `std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;` and `std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;: Iterator` trivially holds</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan> on line 15, column 17</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/multiline_removal_suggestion.rs
+++ b/tests/color/multiline_removal_suggestion.rs
@@ -107,4 +107,8 @@ fn main() {}
     let expected_unicode = file!["multiline_removal_suggestion.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = file!["multiline_removal_suggestion.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }

--- a/tests/color/multiple_annotations.no_graphics.term.svg
+++ b/tests/color/multiple_annotations.no_graphics.term.svg
@@ -1,0 +1,31 @@
+<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: </tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  on line 97, column 17: Variable defined here</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>  on line 99, column 14: Referenced here</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan>  on line 101, column 14: Referenced again here</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/multiple_annotations.rs
+++ b/tests/color/multiple_annotations.rs
@@ -43,4 +43,8 @@ fn case() {
     let expected_unicode = file!["multiple_annotations.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = file!["multiple_annotations.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }

--- a/tests/color/multiple_highlight_duplicated.no_graphics.term.svg
+++ b/tests/color/multiple_highlight_duplicated.no_graphics.term.svg
@@ -1,0 +1,51 @@
+<svg width="740px" height="254px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan> E0061: </tspan><tspan class="bold">this function takes 6 arguments but 7 arguments were supplied</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at $DIR/wrong-highlight-span-extra-arguments-147070.rs:17:15</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>  on line 24: unexpected argument #7 of type `String`</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan>: associated function defined here</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan> at $DIR/wrong-highlight-span-extra-arguments-147070.rs:4:19</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: remove the extra argument</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan> on line 23, column 24, replace with one of</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan>
+</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan>
+</tspan>
+    <tspan x="10px" y="244px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/multiple_highlight_duplicated.rs
+++ b/tests/color/multiple_highlight_duplicated.rs
@@ -90,4 +90,8 @@ fn main() {
     let expected_unicode = file!["multiple_highlight_duplicated.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(report), expected_unicode);
+
+    let expected_no_graphics = file!["multiple_highlight_duplicated.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(report), expected_no_graphics);
 }

--- a/tests/color/multiple_multiline_removal.no_graphics.term.svg
+++ b/tests/color/multiple_multiline_removal.no_graphics.term.svg
@@ -1,0 +1,55 @@
+<svg width="740px" height="290px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan> E0423: </tspan><tspan class="bold">cannot initialize a tuple struct which contains private fields</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at $DIR/suggest-box-new.rs:8:19</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan>: constructor is not visible here due to private fields</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan> at $SRC_DIR/alloc/src/boxed.rs:234:2</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">note</tspan><tspan>: private field</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">note</tspan><tspan>: private field</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: you might have meant to use an associated function to build this type</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan> on line 8, column 21, replace with one of</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-green">::new(_)</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-green">::new_uninit()</tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-green">::new_zeroed()</tspan>
+</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-green">::new_in(_, _)</tspan>
+</tspan>
+    <tspan x="10px" y="244px"><tspan>and 12 other candidates</tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: consider using the `Default` trait</tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan> on line 8, column 18, add `</tspan><tspan class="fg-bright-green">&lt;</tspan><tspan>`</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/multiple_multiline_removal.rs
+++ b/tests/color/multiple_multiline_removal.rs
@@ -90,4 +90,8 @@ fn main() {
     let expected_unicode = file!["multiple_multiline_removal.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(report), expected_unicode);
+
+    let expected_no_graphics = file!["multiple_multiline_removal.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(report), expected_no_graphics);
 }

--- a/tests/color/primary_title_second_group.no_graphics.term.svg
+++ b/tests/color/primary_title_second_group.no_graphics.term.svg
@@ -1,0 +1,32 @@
+<svg width="835px" height="92px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan> E0308: </tspan><tspan class="bold">mismatched types</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at src/multislice.rs:13:22: expected struct `annotate_snippets::snippet::Slice`, found reference</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan>: </tspan><tspan class="bold">expected type: `snippet::Annotation`</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan>      </tspan><tspan class="bold">   found type: `__&amp;__snippet::Annotation`</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/primary_title_second_group.rs
+++ b/tests/color/primary_title_second_group.rs
@@ -28,4 +28,8 @@ fn case() {
     let expected_unicode = file!["primary_title_second_group.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(report), expected_unicode);
+
+    let expected_no_graphics = file!["primary_title_second_group.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(report), expected_no_graphics);
 }

--- a/tests/color/simple.no_graphics.term.svg
+++ b/tests/color/simple.no_graphics.term.svg
@@ -1,0 +1,29 @@
+<svg width="760px" height="74px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: </tspan><tspan class="bold">expected one of `.`, `;`, `?`, or an operator, found `for`</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at src/format_color.rs:171:9: unexpected token</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>  on line 169, column 11 to line 170: expected one of `.`, `;`, `?`, or an operator here</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/simple.rs
+++ b/tests/color/simple.rs
@@ -34,4 +34,8 @@ fn case() {
     let expected_unicode = file!["simple.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = file!["simple.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }

--- a/tests/color/strip_line.no_graphics.term.svg
+++ b/tests/color/strip_line.no_graphics.term.svg
@@ -1,0 +1,27 @@
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan> E0308: </tspan><tspan class="bold">mismatched types</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at $DIR/whitespace-trimming.rs:4:193: expected (), found integer</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/strip_line.rs
+++ b/tests/color/strip_line.rs
@@ -27,4 +27,8 @@ fn case() {
     let expected_unicode = file!["strip_line.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = file!["strip_line.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }

--- a/tests/color/strip_line_char.no_graphics.term.svg
+++ b/tests/color/strip_line_char.no_graphics.term.svg
@@ -1,0 +1,27 @@
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan> E0308: </tspan><tspan class="bold">mismatched types</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at $DIR/whitespace-trimming.rs:4:193: expected (), found integer</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/strip_line_char.rs
+++ b/tests/color/strip_line_char.rs
@@ -27,4 +27,8 @@ fn case() {
     let expected_unicode = file!["strip_line_char.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = file!["strip_line_char.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }

--- a/tests/color/strip_line_non_ws.no_graphics.term.svg
+++ b/tests/color/strip_line_non_ws.no_graphics.term.svg
@@ -1,0 +1,29 @@
+<svg width="740px" height="74px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan> E0308: </tspan><tspan class="bold">mismatched types</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at $DIR/non-whitespace-trimming.rs:4:233: expected due to this</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>  on line 4, column 238: expected `()`, found integer</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/strip_line_non_ws.rs
+++ b/tests/color/strip_line_non_ws.rs
@@ -33,4 +33,8 @@ fn case() {
     let expected_unicode = file!["strip_line_non_ws.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = file!["strip_line_non_ws.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }

--- a/tests/color/styled_title.no_graphics.term.svg
+++ b/tests/color/styled_title.no_graphics.term.svg
@@ -1,0 +1,37 @@
+<svg width="902px" height="128px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-red { fill: #FF5555 }
+    .fg-magenta { fill: #AA00AA }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan> E0277: </tspan><tspan class="bold">the trait bound `CustomErrorHandler: ErrorHandler` is not satisfied</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> at src/main.rs:5:17: the trait `ErrorHandler` is not implemented for `CustomErrorHandler`</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>  on line 5: required by a bound introduced by this call</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: </tspan><tspan class="bold">there are </tspan><tspan class="fg-magenta bold">multiple different versions</tspan><tspan class="bold"> of crate `</tspan><tspan class="fg-magenta bold">c</tspan><tspan class="bold">` in the dependency graph</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan> at src/main.rs:1:5: one version of crate `c` is used here, as a dependency of crate `b`</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>  on line 2, column 5: one version of crate `c` is used here, as a direct dependency of the current crate</tspan>
+</tspan>
+  </text>
+
+</svg>

--- a/tests/color/styled_title.rs
+++ b/tests/color/styled_title.rs
@@ -47,4 +47,8 @@ use c::cnb_runtime;
     let expected_unicode = file!["styled_title.unicode.term.svg": TermSvg];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = file!["styled_title.no_graphics.term.svg": TermSvg];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -32,6 +32,13 @@ error: oops
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: oops
+ at <current file>:2:8: oops
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -62,6 +69,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at <current file>:1:7: world
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -96,6 +110,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at <current file>:1:3 to 2:4: Good morning
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -131,6 +152,14 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at <current file>:1:1: Sushi1
+  on line 2, column 3: Sushi2
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -161,6 +190,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at <current file>:1:7: New world
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -176,6 +212,10 @@ fn test_format_title() {
     let expected_unicode = str!["error[E0001]: This is a title"];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str!["error E0001: This is a title"];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -206,6 +246,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ on line 5402
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -253,6 +300,14 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at file1.rs:5402
+ at file2.rs:2
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -291,6 +346,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+  on line 5403, column 8: Test annotation
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -313,6 +375,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+error: This __is__ a title
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -339,6 +408,14 @@ help: a way to fix this
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: the core problem
+note: more information
+help: a way to fix this
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -363,6 +440,14 @@ help: a way to fix this
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: the core problem
+note: more information
+help: a way to fix this
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -408,6 +493,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ on line 56
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -435,6 +527,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+  on line 1: Example string
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -469,6 +568,14 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+  on line 1: Example string
+  on line 1: Second line
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -497,6 +604,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at file.rs:1
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -530,6 +644,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ on line 56
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -563,6 +684,13 @@ error: dummy
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: dummy
+ at file/path:4:1 to 5:4
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -599,6 +727,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at file/path:3:1 to 4:8
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -635,6 +770,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at file/path:3:1
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -668,6 +810,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at file/path:3:1 to 4:1
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -708,6 +857,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at <current file>:1:2 to 2:1
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -739,6 +895,13 @@ error: bad
 
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: bad
+ at test.txt:1:1
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -775,6 +938,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at file/path:3:2
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -810,6 +980,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at file/path:3:2 to 4:1
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -845,6 +1022,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at file/path:3:3 to 4:1
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -881,6 +1065,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at file/path:3:3
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -921,6 +1112,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at <current file>:1:4 to 2:1
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -956,6 +1154,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at file/path:3:2 to 4:2
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -991,6 +1196,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at file/path:3:3 to 4:2
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1026,6 +1238,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at file/path:3:2 to 4:2
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1066,6 +1285,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at <current file>:1:4 to 2:2
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1103,6 +1329,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at file/path:3:2 to 5:1
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1143,6 +1376,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at file/path:3:3 to 4:3
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1180,6 +1420,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at file/path:3:3 to 5:1
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1215,6 +1462,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at file/path:3:2 to 4:3
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1250,6 +1504,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+ at file/path:3:2 to 4:3
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1295,6 +1556,14 @@ error: unused optional dependency
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: unused optional dependency
+ at Cargo.toml:4:1: I need this to be really long so I can test overlaps
+  on line 4, column 28: This should also be long but not too long
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1349,6 +1618,14 @@ error: unused optional dependency
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: unused optional dependency
+  on line 4, column 42 to line 7, column 43: I need this to be really long so I can test overlaps
+  on line 4, column 28: This should also be long but not too long
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1414,6 +1691,15 @@ error: unused optional dependency
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: unused optional dependency
+  on line 4, column 9 to line 7, column 26: I need this to be really long so I can test overlaps
+  on line 4, column 42 to line 7, column 43: I need this to be really long so I can test overlaps
+  on line 4, column 28: This should also be long but not too long
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1491,6 +1777,16 @@ error: unused optional dependency
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: unused optional dependency
+  on line 4, column 9 to line 7, column 26: I need this to be really long so I can test overlaps
+  on line 4, column 42 to line 7, column 43: I need this to be really long so I can test overlaps
+  on line 5, column 4 to line 8, column 5: I need this to be really long so I can test overlaps
+  on line 4, column 28: This should also be long but not too long
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1530,6 +1826,13 @@ error: title
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: title
+ at origin.txt:3:1: annotation
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1573,6 +1876,13 @@ error: title
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: title
+ at origin.txt:3:2: annotation
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1622,6 +1932,18 @@ help: you might have meant to use one of the following enum variants
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0423: expected value, found enum `A`
+  on line 1
+help: you might have meant to use one of the following enum variants
+ on line 1, column 4, replace with one of
+  (A::Tuple())
+  A::Unit
+
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1713,6 +2035,19 @@ help: the following traits which provide `pick` are implemented but not in scope
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0599: no method named `pick` found for struct `Chaenomeles` in the current scope
+  on line 18, column 25: method not found in `Chaenomeles`
+  on line 3: method `pick` not found for this struct
+help: the following traits which provide `pick` are implemented but not in scope; perhaps you want to import one of them
+ on line 2, column 1, add one of
+  use banana::Apple;
+  use banana::Peach;
+
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1766,6 +2101,15 @@ help: make these changes and things will work
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0423: expected value, found enum `A`
+  on line 1
+help: make these changes and things will work
+ on line 1, column 4, replace with `(A::Tuple())`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1818,6 +2162,15 @@ help: make these changes and things will work
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0423: Found `ThisIsVeryLong`
+  on line 1
+help: make these changes and things will work
+ on line 1, column 4, replace with `(A::Tuple())`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1918,6 +2271,18 @@ help: try explicitly pass `&Self` into the Closure as an argument
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0502: cannot borrow `*self` as mutable because it is also borrowed as immutable
+  on line 2, column 13: immutable borrow occurs here
+  on line 3: first borrow occurs due to use of `*self` in closure
+  on line 5: mutable borrow occurs here
+  on line 6: immutable borrow later used here
+help: try explicitly pass `&Self` into the Closure as an argument
+ on line 2, column 13, add `this: &Self`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2012,6 +2377,18 @@ help: if you want to call `next` on a iterator within the loop, consider using `
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0499: cannot borrow `chars` as mutable more than once at a time
+  on line 5: second mutable borrow occurs here
+  on line 4, column 15: first mutable borrow occurs here
+  on line 4, column 15: first borrow later used here
+help: if you want to call `next` on a iterator within the loop, consider using `while let`
+ on line 4, replace with `let iter = chars.by_ref();
+    while let Some(`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2100,6 +2477,19 @@ help: if you import `cell`, refer to it directly
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0433: failed to resolve: use of undeclared crate or module `st`
+  on line 13, column 10: use of undeclared crate or module `st`
+help: there is a crate or module with a similar name
+ on line 13, column 9, replace with `std`
+help: consider importing this module
+ on line 2, column 1, add `use std::cell;`
+help: if you import `cell`, refer to it directly
+ on line 13, column 9
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2183,6 +2573,16 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0277: the size for values of type `T` cannot be known at compilation time
+  on line 4, column 16: doesn't have a size known at compile-time
+  on line 4, column 8: this type parameter needs to be `Sized`
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+ on line 6, column 1
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2328,6 +2728,21 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0277: the size for values of type `T` cannot be known at compilation time
+ at $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:4:16: doesn't have a size known at compile-time
+  on line 4, column 8: this type parameter needs to be `Sized`
+note: required by an implicit `Sized` bound in `Wrapper`
+ at $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:2:16: required by the implicit `Sized` requirement on this type parameter in `Wrapper`
+help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
+ at $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:2:16: this could be changed to `T: ?Sized`...
+  on line 2, column 19: ...if indirection were used here: `Box<T>`
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+ on line 6, column 4
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2397,6 +2812,14 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0277: the size for values of type `T` cannot be known at compilation time
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+ on line 8, column 2
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2504,6 +2927,16 @@ note: expected this to be `Foo`
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0271: type mismatch resolving `<Result<Result<(), Result<Result<(), Result<Result<(), Option<{integer}>>, ...>>, ...>>, ...> as Future>::Error == Foo`
+ at $DIR/E0271.rs:20:5 to 32:6: type mismatch resolving `<Result<Result<(), Result<Result<(), ...>, ...>>, ...> as Future>::Error == Foo`
+note: expected this to be `Foo`
+ at $DIR/E0271.rs:10:18
+note: required for the cast from `Box<Result<Result<(), Result<Result<(), Result<Result<(), Option<{integer}>>, ()>>, ()>>, ()>>` to `Box<(dyn Future<Error = Foo> + 'static)>`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2616,6 +3049,17 @@ note: expected this to be `Foo`
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0271: type mismatch resolving `<Result<Result<(), Result<Result<(), Result<Result<(), Option<{integer}>>, ...>>, ...>>, ...> as Future>::Error == Foo`
+ at $DIR/E0271.rs:20:5 to 32:6: type mismatch resolving `<Result<Result<(), Result<Result<(), ...>, ...>>, ...> as Future>::Error == Foo`
+note: expected this to be `Foo`
+ at $DIR/E0271.rs:10:18
+note: required for the cast from `Box<Result<Result<(), Result<Result<(), Result<Result<(), Option<{integer}>>, ()>>, ()>>, ()>>` to `Box<(dyn Future<Error = Foo> + 'static)>`
+note: a second note
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2804,6 +3248,18 @@ error[E0308]: mismatched types
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0308: mismatched types
+ at $DIR/long-E0308.rs:48:9 to 52:35: expected `Atype<Btype<Ctype<..., i32>, i32>, i32>`, found `Result<Result<Result<..., _>, _>, _>`
+  on line 24, column 12 to line 48, column 6: expected due to this
+note: expected struct `Atype<Btype<..., i32>, i32>`
+           found enum `Result<Result<..., _>, _>`
+note: the full name for the type has been written to '$TEST_BUILD_DIR/$FILE.long-type-hash.txt'
+note: consider using `--verbose` to print the full type name to the console
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2906,6 +3362,18 @@ note: function defined here
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0308: mismatched types
+ at $DIR/unicode-output.rs:23:11: one type is more general than the other
+  on line 23: arguments to this function are incorrect
+note: expected fn pointer `for<'a> fn(Box<(dyn Any + Send + 'a)>) -> Pin<_>`
+            found fn item `fn(Box<(dyn Any + Send + 'static)>) -> Pin<_> {wrapped_fn}`
+note: function defined here
+ at $DIR/unicode-output.rs:12:10 to 14:4
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 // This tests that an ellipsis is not inserted into Unicode text when a line
@@ -2949,6 +3417,13 @@ error: title
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: title
+  on line 3, column 11 to line 5: annotation
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2978,6 +3453,10 @@ fn trim_unicode_annotate_ascii_end_with_label() {
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str!["  on line 1, column 170: expected item"];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3002,6 +3481,10 @@ fn trim_unicode_annotate_ascii_end_no_label() {
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str!["  on line 1, column 170"];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3031,6 +3514,10 @@ fn trim_unicode_annotate_unicode_end_with_label() {
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str!["  on line 1, column 170: expected item"];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3055,6 +3542,10 @@ fn trim_unicode_annotate_unicode_end_no_label() {
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str!["  on line 1, column 170"];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3084,6 +3575,10 @@ fn trim_unicode_annotate_unicode_middle_with_label() {
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str!["  on line 1, column 86: expected item"];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3108,6 +3603,10 @@ fn trim_unicode_annotate_unicode_middle_no_label() {
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str!["  on line 1, column 86"];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3137,6 +3636,10 @@ fn trim_ascii_annotate_ascii_end_with_label() {
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str!["  on line 1, column 335: expected item"];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3161,6 +3664,10 @@ fn trim_ascii_annotate_ascii_end_no_label() {
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str!["  on line 1, column 335"];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3214,6 +3721,14 @@ error[E0308]: mismatched types
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0308: mismatched types
+ at $DIR/non-whitespace-trimming-unicode.rs:4:415: expected `()`, found integer
+  on line 4, column 410: expected due to this
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3294,6 +3809,18 @@ help: create an owned `String` from a string reference
 
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0369: cannot add `&str` to `&str`
+ at $DIR/non-1-width-unicode-multiline-label.rs:7:260: `+` cannot be used to concatenate two `&str` strings
+  on line 7, column 245: &str
+  on line 7, column 262: &str
+note: string concatenation requires an owned `String` on the left
+help: create an owned `String` from a string reference
+ on line 7, column 258, add `.to_owned()`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3358,6 +3885,16 @@ note: byte `193` is not valid utf-8
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: couldn't read `$DIR/not-utf8.bin`: stream did not contain valid UTF-8
+ at $DIR/not-utf8.rs:6:5
+note: byte `193` is not valid utf-8
+ at $DIR/not-utf8.bin:1:1
+note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3419,6 +3956,16 @@ error[E0308]: mismatched types
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0308: mismatched types
+ at $DIR/mismatched-types.rs:3:19: expected `&str`, found `&[u8; 0]`
+  on line 3, column 12: expected due to this
+expected reference `&str`
+found reference `&'static [u8; 0]`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3480,6 +4027,16 @@ error[E0308]: mismatched types
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0308: mismatched types
+ at $DIR/mismatched-types.rs:3:19: expected `&str`, found `&[u8; 0]`
+  on line 3, column 12: expected due to this
+custom: expected reference `&str`
+        found reference `&'static [u8; 0]`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3586,6 +4143,16 @@ suggestion[S0123]: use `break` on its own without a value inside this `while` lo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0571: `break` with value from a `while` loop
+ at $DIR/issue-114529-illegal-break-with-value.rs:22:9 to 24:11: can only break with a value inside `loop` or breakable block
+  on line 21: you can't `break` with a value in a `while` loop
+suggestion S0123: use `break` on its own without a value inside this `while` loop
+ on line 22, column 8, replace with `break`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3639,6 +4206,13 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0277: the size for values of type `T` cannot be known at compilation time
+  on line 9
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3676,6 +4250,10 @@ fn empty_span_start_line() {
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str!["  on line 9: E112"];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3762,6 +4340,20 @@ help: or use `IntoIterator::into_iter(..)` instead of `.into_iter()` to explicit
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
+ at lint_example.rs:3:11
+warning: this changes meaning in Rust 2021
+note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+note: `#[warn(array_into_iter)]` on by default
+help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
+ on line 5, column 10, replace with `iter`
+help: or use `IntoIterator::into_iter(..)` instead of `.into_iter()` to explicitly iterate by value
+ on line 5, column 44, add ` // Span after line end`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3854,6 +4446,20 @@ help: or use `IntoIterator::into_iter(..)` instead of `.into_iter()` to explicit
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
+ at lint_example.rs:3:11
+warning: this changes meaning in Rust 2021
+note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+note: `#[warn(array_into_iter)]` on by default
+help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
+ on line 3, column 10, replace with `iter`
+help: or use `IntoIterator::into_iter(..)` instead of `.into_iter()` to explicitly iterate by value
+ on line 3, column 45, add ` // Span after line end`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3946,6 +4552,20 @@ help: or use `IntoIterator::into_iter(..)` instead of `.into_iter()` to explicit
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
+ at lint_example.rs:3:11
+warning: this changes meaning in Rust 2021
+note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+note: `#[warn(array_into_iter)]` on by default
+help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
+ on line 3, column 10, replace with `iter`
+help: or use `IntoIterator::into_iter(..)` instead of `.into_iter()` to explicitly iterate by value
+ on line 3, column 45, replace with ` // Span after line end`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4023,6 +4643,13 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+  on line 1, column 5: annotation
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4066,6 +4693,14 @@ error:
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: 
+  on line 1, column 5: annotation
+  on line 1, column 5: annotation
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4121,6 +4756,14 @@ error[E0282]: type annotations needed
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0282: type annotations needed
+ at $DIR/issue-42234-unknown-receiver-type.rs:12:10: cannot infer type of the type parameter `S` declared on the method `sum`
+
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4197,6 +4840,15 @@ help: consider specifying the generic argument
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0282: type annotations needed
+ at $DIR/issue-42234-unknown-receiver-type.rs:12:10: cannot infer type of the type parameter `S` declared on the method `sum`
+help: consider specifying the generic argument
+ on line 23, column 12, replace with `::<GENERIC_ARG>`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4269,6 +4921,15 @@ help: consider specifying the generic argument
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0282: type annotations needed
+ at $DIR/issue-42234-unknown-receiver-type.rs:12:10: cannot infer type of the type parameter `S` declared on the method `sum`
+help: consider specifying the generic argument
+ on line 23, column 12, replace with `::<_>`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4315,6 +4976,13 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0277: the size for values of type `T` cannot be known at compilation time
+  on line 12
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4361,6 +5029,13 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0277: the size for values of type `T` cannot be known at compilation time
+  on line 12
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4433,6 +5108,14 @@ error[E0609]: no field `field` on type `Thing`
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0609: no field `field` on type `Thing`
+note: a `Title` then a `Message`!?!?
+ at $DIR/too-many-field-suggestions.rs:26:7: unknown field
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4479,6 +5162,13 @@ error: invalid character `^` in path base name: `^^not-valid^^`, the first chara
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: invalid character `^` in path base name: `^^not-valid^^`, the first character must be a Unicode XID start character (most letters or `_`)
+ at Cargo.toml:10:24
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4520,6 +5210,13 @@ error: showing how tabs are rendered
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: showing how tabs are rendered
+ at tabbed.txt:2:2
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4564,6 +5261,14 @@ warning: whatever
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(report), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+warning: whatever
+ at whatever:1:1 to 3:22: blah
+  on line 1 to line 3, column 22: blah
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(report), expected_no_graphics);
 }
 
 #[test]
@@ -4607,6 +5312,14 @@ error: ensure single line at line 0 rendered correctly with group line lined up
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: ensure single line at line 0 rendered correctly with group line lined up
+ at Cargo.toml:0:8: unexpected token
+  on line 0: while parsing statement
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4715,6 +5428,25 @@ help: provide the argument
 "#]];
     let renderer_unicode = renderer_ascii.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer_unicode.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0061: this function takes 6 arguments but 5 arguments were supplied
+ at $DIR/trimmed_multiline_suggestion.rs:5:5
+  on line 7: argument #2 of type `char` is missing
+note: function defined here
+ at $DIR/trimmed_multiline_suggestion.rs:1:4
+help: provide the argument
+ on line 5, column 35, replace with `(
+        variable_name,
+        /* char */,
+        variable_name,
+        variable_name,
+        variable_name,
+        variable_name,
+    )`
+"#]];
+    let renderer_no_graphics = renderer_unicode.no_graphics(true);
+    assert_data_eq!(renderer_no_graphics.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4819,6 +5551,23 @@ help: add a `;` here
 "#]];
     let renderer_unicode = renderer_ascii.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer_unicode.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: consider adding a `;` to the last statement for consistent formatting
+ at tests/ui/semicolon_if_nothing_returned_testing.rs:4:5 to 10:7
+note: the lint level is defined here
+ at tests/ui/semicolon_if_nothing_returned_testing.rs:2:9
+help: add a `;` here
+ on line 4, column 4, replace with `nums.iter().for_each(|x| {
+        if *x > 0 {
+            println!("Positive number");
+        } else {
+            println!("Negative number");
+        }
+    });`
+"#]];
+    let renderer_no_graphics = renderer_unicode.no_graphics(true);
+    assert_data_eq!(renderer_no_graphics.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4920,6 +5669,22 @@ help: provide the argument
 "#]];
     let renderer_unicode = renderer_ascii.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer_unicode.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0061: this function takes 6 arguments but 5 arguments were supplied
+ at $DIR/trimmed_multiline_suggestion.rs:3:5
+  on line 5: argument #2 of type `char` is missing
+help: provide the argument
+ on line 3, column 35, replace with `(
+        variable_name,
+        /* char */,
+        variable_name,
+        variable_name,
+        variable_name,
+    )`
+"#]];
+    let renderer_no_graphics = renderer_unicode.no_graphics(true);
+    assert_data_eq!(renderer_no_graphics.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -5020,6 +5785,15 @@ help: consider importing this module
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0433: failed to resolve: use of undeclared crate or module `st`
+  on line 13, column 10: use of undeclared crate or module `st`
+help: consider importing this module
+ on line 2, column 1, add `use std::cell;`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -5069,6 +5843,69 @@ help: consider importing this module instead
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+ at /tmp/test.rs:1:5: no `sync` in the root
+help: consider importing this module instead
+ on line 1, column 4, replace with `std::sync`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
+}
+
+#[test]
+fn remove_whole_line() {
+    let source = r#"    code    "#;
+    let input = &[
+        Group::with_level(Level::ERROR).element(
+            Snippet::source(source)
+                .path("/tmp/test.rs")
+                .annotation(AnnotationKind::Primary.span(4..8).label("the code")),
+        ),
+        Level::HELP.secondary_title("replace the code").element(
+            Snippet::source(source)
+                .path("/tmp/test.rs")
+                .patch(Patch::new(4..8, "replaced")),
+        ),
+    ];
+
+    let expected_ascii = str![[r#"
+ --> /tmp/test.rs:1:5
+  |
+1 |     code    
+  |     ^^^^ the code
+  |
+help: replace the code
+  |
+1 -     code    
+1 +     replaced    
+  |
+"#]];
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    let expected_unicode = str![[r#"
+  ╭▸ /tmp/test.rs:1:5
+  │
+1 │     code    
+  │     ━━━━ the code
+  ╰╴
+help: replace the code
+  ╭╴
+1 -     code    
+1 +     replaced    
+  ╰╴
+"#]];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+ at /tmp/test.rs:1:5: the code
+help: replace the code
+ on line 1, replace with `replaced`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -5102,6 +5939,13 @@ warning: variable does not need to be mutable
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+warning: variable does not need to be mutable
+ at ice.rs:1:18: help: remove this `mut`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -5176,6 +6020,16 @@ help: consider making `bar` public
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0624: method `five_years` is private
+ at lib.rs:1:9: private method
+ at other.rs:1:4: private method defined here
+help: consider making `bar` public
+ at other.rs:1:1, add `pub `
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]

--- a/tests/no_graphics.rs
+++ b/tests/no_graphics.rs
@@ -1,0 +1,439 @@
+use annotate_snippets::{AnnotationKind, Level, Patch, Renderer, Snippet};
+
+use annotate_snippets::renderer::DecorStyle;
+use snapbox::{assert_data_eq, str};
+
+#[test]
+fn missing_fields_in_builder() {
+    let source = r#"use bitbybit::bitfield;
+
+#[bitfield(u32, default = 0, forbid_overlaps)]
+struct Test {
+    #[bits(8..=15, rw)]
+    foo: u8,
+    #[bits(0..=7, rw)]
+    bar: u8,
+}
+
+fn main() {
+    Test::builder().with_foo(1).build();
+    Test::builder().with_bar(1).build();
+    Test::builder().with_bar(1).with_foo(1).build();
+    Test::builder().with_bar(1).with_foo(1).with_bar(2).build();
+}
+"#;
+    let title =
+        "no method named `build` found for struct `PartialTest<true, false>` in the current scope";
+    let path = "tests/no_compile/missing_fields_in_builder.rs";
+
+    let report = &[Level::ERROR
+        .primary_title(title)
+        .id("E0599")
+        .element(
+            Snippet::source(source)
+                .path(path)
+                .annotation(
+                    AnnotationKind::Primary
+                        .span(206..211)
+                        .label("method not found in `PartialTest<true, false>`"),
+                )
+                .annotation(
+                    AnnotationKind::Context
+                        .span(25..71)
+                        .label("method `build` not found for this struct"),
+                ),
+        )
+        .element(Level::NOTE.message("the method was found for\n- `PartialTest<true, true>`"))];
+
+    let expected_ascii = str![[r#"
+error[E0599]: no method named `build` found for struct `PartialTest<true, false>` in the current scope
+  --> tests/no_compile/missing_fields_in_builder.rs:12:33
+   |
+ 3 | #[bitfield(u32, default = 0, forbid_overlaps)]
+   | ---------------------------------------------- method `build` not found for this struct
+...
+12 |     Test::builder().with_foo(1).build();
+   |                                 ^^^^^ method not found in `PartialTest<true, false>`
+   |
+   = note: the method was found for
+           - `PartialTest<true, true>`
+"#]];
+    let renderer_ascii = Renderer::plain().decor_style(DecorStyle::Ascii);
+    assert_data_eq!(renderer_ascii.render(report), expected_ascii);
+
+    let expected_no_graphics = str![[r#"
+error E0599: no method named `build` found for struct `PartialTest<true, false>` in the current scope
+ at tests/no_compile/missing_fields_in_builder.rs:12:33: method not found in `PartialTest<true, false>`
+  on line 3: method `build` not found for this struct
+note: the method was found for
+      - `PartialTest<true, true>`
+"#]];
+    let renderer_no_graphics = Renderer::plain().no_graphics(true);
+    assert_data_eq!(renderer_no_graphics.render(report), expected_no_graphics);
+}
+
+#[test]
+fn missing_fields_in_builder2() {
+    let source = r#"use bitbybit::bitfield;
+
+#[bitfield(u32, default = 0, forbid_overlaps)]
+struct Test {
+    #[bits(8..=15, rw)]
+    foo: u8,
+    #[bits(0..=7, rw)]
+    bar: u8,
+}
+
+fn main() {
+    Test::builder().with_foo(1).build();
+    Test::builder().with_bar(1).build();
+    Test::builder().with_bar(1).with_foo(1).build();
+    Test::builder().with_bar(1).with_foo(1).with_bar(2).build();
+}
+"#;
+    let title = "no method named `with_bar` found for struct `PartialTest<true, true>` in the current scope";
+    let path = "tests/no_compile/missing_fields_in_builder.rs";
+
+    let report = &[
+        Level::ERROR
+            .primary_title(title)
+            .id("E0599")
+            .element(
+                Snippet::source(source)
+                    .path(path)
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(353..361)
+                            .label("method not found in `PartialTest<true, true>`"),
+                    )
+                    .annotation(
+                        AnnotationKind::Context
+                            .span(25..71)
+                            .label("method `with_bar` not found for this struct"),
+                    ),
+            )
+            .element(
+                Level::NOTE
+                    .message("the method was found for\n- `PartialTest<foo_bitfield, false>`"),
+            ),
+        Level::HELP
+            .primary_title("one of the expressions' fields has a method of the same name")
+            .element(
+                Snippet::source(source)
+                    .path(path)
+                    .patch(Patch::new(353..353, "value.")),
+            ),
+    ];
+
+    let expected_ascii = str![[r#"
+error[E0599]: no method named `with_bar` found for struct `PartialTest<true, true>` in the current scope
+  --> tests/no_compile/missing_fields_in_builder.rs:15:45
+   |
+ 3 | #[bitfield(u32, default = 0, forbid_overlaps)]
+   | ---------------------------------------------- method `with_bar` not found for this struct
+...
+15 |     Test::builder().with_bar(1).with_foo(1).with_bar(2).build();
+   |                                             ^^^^^^^^ method not found in `PartialTest<true, true>`
+   |
+   = note: the method was found for
+           - `PartialTest<foo_bitfield, false>`
+help: one of the expressions' fields has a method of the same name
+   |
+15 |     Test::builder().with_bar(1).with_foo(1).value.with_bar(2).build();
+   |                                             ++++++
+"#]];
+    let renderer_ascii = Renderer::plain().decor_style(DecorStyle::Ascii);
+    assert_data_eq!(renderer_ascii.render(report), expected_ascii);
+
+    let expected_no_graphics = str![[r#"
+error E0599: no method named `with_bar` found for struct `PartialTest<true, true>` in the current scope
+ at tests/no_compile/missing_fields_in_builder.rs:15:45: method not found in `PartialTest<true, true>`
+  on line 3: method `with_bar` not found for this struct
+note: the method was found for
+      - `PartialTest<foo_bitfield, false>`
+help: one of the expressions' fields has a method of the same name
+ on line 15, column 44, add `value.`
+"#]];
+    let renderer_no_graphics = Renderer::plain().no_graphics(true);
+    assert_data_eq!(renderer_no_graphics.render(report), expected_no_graphics);
+}
+
+#[test]
+fn missing_type() {
+    let source = r#"//@ edition: 2015
+//@ compile-flags: --error-format human
+
+pub fn main() {
+    let x: Iter;
+}
+
+//~? RAW cannot find type `Iter` in this scope
+"#;
+    let path = "$DIR/missing-type.rs";
+
+    let report = &[
+        Level::ERROR
+            .primary_title("cannot find type `Iter` in this scope")
+            .id("E0425")
+            .element(
+                Snippet::source(source).path(path).annotation(
+                    AnnotationKind::Primary
+                        .span(86..90)
+                        .label("not found in this scope"),
+                ),
+            ),
+        Level::HELP
+            .secondary_title("consider importing one of these structs")
+            .element(Snippet::source(source).path(path).patch(Patch::new(
+                59..59,
+                "use std::collections::binary_heap::Iter;\n\n",
+            )))
+            .element(Snippet::source(source).path(path).patch(Patch::new(
+                59..59,
+                "use std::collections::btree_map::Iter;\n\n",
+            )))
+            .element(Snippet::source(source).path(path).patch(Patch::new(
+                59..59,
+                "use std::collections::btree_set::Iter;\n\n",
+            )))
+            .element(Snippet::source(source).path(path).patch(Patch::new(
+                59..59,
+                "use std::collections::hash_map::Iter;\n\n",
+            )))
+            .element(Level::NOTE.no_name().message("and 9 other candidates")),
+    ];
+
+    let expected_ascii = str![[r#"
+error[E0425]: cannot find type `Iter` in this scope
+ --> $DIR/missing-type.rs:5:12
+  |
+5 |     let x: Iter;
+  |            ^^^^ not found in this scope
+  |
+help: consider importing one of these structs
+  |
+4 + use std::collections::binary_heap::Iter;
+  |
+4 + use std::collections::btree_map::Iter;
+  |
+4 + use std::collections::btree_set::Iter;
+  |
+4 + use std::collections::hash_map::Iter;
+  |
+  = and 9 other candidates
+"#]];
+    let renderer_ascii = Renderer::plain();
+    assert_data_eq!(renderer_ascii.render(report), expected_ascii);
+
+    let expected_no_graphics = str![[r#"
+error E0425: cannot find type `Iter` in this scope
+ at $DIR/missing-type.rs:5:12: not found in this scope
+help: consider importing one of these structs
+ on line 4, column 1, add one of
+  use std::collections::binary_heap::Iter;
+  use std::collections::btree_map::Iter;
+  use std::collections::btree_set::Iter;
+  use std::collections::hash_map::Iter;
+and 9 other candidates
+"#]];
+    let renderer_no_graphics = Renderer::plain().no_graphics(true);
+    assert_data_eq!(renderer_no_graphics.render(report), expected_no_graphics);
+}
+
+#[test]
+fn multiple_files() {
+    let source_og = r#"//@ aux-build:other_file.rs
+//@ compile-flags: --error-format human
+
+extern crate other_file;
+
+fn main() {
+    other_file::WithPrivateMethod.private_method();
+}"#;
+
+    let source_og1 = r#"pub struct WithPrivateMethod;
+
+impl WithPrivateMethod {
+    /// Private to get an error involving two files
+    fn private_method(&self) {}
+}
+"#;
+
+    let report = &[Level::ERROR
+        .primary_title("method `private_method` is private")
+        .id("E0624")
+        .element(
+            Snippet::source(source_og)
+                .path("$DIR/multiple-files.rs")
+                .annotation(
+                    AnnotationKind::Primary
+                        .span(141..155)
+                        .label("private method"),
+                ),
+        )
+        .element(
+            Snippet::source(source_og1)
+                .path("$DIR/auxiliary/other_file.rs")
+                .annotation(
+                    AnnotationKind::Context
+                        .span(112..136)
+                        .label("private method defined here"),
+                ),
+        )];
+
+    let expected_ascii = str![[r#"
+error[E0624]: method `private_method` is private
+  --> $DIR/multiple-files.rs:7:35
+   |
+LL |     other_file::WithPrivateMethod.private_method();
+   |                                   ^^^^^^^^^^^^^^ private method
+   |
+  ::: $DIR/auxiliary/other_file.rs:5:5
+   |
+LL |     fn private_method(&self) {}
+   |     ------------------------ private method defined here
+"#]];
+    let renderer_ascii = Renderer::plain().anonymized_line_numbers(true);
+    assert_data_eq!(renderer_ascii.render(report), expected_ascii);
+
+    let expected_no_graphics = str![[r#"
+error E0624: method `private_method` is private
+ at $DIR/multiple-files.rs:7:35: private method
+ at $DIR/auxiliary/other_file.rs:5:5: private method defined here
+"#]];
+    let renderer_no_graphics = Renderer::plain().no_graphics(true);
+    assert_data_eq!(renderer_no_graphics.render(report), expected_no_graphics);
+}
+
+#[test]
+fn multispan() {
+    let source = r#"//@ proc-macro: multispan.rs
+//@ compile-flags: --error-format human
+
+#![feature(proc_macro_hygiene)]
+
+extern crate multispan;
+
+use multispan::hello;
+
+fn main() {
+    // This one emits no error.
+    hello!();
+
+    // Exactly one 'hi'.
+    hello!(hi);
+
+    // Now two, back to back.
+    hello!(hi hi);
+
+    // Now three, back to back.
+    hello!(hi hi hi);
+
+    // Now several, with spacing.
+    hello!(hi hey hi yo hi beep beep hi hi);
+    hello!(hi there, hi how are you? hi... hi.);
+    hello!(whoah. hi di hi di ho);
+    hello!(hi good hi and good bye);
+}
+
+//~? RAW hello to you, too!"#;
+    let message = "this error originates in the macro `hello` (in Nightly builds, run with -Z macro-backtrace for more info)";
+
+    let report = &[
+        Level::ERROR.primary_title("hello to you, too!").element(
+            Snippet::source(source)
+                .path("$DIR/multispan.rs")
+                .annotation(AnnotationKind::Primary.span(286..299)),
+        ),
+        Level::NOTE
+            .secondary_title("found these 'hi's")
+            .element(
+                Snippet::source(source)
+                    .path("$DIR/multispan.rs")
+                    .annotation(AnnotationKind::Primary.span(293..295))
+                    .annotation(AnnotationKind::Primary.span(296..298)),
+            )
+            .element(Level::NOTE.message(message)),
+    ];
+
+    let expected_ascii = str![[r#"
+error: hello to you, too!
+  --> $DIR/multispan.rs:18:5
+   |
+LL |     hello!(hi hi);
+   |     ^^^^^^^^^^^^^
+   |
+note: found these 'hi's
+  --> $DIR/multispan.rs:18:12
+   |
+LL |     hello!(hi hi);
+   |            ^^ ^^
+   = note: this error originates in the macro `hello` (in Nightly builds, run with -Z macro-backtrace for more info)
+"#]];
+    let renderer_ascii = Renderer::plain().anonymized_line_numbers(true);
+    assert_data_eq!(renderer_ascii.render(report), expected_ascii);
+
+    let expected_no_graphics = str![[r#"
+error: hello to you, too!
+ at $DIR/multispan.rs:18:5
+note: found these 'hi's
+ at $DIR/multispan.rs:18:12
+note: this error originates in the macro `hello` (in Nightly builds, run with -Z macro-backtrace for more info)
+"#]];
+    let renderer_no_graphics = Renderer::plain().no_graphics(true);
+    assert_data_eq!(renderer_no_graphics.render(report), expected_no_graphics);
+}
+
+#[test]
+fn foreign_suggestion() {
+    let source1 = r#"
+fn main() {
+    hello!();
+}
+"#;
+    let source2 = r#"
+macro_rules! hello {
+    () => {{ foo() }}
+}
+"#;
+    let report = &[
+        Level::ERROR.primary_title("foo").element(
+            Snippet::source(source1)
+                .path("$DIR/foo.rs")
+                .annotation(AnnotationKind::Primary.span(17..25)),
+        ),
+        Level::HELP
+            .secondary_title("consider removing this")
+            .element(
+                Snippet::source(source2)
+                    .path("$DIR/macro.rs")
+                    .patch(Patch::new(35..40, "")),
+            ),
+    ];
+
+    let expected_ascii = str![[r#"
+error: foo
+  --> $DIR/foo.rs:3:5
+   |
+LL |     hello!();
+   |     ^^^^^^^^
+   |
+help: consider removing this
+  --> $DIR/macro.rs:3:14
+   |
+LL -     () => {{ foo() }}
+LL +     () => {{  }}
+   |
+"#]];
+    let renderer_ascii = Renderer::plain().anonymized_line_numbers(true);
+    assert_data_eq!(renderer_ascii.render(report), expected_ascii);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at $DIR/foo.rs:3:5
+help: consider removing this
+ at $DIR/macro.rs:3:13
+"#]];
+    let renderer_no_graphics = Renderer::plain().no_graphics(true);
+    assert_data_eq!(renderer_no_graphics.render(report), expected_no_graphics);
+}

--- a/tests/rustc_tests.rs
+++ b/tests/rustc_tests.rs
@@ -43,6 +43,13 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:2:10 to 3:2: test
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn ends_on_col2() {
@@ -83,6 +90,13 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:2:10 to 5:4: test
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn non_nested() {
@@ -140,6 +154,14 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:3:3 to 5:5: `X` is a good letter
+  on line 3, column 6 to line 5: `Y` is a good letter too
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn nested() {
@@ -194,6 +216,14 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:3:3 to 4:8: `X` is a good letter
+  on line 3, column 6 to line 4, column 5: `Y` is a good letter too
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn different_overlap() {
@@ -252,6 +282,14 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:3:6 to 5:5: `X` is a good letter
+  on line 4, column 9 to line 6, column 5: `Y` is a good letter too
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn triple_overlap() {
@@ -314,6 +352,15 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:3:3 to 5:5: `X` is a good letter
+  on line 3, column 6 to line 5, column 8: `Y` is a good letter too
+  on line 3, column 9 to line 5: `Z` label
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn triple_exact_overlap() {
@@ -374,6 +421,15 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:3:3 to 5:5: `X` is a good letter
+  on line 3 to line 5, column 5: `Y` is a good letter too
+  on line 3 to line 5, column 5: `Z` label
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn minimum_depth() {
@@ -441,6 +497,15 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:3:6 to 4:5: `X` is a good letter
+  on line 4, column 6 to line 5: `Y` is a good letter too
+  on line 5 to line 6, column 8: `Z`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn non_overlapping() {
@@ -497,6 +562,14 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:3:3 to 4:5: `X` is a good letter
+  on line 5, column 6 to line 6: `Y` is a good letter too
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn overlapping_start_and_end() {
@@ -557,6 +630,14 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:3:6 to 4:5: `X` is a good letter
+  on line 4, column 9 to line 6: `Y` is a good letter too
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn multiple_labels_primary_without_message() {
@@ -597,6 +678,14 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:3:7
+  on line 3: `a` is a good letter
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn multiple_labels_secondary_without_message() {
@@ -636,6 +725,13 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:3:3: `a` is a good letter
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn multiple_labels_primary_without_message_2() {
@@ -680,6 +776,13 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:3:7: `b` is a good letter
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn multiple_labels_secondary_without_message_2() {
@@ -723,6 +826,14 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:3:3
+  on line 3, column 7: `b` is a good letter
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn multiple_labels_secondary_without_message_3() {
@@ -766,6 +877,13 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:3:3: `a` is a good letter
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn multiple_labels_without_message() {
@@ -801,6 +919,13 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:3:3
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn multiple_labels_without_message_2() {
@@ -837,6 +962,13 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:3:7
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn multiple_labels_with_message() {
@@ -886,6 +1018,14 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:3:3: `a` is a good letter
+  on line 3, column 7: `b` is a good letter
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn ingle_label_with_message() {
@@ -924,6 +1064,13 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:3:3: `a` is a good letter
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn single_label_without_message() {
@@ -958,6 +1105,13 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:3:3
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn long_snippet() {
@@ -1036,6 +1190,14 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:3:6 to 4:5: `X` is a good letter
+  on line 4, column 9 to line 16: `Y` is a good letter too
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 #[test]
 fn long_snippet_multiple_spans() {
@@ -1120,6 +1282,14 @@ error: foo
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: foo
+ at test.rs:3:6 to 16:8: `Y` is a good letter
+  on line 7, column 9 to line 11: `Z` is a good letter too
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1182,6 +1352,16 @@ error: this file contains an unclosed delimiter
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: this file contains an unclosed delimiter
+ at $DIR/issue-91334.rs:7:23
+  on line 7, column 7: unclosed delimiter
+  on line 7, column 15: unclosed delimiter
+  on line 7, column 20: missing open `(` for this delimiter
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1286,6 +1466,16 @@ help: use `break` on its own without a value inside this `while` loop
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0571: `break` with value from a `while` loop
+ at $DIR/issue-114529-illegal-break-with-value.rs:22:9 to 24:11: can only break with a value inside `loop` or breakable block
+  on line 21: you can't `break` with a value in a `while` loop
+help: use `break` on its own without a value inside this `while` loop
+ at $DIR/issue-114529-illegal-break-with-value.rs:22:9 to 24:11: break
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1518,6 +1708,16 @@ note: required by a bound in `is_transmutable`
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0277: `V0usize` cannot be safely transmuted into `[usize; 2]`
+ at $DIR/primitive_reprs_should_have_correct_length.rs:144:44: the size of `V0usize` is smaller than the size of `[usize; 2]`
+note: required by a bound in `is_transmutable`
+ at $DIR/primitive_reprs_should_have_correct_length.rs:12:14 to 19:11: required by this bound in `is_transmutable`
+  on line 10, column 12: required by a bound in this function
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1578,6 +1778,13 @@ error[E027s7]: `&[u8; 0]` cannot be safely transmuted into `&[u16; 0]`
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E027s7: `&[u8; 0]` cannot be safely transmuted into `&[u16; 0]`
+ at $DIR/align-fail.rs:21:55: the minimum alignment of `&[u8; 0]` (1) should be greater than that of `&[u16; 0]` (2)
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1677,6 +1884,16 @@ error[E0618]: expected function, found `{integer}`
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0618: expected function, found `{integer}`
+ at $DIR/missing-semicolon.rs:5:13
+  on line 4, column 9: `x` has type `{integer}`
+  on line 5, column 13 to line 6, column 7: call expression requires function
+  on line 5, column 14: help: consider using a semicolon here to finish the statement: `;`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1830,6 +2047,19 @@ note: the lint level is defined here
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+warning: non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
+ at $DIR/auxiliary/nested-macro-rules.rs:7:9 to 12:10
+  on line 4: in this expansion of `nested_macro_rules::outer_macro!`
+ at $DIR/nested-macro-rules.rs:23:5: in this macro invocation
+help: remove the `#[macro_export]` or move this `macro_rules!` outside the of the current function `main`
+note: a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute
+note: the lint level is defined here
+ at $DIR/nested-macro-rules.rs:8:9
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1936,6 +2166,15 @@ help: you must specify a type for this binding, like `i32`
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0689: can't call method `pow` on ambiguous numeric type `{integer}`
+ at $DIR/method-on-ambiguous-numeric-type.rs:37:9
+help: you must specify a type for this binding, like `i32`
+ at $DIR/auxiliary/macro-in-other-crate.rs:3:35: : i32
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -1992,6 +2231,13 @@ error[E0282]: type annotations needed
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0282: type annotations needed
+ at $DIR/issue-42234-unknown-receiver-type.rs:15:10: cannot infer type of the type parameter `S` declared on the method `sum`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2185,6 +2431,25 @@ help: ensure that all possible cases are being handled by adding a match arm wit
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0004: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
+ at $DIR/empty-match.rs:71:24: patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
+note: `NonEmptyEnum5` defined here
+ at $DIR/empty-match.rs:38:10
+  on line 39: not covered
+  on line 40: not covered
+  on line 41: not covered
+  on line 42: not covered
+  on line 43: not covered
+note: the matched value is of type `NonEmptyEnum5`
+note: match arms with guards don't count towards exhaustivity
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
+ at $DIR/empty-match.rs:17:33: ,
+                _ => todo!()
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2277,6 +2542,18 @@ note: for a trait to be dyn compatible it needs to allow building a vtable
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0038: the trait alias `EqAlias` is not dyn compatible
+ at $DIR/object-fail.rs:7:17: `EqAlias` is not dyn compatible
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+ at $SRC_DIR/core/src/cmp.rs:334:14
+note: ...because it uses `Self` as a type parameter
+ at $DIR/object-fail.rs:3:7: this trait is not dyn compatible...
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2319,6 +2596,13 @@ error[E0038]: mismatched types
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0038: mismatched types
+ at $DIR/long-span.rs:2:15: expected `u8`, found `[{integer}; 1680]`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2363,6 +2647,13 @@ error[E0038]: mismatched types
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0038: mismatched types
+ at $DIR/long-span.rs:2:15: expected `u8`, found `[{integer}; 1680]`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2407,6 +2698,13 @@ error[E0038]: mismatched types
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0038: mismatched types
+ at $DIR/long-span.rs:2:15: expected `u8`, found `[{integer}; 1680]`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2449,6 +2747,13 @@ error[E0038]: mismatched types
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0038: mismatched types
+ at $DIR/long-span.rs:2:15: expected `u8`, found `[{integer}; 1680]`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2562,6 +2867,19 @@ help: you might have meant to use `Iterator::for_each`
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: `Iterator::map` call that discard the iterator's values
+ at $DIR/lint_map_unit_fn.rs:11:18 to 14:7
+  on line 11, column 18 to line 14, column 7: after this call to map, the resulting iterator is `impl Iterator<Item = ()>`, which means the only information carried by the iterator is the number of items
+  on line 11, column 22: this function returns `()`, which is likely not what you wanted
+  on line 11, column 22 to line 14, column 6: called `Iterator::map` with callable that returns `()`
+note: `Iterator::map`, like many of the methods on `Iterator`, gets executed lazily, meaning that its effects won't be visible until it is iterated
+help: you might have meant to use `Iterator::for_each`
+ on line 11, column 17, replace with `for_each`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2641,6 +2959,15 @@ help: escape the character
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: character constant must be escaped: `/n`
+ at $DIR/bad-char-literals.rs:10:6 to 11:1
+help: escape the character
+ on line 10, column 5, add `/n`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2708,6 +3035,15 @@ note: frontmatter opening here was not closed
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: unclosed frontmatter
+ at $DIR/unclosed-1.rs:1:1 to 7:1
+note: frontmatter opening here was not closed
+ at $DIR/unclosed-1.rs:1:1
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2782,6 +3118,15 @@ note: frontmatter opening here was not closed
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: unclosed frontmatter
+ at $DIR/unclosed-2.rs:1:1 to 15:3
+note: frontmatter opening here was not closed
+ at $DIR/unclosed-2.rs:1:1
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2853,6 +3198,15 @@ note: frontmatter close should not be preceded by whitespace
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: invalid preceding whitespace for frontmatter close
+ at $DIR/unclosed-3.rs:12:1
+note: frontmatter close should not be preceded by whitespace
+ at $DIR/unclosed-3.rs:12:1
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2919,6 +3273,15 @@ note: frontmatter opening here was not closed
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: unclosed frontmatter
+ at $DIR/unclosed-4.rs:1:1 to 3:1
+note: frontmatter opening here was not closed
+ at $DIR/unclosed-4.rs:1:1
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -2987,6 +3350,15 @@ note: frontmatter opening here was not closed
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: unclosed frontmatter
+ at $DIR/unclosed-5.rs:1:1 to 7:1
+note: frontmatter opening here was not closed
+ at $DIR/unclosed-5.rs:1:1
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3166,6 +3538,19 @@ help: a unit variant with a similar name exists
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0532: expected unit struct, unit variant or constant, found tuple variant `E1::Z1`
+ at $DIR/pat-tuple-field-count-cross.rs:35:9
+ at $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:11:15: similarly named unit variant `Z0` defined here
+  on line 11, column 19: `E1::Z1` defined here
+help: use the tuple variant pattern syntax instead
+ on line 35, column 8, replace with `E1::Z1()`
+help: a unit variant with a similar name exists
+ on line 35, column 12, replace with `Z0`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3243,6 +3628,16 @@ error[E0758]: unterminated block comment
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0758: unterminated block comment
+ at $DIR/unterminated-nested-comment.rs:1:1 to 4:4
+  on line 1: unterminated block comment
+  on line 3: ...as last nested comment starts here, maybe you want to close this instead?
+  on line 4: ...and last nested comment terminates here.
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3326,6 +3721,17 @@ error[E0308]: mismatched types
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0308: mismatched types
+ at $DIR/file.txt:3:1: expected `&[u8]`, found `&str`
+ at $DIR/mismatched-types.rs:2:12: expected due to this
+  on line 2, column 20: in this macro invocation
+note: expected reference `&[u8]`
+         found reference `&'static str`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3387,6 +3793,16 @@ error[E0308]: mismatched types
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0308: mismatched types
+ at $DIR/mismatched-types.rs:3:19: expected `&str`, found `&[u8; 0]`
+  on line 3, column 12: expected due to this
+note: expected reference `&str`
+         found reference `&'static [u8; 0]`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3443,6 +3859,16 @@ $DIR/short-error-format.rs:6:9: error[E0308]: mismatched types: expected `u32`, 
     ];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0308: mismatched types
+ at $DIR/short-error-format.rs:6:9: expected `u32`, found `String`
+  on line 6: arguments to this function are incorrect
+note: function defined here
+ at $DIR/short-error-format.rs:3:4
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3484,6 +3910,13 @@ $DIR/short-error-format.rs:8:7: error[E0599]: no method named `salut` found for 
     ];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0599: no method named `salut` found for type `u32` in the current scope
+ at $DIR/short-error-format.rs:8:7: method not found in `u32`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3569,6 +4002,18 @@ help: use an automatic link instead
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: this URL is not a hyperlink
+ at $DIR/diagnostic-width.rs:4:41
+note: bare URLs are not automatically turned into clickable links
+note: the lint level is defined here
+ at $DIR/diagnostic-width.rs:2:9
+help: use an automatic link instead
+ on line 4, column 40, add `<`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3660,6 +4105,20 @@ help: or use `IntoIterator::into_iter(..)` instead of `.into_iter()` to explicit
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
+ at lint_example.rs:3:11
+warning: this changes meaning in Rust 2021
+note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+note: `#[warn(array_into_iter)]` on by default
+help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
+ on line 3, column 10, replace with `iter`
+help: or use `IntoIterator::into_iter(..)` instead of `.into_iter()` to explicitly iterate by value
+ on line 3, column 1, add `IntoIterator::into_iter(`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3764,6 +4223,19 @@ note: the foreign item type `Box<isize>` doesn't implement `Add`
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0369: cannot add `Box<isize>` to `Box<isize>`
+ at $DIR/autoderef-box-no-add.rs:25:24
+  on line 25, column 20: Box<isize>
+  on line 25, column 26: Box<isize>
+note: the foreign item type `Box<isize>` doesn't implement `Add`
+ at $SRC_DIR/alloc/src/boxed.rs:231:0
+ at $SRC_DIR/alloc/src/boxed.rs:234:1
+note: not implement `Add`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -3904,6 +4376,18 @@ help: trait `Future` which provides `poll` is implemented but not in scope; perh
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0599: no method named `poll` found for struct `Pin<&mut impl Future<Output = ()>>` in the current scope
+ at $DIR/dont-project-to-specializable-projection.rs:48:28: method not found in `Pin<&mut impl Future<Output = ()>>`
+ at $SRC_DIR/core/src/future/future.rs:104:7
+note: the method is available for `Pin<&mut impl Future<Output = ()>>` here
+help: items from traits can only be used if the trait is in scope
+help: trait `Future` which provides `poll` is implemented but not in scope; perhaps you want to import it
+ on line 6, column 1, add `use std::future::Future;`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4005,6 +4489,20 @@ note: the foreign item types don't implement required traits for this operation 
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0369: binary operation `==` cannot be applied to type `(std::io::Error, Thread)`
+ at $DIR/binary-op-not-allowed-issue-125631.rs:11:9
+  on line 10: (std::io::Error, Thread)
+  on line 11, column 12: (std::io::Error, Thread)
+note: the foreign item types don't implement required traits for this operation to be valid
+ at $SRC_DIR/std/src/io/error.rs:65:0
+note: not implement `PartialEq`
+ at $SRC_DIR/std/src/thread/mod.rs:1415:0
+note: not implement `PartialEq`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4077,6 +4575,16 @@ error: cannot find derive macro `Eqr` in this scope
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: cannot find derive macro `Eqr` in this scope
+ at $DIR/deriving-meta-unknown-trait.rs:1:10: help: a derive macro with a similar name exists: `Eq`
+ at $SRC_DIR/core/src/cmp.rs:356:0
+note: similarly named derive macro `Eq` defined here
+note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4185,6 +4693,26 @@ note: the traits `Iterator` and `ToTokens` must be implemented
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0599: the method `quote_into_iter` exists for struct `Ipv4Addr`, but its trait bounds were not satisfied
+ at $DIR/not-repeatable.rs:11:13: method cannot be called on `Ipv4Addr` due to unsatisfied trait bounds
+  on line 7: method `quote_into_iter` not found for this struct because it doesn't satisfy `Ipv4Addr: Iterator`, `Ipv4Addr: ToTokens`, `Ipv4Addr: proc_macro::ext::RepIteratorExt` or `Ipv4Addr: proc_macro::ext::RepToTokensExt`
+note: the following trait bounds were not satisfied:
+      `Ipv4Addr: Iterator`
+      which is required by `Ipv4Addr: proc_macro::ext::RepIteratorExt`
+      `&Ipv4Addr: Iterator`
+      which is required by `&Ipv4Addr: proc_macro::ext::RepIteratorExt`
+      `Ipv4Addr: ToTokens`
+      which is required by `Ipv4Addr: proc_macro::ext::RepToTokensExt`
+      `&mut Ipv4Addr: Iterator`
+      which is required by `&mut Ipv4Addr: proc_macro::ext::RepIteratorExt`
+note: the traits `Iterator` and `ToTokens` must be implemented
+ at $SRC_DIR/proc_macro/src/to_tokens.rs:11:0
+ at $SRC_DIR/core/src/iter/traits/iterator.rs:39:0
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4274,6 +4802,16 @@ error[E0220]: associated type `Pr` not found for `S<bool>` in the current scope
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0220: associated type `Pr` not found for `S<bool>` in the current scope
+ at $DIR/not-found-self-type-differs-shadowing-trait-item.rs:28:23: associated item not found in `S<bool>`
+  on line 12: associated type `Pr` not found for this struct
+note: the associated type was found for
+      
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4381,6 +4919,18 @@ note: the lint level is defined here
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: extern blocks should be unsafe
+ at $DIR/unsafe-extern-suggestion.rs:6:1 to 11:2
+  on line 6: help: needs `unsafe` before the extern keyword: `unsafe`
+warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
+note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-extern.html>
+note: the lint level is defined here
+ at $DIR/unsafe-extern-suggestion.rs:3:9
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4520,6 +5070,22 @@ note: function defined here
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0308: mismatched types
+ at $DIR/alloc-error-handler-bad-signature-2.rs:10:1 to 14:2: expected `Layout`, found `core::alloc::Layout`
+  on line 9: in this procedural macro expansion
+  on line 10 to line 12, column 2: arguments to this function are incorrect
+note: `core::alloc::Layout` and `Layout` have similar names, but are actually distinct types
+note: `core::alloc::Layout` is defined in crate `core`
+ at $SRC_DIR/core/src/alloc/layout.rs:40:0
+note: `Layout` is defined in the current crate
+ at $DIR/alloc-error-handler-bad-signature-2.rs:7:1
+note: function defined here
+ at $DIR/alloc-error-handler-bad-signature-2.rs:10:4
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4600,6 +5166,14 @@ warning: whitespace symbol '\u{a0}' is not skipped
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode.raw());
+
+    let expected_no_graphics = str![[r#"
+warning: whitespace symbol '\u{a0}' is not skipped
+ at $DIR/str-escape.rs:12:18 to 13:4
+  on line 13: whitespace symbol '\u{a0}' is not skipped
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics.raw());
 }
 
 #[test]
@@ -4709,6 +5283,21 @@ help: ensure that all possible cases are being handled by adding a match arm wit
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0004: non-exhaustive patterns: `Some(Private { misc: true, .. })` not covered
+ at $DIR/match-privately-empty.rs:14:11: pattern `Some(Private { misc: true, .. })` not covered
+note: `Option<Private>` defined here
+ at $SRC_DIR/core/src/option.rs:593:0
+ at $SRC_DIR/core/src/option.rs:601:4
+note: not covered
+note: the matched value is of type `Option<Private>`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+ on line 33, column 56, add `,
+        Some(Private { misc: true, .. }) => todo!()`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4821,6 +5410,21 @@ help: consider using an opaque type instead
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0038: the trait `Ord` is not dyn compatible
+ at $DIR/bare-trait-dont-suggest-dyn.rs:6:33: `Ord` is not dyn compatible
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+ at $SRC_DIR/core/src/cmp.rs:961:20
+note: the trait is not dyn compatible because it uses `Self` as a type parameter
+ at $SRC_DIR/core/src/cmp.rs:338:14
+note: the trait is not dyn compatible because it uses `Self` as a type parameter
+help: consider using an opaque type instead
+ on line 11, column 32, add `impl `
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -4924,6 +5528,20 @@ note: the foreign item types don't implement required traits for this operation 
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0369: binary operation `==` cannot be applied to type `(std::io::Error, Thread)`
+ at $DIR/binary-op-not-allowed-issue-125631.rs:11:9
+  on line 10: (std::io::Error, Thread)
+  on line 11, column 12: (std::io::Error, Thread)
+note: the foreign item types don't implement required traits for this operation to be valid
+ at $SRC_DIR/std/src/io/error.rs:65:0
+note: not implement `PartialEq`
+ at $SRC_DIR/std/src/thread/mod.rs:1439:0
+note: not implement `PartialEq`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -5054,6 +5672,20 @@ help: consider importing one of these structs
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0433: failed to resolve: use of undeclared type `IntoIter`
+ at $DIR/issue-82956.rs:25:24: use of undeclared type `IntoIter`
+help: consider importing one of these structs
+ on line 4, column 1, add one of
+  use std::array::IntoIter;
+  use std::collections::binary_heap::IntoIter;
+  use std::collections::btree_map::IntoIter;
+  use std::collections::btree_set::IntoIter;
+and 9 other candidates
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -5199,6 +5831,23 @@ help: consider using the `Default` trait
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0423: expected function, tuple struct or tuple variant, found struct `std::collections::HashMap`
+ at $DIR/multi-suggestion.rs:17:13
+ at $SRC_DIR/std/src/collections/hash/map.rs:242:0
+note: `std::collections::HashMap` defined here
+help: you might have meant to use an associated function to build this type
+ on line 17, column 37, replace with one of
+  ::new()
+  ::with_capacity(_)
+  ::with_hasher(_)
+  ::with_capacity_and_hasher(_, _)
+help: consider using the `Default` trait
+ on line 17, column 12, add `<`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -5389,6 +6038,26 @@ help: consider using the `Default` trait
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0423: cannot initialize a tuple struct which contains private fields
+ at $DIR/suggest-box-new.rs:11:19
+note: constructor is not visible here due to private fields
+ at $SRC_DIR/alloc/src/boxed.rs:234:2
+note: private field
+note: private field
+help: you might have meant to use an associated function to build this type
+ on line 11, column 21, replace with one of
+  ::new(_)
+  ::new_uninit()
+  ::new_zeroed()
+  ::new_in(_, _)
+and 12 other candidates
+help: consider using the `Default` trait
+ on line 11, column 18, add `<`
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -5517,6 +6186,21 @@ help: some of the expressions' fields have a method of the same name
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0599: no method named `bar` found for struct `Thing` in the current scope
+ at $DIR/too-many-field-suggestions.rs:25:7: method not found in `Thing`
+  on line 1: method `bar` not found for this struct
+help: some of the expressions' fields have a method of the same name
+ on line 25, column 6, add one of
+  a0.
+  a1.
+  a2.
+  a3.
+and 6 other candidates
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -5548,6 +6232,14 @@ error: invalid `--check-cfg` argument: `cfg(`
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: invalid `--check-cfg` argument: `cfg(`
+note: expected `cfg(name, values("value1", "value2", ... "valueN"))`
+note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -5636,6 +6328,19 @@ help: the constant being evaluated
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: constant evaluation is taking a long time
+ at $SRC_DIR/core/src/num/mod.rs:1151:4
+note: this lint makes sure the compiler doesn't get stuck due to infinite loops in const eval.
+      If your compilation actually takes a long time, you can safely allow the lint.
+help: the constant being evaluated
+ at $DIR/timeout.rs:7:1
+note: `#[deny(long_running_const_eval)]` on by default
+note: this error originates in the macro `uint_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+"#]];
+    let renderer = renderer.no_graphics(true);
+    assert_data_eq!(renderer.render(input), expected_no_graphics);
 }
 
 #[test]
@@ -5688,6 +6393,15 @@ help: Unicode character ' ' (No-Break Space) looks like ' ' (Space), but it is 
 "#]];
     let renderer_unicode = renderer_ascii.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer_unicode.render(report), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: unknown start of token:  
+ at $DIR/emitter-overflow-bad-whitespace.rs:10:1
+help: Unicode character ' ' (No-Break Space) looks like ' ' (Space), but it is not
+ on line 10, column 1
+"#]];
+    let renderer_no_graphics = renderer_unicode.no_graphics(true);
+    assert_data_eq!(renderer_no_graphics.render(report), expected_no_graphics);
 }
 
 #[test]
@@ -5830,6 +6544,23 @@ help: remove the extra arguments
 "##]];
     let renderer_unicode = renderer_ascii.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer_unicode.render(report), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error E0061: this function takes 1 argument but 3 arguments were supplied
+ at $DIR/issue-109854.rs:2:5
+  on line 5 to line 7, column 3: unexpected argument #2 of type `&'static str`
+  on line 8: unexpected argument #3 of type `&'static str`
+note: expected `usize`, found fn item
+ at $DIR/issue-109854.rs:4:5
+note: expected type `[22;1;35musize[22;39m`
+      found fn item `[22;1;35mfn() {generate_setter}[22;39m`
+note: associated function defined here
+ at $SRC_DIR/alloc/src/string.rs:480:11
+help: remove the extra arguments
+ on line 4, column 4, replace with `/* usize */`
+"#]];
+    let renderer_no_graphics = renderer_unicode.no_graphics(true);
+    assert_data_eq!(renderer_no_graphics.render(report), expected_no_graphics);
 }
 
 #[test]
@@ -5910,4 +6641,15 @@ help: otherwise remove the non-wildcard arms
 "#]];
     let renderer_unicode = renderer_ascii.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer_unicode.render(report), expected_unicode);
+
+    let expected_no_graphics = str![[r#"
+error: these match arms have identical bodies
+ at tests/ui/match_same_arms.rs:20:9
+  on line 22: the wildcard arm
+help: if this is unintentional make the arms return different values
+help: otherwise remove the non-wildcard arms
+ on line 20, column 8
+"#]];
+    let renderer_no_graphics = renderer_unicode.no_graphics(true);
+    assert_data_eq!(renderer_no_graphics.render(report), expected_no_graphics);
 }


### PR DESCRIPTION
Introduce a new text only renderer mode. The new output is meant to be less verbose, and usable by users relying on Text-To-Speech and Braille displays. All information that annotate-snippets has available is surfaced, but with an eye at reducing duplicated output and making sure there is no reliance on visuals for highlighting or differentiating necessary information, beyond newlines.

Each individual error group is separated by a single newline. Within an error, each section follows the pattern "LEVEL: message" on one line, followed by the position in the format `at PATH:LL:CC`, indented by one space. If that position has a `Message`, its text is on that same line, separated by a colon: `at PATH:LL:CC: message`. If there are multiple `Message`s, every subsequent position from the same path skip printing it, we use a more textual format and is indented by one additional space: `on line LL, column CC: message`. For suggestions, if there are multiple, we render each of them on their own line.

The renderer is color aware, so the same stylesheet is used as regular ASCII and Unicode drawing modes.

<img width="740" height="290" alt="example of multiple multiline removal rendering in no_graphics mode" src="https://github.com/user-attachments/assets/70c29c52-a0bd-4b16-9c6f-0804a8e4356c" />

Fixes #351.