### PR TITLE
fix(simd): Fix indentation with trailing newline 

### DIFF
--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -2736,7 +2736,10 @@ fn pre_process<'a>(
 fn newline_count(body: &str) -> usize {
     #[cfg(feature = "simd")]
     {
-        memchr::memchr_iter(b'\n', body.as_bytes()).count()
+        // Trailing newlines do not count towards the number of lines
+        // (this is based into `str::lines`)
+        let trailing_newline = body.ends_with('\n');
+        memchr::memchr_iter(b'\n', body.as_bytes()).count() - usize::from(trailing_newline)
     }
     #[cfg(not(feature = "simd"))]
     {
@@ -2788,26 +2791,14 @@ mod test {
 
         assert_eq!(newline_count("one"), 0);
 
-        #[cfg(feature = "simd")]
-        assert_eq!(newline_count("one\n"), 1);
-        #[cfg(not(feature = "simd"))]
         assert_eq!(newline_count("one\n"), 0);
 
         assert_eq!(newline_count("one\ntwo"), 1);
 
-        #[cfg(feature = "simd")]
-        assert_eq!(newline_count("one\ntwo\n"), 2);
-        #[cfg(not(feature = "simd"))]
         assert_eq!(newline_count("one\ntwo\n"), 1);
 
-        #[cfg(feature = "simd")]
-        assert_eq!(newline_count("one\n\n"), 2);
-        #[cfg(not(feature = "simd"))]
         assert_eq!(newline_count("one\n\n"), 1);
 
-        #[cfg(feature = "simd")]
-        assert_eq!(newline_count("one\r\ntwo\r\n"), 2);
-        #[cfg(not(feature = "simd"))]
         assert_eq!(newline_count("one\r\ntwo\r\n"), 1);
     }
 }

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -2782,9 +2782,32 @@ mod test {
                 [dependencies]
                 bar = { base = '^^not-valid^^', path = 'bar' }
             "#;
-        let actual_count = newline_count(source);
-        let expected_count = 10;
+        assert_eq!(newline_count(source), 10);
 
-        assert_eq!(expected_count, actual_count);
+        assert_eq!(newline_count(""), 0);
+
+        assert_eq!(newline_count("one"), 0);
+
+        #[cfg(feature = "simd")]
+        assert_eq!(newline_count("one\n"), 1);
+        #[cfg(not(feature = "simd"))]
+        assert_eq!(newline_count("one\n"), 0);
+
+        assert_eq!(newline_count("one\ntwo"), 1);
+
+        #[cfg(feature = "simd")]
+        assert_eq!(newline_count("one\ntwo\n"), 2);
+        #[cfg(not(feature = "simd"))]
+        assert_eq!(newline_count("one\ntwo\n"), 1);
+
+        #[cfg(feature = "simd")]
+        assert_eq!(newline_count("one\n\n"), 2);
+        #[cfg(not(feature = "simd"))]
+        assert_eq!(newline_count("one\n\n"), 1);
+
+        #[cfg(feature = "simd")]
+        assert_eq!(newline_count("one\r\ntwo\r\n"), 2);
+        #[cfg(not(feature = "simd"))]
+        assert_eq!(newline_count("one\r\ntwo\r\n"), 1);
     }
 }

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -5247,18 +5247,6 @@ fn consistent_indentation_with_trailing_newline() {
                 .line_start(7)
                 .annotation(AnnotationKind::Primary.span(4..12)),
         )];
-    #[cfg(feature = "simd")]
-    let expected_ascii = str![[r#"
-error[test-diagnostic]: main diagnostic message
-  --> spacey-animals:8:1
-   |
- 7 | dog
- 8 | elephant
-   | ^^^^^^^^
- 9 | finch
-   |
-"#]];
-    #[cfg(not(feature = "simd"))]
     let expected_ascii = str![[r#"
 error[test-diagnostic]: main diagnostic message
  --> spacey-animals:8:1
@@ -5273,18 +5261,6 @@ error[test-diagnostic]: main diagnostic message
     let renderer = Renderer::plain();
     assert_data_eq!(renderer.render(input), expected_ascii);
 
-    #[cfg(feature = "simd")]
-    let expected_unicode = str![[r#"
-error[test-diagnostic]: main diagnostic message
-   ╭▸ spacey-animals:8:1
-   │
- 7 │ dog
- 8 │ elephant
-   │ ━━━━━━━━
- 9 │ finch
-   ╰╴
-"#]];
-    #[cfg(not(feature = "simd"))]
     let expected_unicode = str![[r#"
 error[test-diagnostic]: main diagnostic message
   ╭▸ spacey-animals:8:1

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -5234,3 +5234,67 @@ error[test-diagnostics]: main diagnostic message
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
+
+#[test]
+fn consistent_indentation_with_trailing_newline() {
+    let input = &[Level::ERROR
+        .primary_title("main diagnostic message")
+        .id("test-diagnostic")
+        .element(
+            Snippet::source("dog\nelephant\nfinch\n")
+                .path("spacey-animals")
+                .fold(false)
+                .line_start(7)
+                .annotation(AnnotationKind::Primary.span(4..12)),
+        )];
+    #[cfg(feature = "simd")]
+    let expected_ascii = str![[r#"
+error[test-diagnostic]: main diagnostic message
+  --> spacey-animals:8:1
+   |
+ 7 | dog
+ 8 | elephant
+   | ^^^^^^^^
+ 9 | finch
+   |
+"#]];
+    #[cfg(not(feature = "simd"))]
+    let expected_ascii = str![[r#"
+error[test-diagnostic]: main diagnostic message
+ --> spacey-animals:8:1
+  |
+7 | dog
+8 | elephant
+  | ^^^^^^^^
+9 | finch
+  |
+"#]];
+
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    #[cfg(feature = "simd")]
+    let expected_unicode = str![[r#"
+error[test-diagnostic]: main diagnostic message
+   ╭▸ spacey-animals:8:1
+   │
+ 7 │ dog
+ 8 │ elephant
+   │ ━━━━━━━━
+ 9 │ finch
+   ╰╴
+"#]];
+    #[cfg(not(feature = "simd"))]
+    let expected_unicode = str![[r#"
+error[test-diagnostic]: main diagnostic message
+  ╭▸ spacey-animals:8:1
+  │
+7 │ dog
+8 │ elephant
+  │ ━━━━━━━━
+9 │ finch
+  ╰╴
+"#]];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+}


### PR DESCRIPTION
When calculating gutter size, we use the number of digits for the
largest line count.
However, we calculated that in different ways with and without `simd`
which is only noticeable if it would add another digit.