### PR TITLE
fix(render): Don't hide id if level is hidden 

### DIFF
--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -351,24 +351,31 @@ fn render_title(
             (ElementStyle::MainHeaderMsg, ElementStyle::NoStyle)
         }
     };
-    let mut label_width = 0;
 
+    let mut label_width = 0;
     if title.level().name != Some(None) {
         buffer.append(buffer_msg_line_offset, title.level().as_str(), label_style);
         label_width += title.level().as_str().len();
+
         if let Some(Id { id: Some(id), url }) = &title.id() {
             let url = url
                 .as_deref()
                 .filter(|_| renderer.hyperlink)
                 .map(Hyperlink::with_url)
                 .unwrap_or_default();
+
             buffer.append(buffer_msg_line_offset, "[", label_style);
+            label_width += 1;
+
             buffer.append(buffer_msg_line_offset, &format!("{url}"), label_style);
             buffer.append(buffer_msg_line_offset, id, label_style);
             buffer.append(buffer_msg_line_offset, &format!("{url:#}"), label_style);
+            label_width += id.len();
+
             buffer.append(buffer_msg_line_offset, "]", label_style);
-            label_width += 2 + id.len();
+            label_width += 1;
         }
+
         buffer.append(buffer_msg_line_offset, ": ", title_element_style);
         label_width += 2;
     }

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -354,9 +354,11 @@ fn render_title(
 
     let mut label_width = 0;
     let level_is_visible = title.level().name != Some(None);
-    if level_is_visible {
-        buffer.append(buffer_msg_line_offset, title.level().as_str(), label_style);
-        label_width += title.level().as_str().len();
+    if level_is_visible || title.id().is_some() {
+        if level_is_visible {
+            buffer.append(buffer_msg_line_offset, title.level().as_str(), label_style);
+            label_width += title.level().as_str().len();
+        }
 
         if let Some(Id { id: Some(id), url }) = &title.id() {
             let url = url
@@ -365,16 +367,20 @@ fn render_title(
                 .map(Hyperlink::with_url)
                 .unwrap_or_default();
 
-            buffer.append(buffer_msg_line_offset, "[", label_style);
-            label_width += 1;
+            if level_is_visible {
+                buffer.append(buffer_msg_line_offset, "[", label_style);
+                label_width += 1;
+            }
 
             buffer.append(buffer_msg_line_offset, &format!("{url}"), label_style);
             buffer.append(buffer_msg_line_offset, id, label_style);
             buffer.append(buffer_msg_line_offset, &format!("{url:#}"), label_style);
             label_width += id.len();
 
-            buffer.append(buffer_msg_line_offset, "]", label_style);
-            label_width += 1;
+            if level_is_visible {
+                buffer.append(buffer_msg_line_offset, "]", label_style);
+                label_width += 1;
+            }
         }
 
         buffer.append(buffer_msg_line_offset, ": ", title_element_style);

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -357,22 +357,15 @@ fn render_title(
         buffer.append(buffer_msg_line_offset, title.level().as_str(), label_style);
         label_width += title.level().as_str().len();
         if let Some(Id { id: Some(id), url }) = &title.id() {
-            let mut url = url.as_ref();
-            if !renderer.hyperlink {
-                url = None;
-            }
+            let url = url
+                .as_deref()
+                .filter(|_| renderer.hyperlink)
+                .map(Hyperlink::with_url)
+                .unwrap_or_default();
             buffer.append(buffer_msg_line_offset, "[", label_style);
-            if let Some(url) = url.as_ref() {
-                buffer.append(
-                    buffer_msg_line_offset,
-                    &format!("\x1B]8;;{url}\x1B\\"),
-                    label_style,
-                );
-            }
+            buffer.append(buffer_msg_line_offset, &format!("{url}"), label_style);
             buffer.append(buffer_msg_line_offset, id, label_style);
-            if url.is_some() {
-                buffer.append(buffer_msg_line_offset, "\x1B]8;;\x1B\\", label_style);
-            }
+            buffer.append(buffer_msg_line_offset, &format!("{url:#}"), label_style);
             buffer.append(buffer_msg_line_offset, "]", label_style);
             label_width += 2 + id.len();
         }
@@ -2775,6 +2768,35 @@ fn newline_count(body: &str) -> usize {
     #[cfg(not(feature = "simd"))]
     {
         body.lines().count().saturating_sub(1)
+    }
+}
+
+struct Hyperlink<D: fmt::Display> {
+    url: Option<D>,
+}
+
+impl<D: fmt::Display> Hyperlink<D> {
+    pub(crate) fn with_url(url: D) -> Self {
+        Self { url: Some(url) }
+    }
+}
+
+impl<D: fmt::Display> Default for Hyperlink<D> {
+    fn default() -> Self {
+        Self { url: None }
+    }
+}
+
+impl<D: fmt::Display> fmt::Display for Hyperlink<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Some(url) = self.url.as_ref() else {
+            return Ok(());
+        };
+        if f.alternate() {
+            write!(f, "\x1B]8;;\x1B\\")
+        } else {
+            write!(f, "\x1B]8;;{url}\x1B\\")
+        }
     }
 }
 

--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -353,7 +353,8 @@ fn render_title(
     };
 
     let mut label_width = 0;
-    if title.level().name != Some(None) {
+    let level_is_visible = title.level().name != Some(None);
+    if level_is_visible {
         buffer.append(buffer_msg_line_offset, title.level().as_str(), label_style);
         label_width += title.level().as_str().len();
 

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -3447,11 +3447,11 @@ fn test_format_no_severity() {
             .id("E0001"),
     )];
 
-    let expected_ascii = str!["This is a title"];
+    let expected_ascii = str!["E0001: This is a title"];
     let renderer = Renderer::plain();
     assert_data_eq!(renderer.render(input), expected_ascii);
 
-    let expected_unicode = str!["This is a title"];
+    let expected_unicode = str!["E0001: This is a title"];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -3439,6 +3439,54 @@ note: byte `193` is not valid utf-8
 }
 
 #[test]
+fn test_format_no_severity() {
+    let input = &[Group::with_title(
+        Level::ERROR
+            .no_name()
+            .primary_title("This is a title")
+            .id("E0001"),
+    )];
+
+    let expected_ascii = str!["This is a title"];
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    let expected_unicode = str!["This is a title"];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+}
+
+#[test]
+fn test_format_no_id() {
+    let input = &[Group::with_title(
+        Level::ERROR.primary_title("This is a title"),
+    )];
+
+    let expected_ascii = str!["error: This is a title"];
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    let expected_unicode = str!["error: This is a title"];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+}
+
+#[test]
+fn test_format_no_severity_or_id() {
+    let input = &[Group::with_title(
+        Level::ERROR.no_name().primary_title("This is a title"),
+    )];
+
+    let expected_ascii = str!["This is a title"];
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    let expected_unicode = str!["This is a title"];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+}
+
+#[test]
 fn secondary_title_no_level_text() {
     let source = r#"fn main() {
     let b: &[u8] = include_str!("file.txt");    //~ ERROR mismatched types


### PR DESCRIPTION
In some tools, like `ruff`, the `level` can be assumed and becomes
redundant, while the `id` stays relevant.
The `level` can't be abused for as the id because of `id_url`.

Fixes #452