### PR TITLE
fix: Pick correct origin for non-folded secondary snippets

### DIFF
--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -546,7 +546,11 @@ fn render_snippet_annotations(
                 buffer_msg_line_offset,
                 max_line_num_len + 1,
             );
-            if let Some(first_line) = annotated_lines.first() {
+            if let Some(first_line) = annotated_lines
+                .iter()
+                .find(|l| !l.annotations.is_empty())
+                .or(annotated_lines.first())
+            {
                 origin.line = Some(first_line.line_index);
                 if let Some(first_annotation) = first_line.annotations.first() {
                     origin.char_column = Some(first_annotation.start.char + 1);

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -5177,3 +5177,60 @@ help: consider making `bar` public
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
+
+#[test]
+fn ensure_col_with_second_snippet_without_folding() {
+    let input = &[Level::ERROR
+        .primary_title("main diagnostic message")
+        .id("test-diagnostics")
+        .element(
+            Snippet::source("aardvark\nbeetle\ncanary\n")
+                .path("animals")
+                .fold(false)
+                .annotation(AnnotationKind::Primary.span(0..8)),
+        )
+        .element(
+            Snippet::source("inchworm\njackrabbit\nkangaroo\n")
+                .path("animals")
+                .fold(false)
+                .annotation(AnnotationKind::Context.span(20..28)),
+        )];
+
+    let expected_ascii = str![[r#"
+error[test-diagnostics]: main diagnostic message
+ --> animals:1:1
+  |
+1 | aardvark
+  | ^^^^^^^^
+2 | beetle
+3 | canary
+  |
+ ::: animals:1
+  |
+1 | inchworm
+2 | jackrabbit
+3 | kangaroo
+  | --------
+"#]];
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    let expected_unicode = str![[r#"
+error[test-diagnostics]: main diagnostic message
+  ╭▸ animals:1:1
+  │
+1 │ aardvark
+  │ ━━━━━━━━
+2 │ beetle
+3 │ canary
+  │
+  ⸬  animals:1
+  │
+1 │ inchworm
+2 │ jackrabbit
+3 │ kangaroo
+  ╰╴────────
+"#]];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+}

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -5179,7 +5179,7 @@ help: consider making `bar` public
 }
 
 #[test]
-fn ensure_col_with_second_snippet_without_folding() {
+fn prefer_first_annotation_on_secondary_snippets() {
     let input = &[Level::ERROR
         .primary_title("main diagnostic message")
         .id("test-diagnostics")
@@ -5205,7 +5205,7 @@ error[test-diagnostics]: main diagnostic message
 2 | beetle
 3 | canary
   |
- ::: animals:1
+ ::: animals:3:1
   |
 1 | inchworm
 2 | jackrabbit
@@ -5224,7 +5224,7 @@ error[test-diagnostics]: main diagnostic message
 2 │ beetle
 3 │ canary
   │
-  ⸬  animals:1
+  ⸬  animals:3:1
   │
 1 │ inchworm
 2 │ jackrabbit


### PR DESCRIPTION
Found through my work on `ruff_annotate_snippets`.