### PR TITLE
feat(render): Add Snippet::line_numbering(false) 

### DIFF
--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -718,6 +718,7 @@ fn render_snippet_annotations(
             max_line_num_len,
             margin,
             !is_cont && annotated_line_idx + 1 == annotated_lines.len(),
+            snippet.line_numbering,
         );
 
         let mut to_add = BTreeMap::new();
@@ -801,6 +802,7 @@ fn render_snippet_annotations(
                         code_offset,
                         max_line_num_len,
                         margin,
+                        snippet.line_numbering,
                     );
 
                     for (depth, style) in &multilines {
@@ -852,6 +854,7 @@ fn render_source_line(
     max_line_num_len: usize,
     margin: Margin,
     close_window: bool,
+    line_numbering: bool,
 ) -> Vec<(usize, ElementStyle)> {
     // Draw:
     //
@@ -881,6 +884,7 @@ fn render_source_line(
         code_offset,
         max_line_num_len,
         margin,
+        line_numbering,
     );
 
     // If there are no annotations, we are done
@@ -1526,7 +1530,7 @@ fn emit_suggestion_default(
             buffer.puts(
                 row_num - 1 + line - line_start.line,
                 0,
-                &maybe_anonymized(renderer, line, max_line_num_len),
+                &maybe_anonymized(renderer, line, max_line_num_len, suggestion.line_numbering),
                 ElementStyle::LineNumber,
             );
             buffer.puts(
@@ -1571,6 +1575,7 @@ fn emit_suggestion_default(
                     max_line_num_len,
                     &file_lines,
                     is_multiline,
+                    suggestion.line_numbering,
                 );
             }),
             // Print first unhighlighted line, "..." and last unhighlighted line, like so:
@@ -1597,6 +1602,7 @@ fn emit_suggestion_default(
                         max_line_num_len,
                         &file_lines,
                         is_multiline,
+                        suggestion.line_numbering,
                     );
                 }
 
@@ -1623,6 +1629,7 @@ fn emit_suggestion_default(
                         max_line_num_len,
                         &file_lines,
                         is_multiline,
+                        suggestion.line_numbering,
                     );
                 }
             }
@@ -1639,6 +1646,7 @@ fn emit_suggestion_default(
             max_line_num_len,
             &file_lines,
             is_multiline,
+            suggestion.line_numbering,
         );
     }
 
@@ -1757,6 +1765,7 @@ fn draw_code_line(
     max_line_num_len: usize,
     file_lines: &[&LineInfo<'_>],
     is_multiline: bool,
+    line_numbering: bool,
 ) {
     if let DisplaySuggestion::Diff = show_code_change {
         // We need to print more than one line if the span we need to remove is multiline.
@@ -1766,7 +1775,7 @@ fn draw_code_line(
             buffer.puts(
                 *row_num - 1,
                 0,
-                &maybe_anonymized(renderer, line_num + index, max_line_num_len),
+                &maybe_anonymized(renderer, line_num + index, max_line_num_len, line_numbering),
                 ElementStyle::LineNumber,
             );
             buffer.puts(
@@ -1815,7 +1824,12 @@ fn draw_code_line(
             buffer.puts(
                 *row_num - 1,
                 0,
-                &maybe_anonymized(renderer, line_num + file_lines.len() - 1, max_line_num_len),
+                &maybe_anonymized(
+                    renderer,
+                    line_num + file_lines.len() - 1,
+                    max_line_num_len,
+                    line_numbering,
+                ),
                 ElementStyle::LineNumber,
             );
             buffer.puts(
@@ -1858,7 +1872,7 @@ fn draw_code_line(
                 buffer.puts(
                     *row_num,
                     0,
-                    &maybe_anonymized(renderer, line_num, max_line_num_len),
+                    &maybe_anonymized(renderer, line_num, max_line_num_len, line_numbering),
                     ElementStyle::LineNumber,
                 );
                 buffer.puts(*row_num, max_line_num_len + 1, "+ ", ElementStyle::Addition);
@@ -1873,7 +1887,7 @@ fn draw_code_line(
         buffer.puts(
             *row_num,
             0,
-            &maybe_anonymized(renderer, line_num, max_line_num_len),
+            &maybe_anonymized(renderer, line_num, max_line_num_len, line_numbering),
             ElementStyle::LineNumber,
         );
         match &highlight_parts {
@@ -1909,7 +1923,7 @@ fn draw_code_line(
         buffer.puts(
             *row_num,
             0,
-            &maybe_anonymized(renderer, line_num, max_line_num_len),
+            &maybe_anonymized(renderer, line_num, max_line_num_len, line_numbering),
             ElementStyle::LineNumber,
         );
         buffer.puts(*row_num, max_line_num_len + 1, "+ ", ElementStyle::Addition);
@@ -1922,7 +1936,7 @@ fn draw_code_line(
         buffer.puts(
             *row_num,
             0,
-            &maybe_anonymized(renderer, line_num, max_line_num_len),
+            &maybe_anonymized(renderer, line_num, max_line_num_len, line_numbering),
             ElementStyle::LineNumber,
         );
         draw_col_separator(renderer, buffer, *row_num, max_line_num_len + 1);
@@ -1982,6 +1996,7 @@ fn draw_line(
     code_offset: usize,
     max_line_num_len: usize,
     margin: Margin,
+    line_numbering: bool,
 ) -> usize {
     // Tabs are assumed to have been replaced by spaces in calling code.
     debug_assert!(!source_string.contains('\t'));
@@ -2074,7 +2089,7 @@ fn draw_line(
     buffer.puts(
         line_offset,
         0,
-        &maybe_anonymized(renderer, line_index, max_line_num_len),
+        &maybe_anonymized(renderer, line_index, max_line_num_len, line_numbering),
         ElementStyle::LineNumber,
     );
 
@@ -2216,10 +2231,17 @@ fn draw_col_separator_no_space_with_style(
     buffer.putc(line, col, chr, style);
 }
 
-fn maybe_anonymized(renderer: &Renderer, line_num: usize, max_line_num_len: usize) -> String {
+fn maybe_anonymized(
+    renderer: &Renderer,
+    line_num: usize,
+    max_line_num_len: usize,
+    line_numbering: bool,
+) -> String {
     format!(
         "{:>max_line_num_len$}",
-        if renderer.anonymized_snippet_line_numbers {
+        if !line_numbering {
+            Cow::Borrowed("")
+        } else if renderer.anonymized_snippet_line_numbers {
             Cow::Borrowed(ANONYMIZED_LINE_NUM)
         } else {
             Cow::Owned(line_num.to_string())
@@ -2680,15 +2702,19 @@ fn pre_process<'a>(
                             .unwrap_or(cause.source.len())
                             .min(cause.source.len());
 
-                        max_line_num = Some(max(
-                            cause.line_start + newline_count(&cause.source[..end]),
-                            max_line_num.unwrap_or(0),
-                        ));
+                        if cause.line_numbering {
+                            max_line_num = Some(max(
+                                cause.line_start + newline_count(&cause.source[..end]),
+                                max_line_num.unwrap_or(0),
+                            ));
+                        }
                     } else {
-                        max_line_num = Some(max(
-                            cause.line_start + newline_count(&cause.source),
-                            max_line_num.unwrap_or(0),
-                        ));
+                        if cause.line_numbering {
+                            max_line_num = Some(max(
+                                cause.line_start + newline_count(&cause.source),
+                                max_line_num.unwrap_or(0),
+                            ));
+                        }
                     }
 
                     if primary_path.is_none() {
@@ -2720,14 +2746,18 @@ fn pre_process<'a>(
                                     DisplaySuggestion::None => l_start.line + nc,
                                     DisplaySuggestion::Add => l_start.line + nc,
                                 };
-                                max_line_num =
-                                    Some(max(sugg_max_line_num, max_line_num.unwrap_or(0)));
+                                if suggestion.line_numbering {
+                                    max_line_num =
+                                        Some(max(sugg_max_line_num, max_line_num.unwrap_or(0)));
+                                }
                             }
                         } else {
-                            max_line_num = Some(max(
-                                suggestion.line_start + newline_count(&complete),
-                                max_line_num.unwrap_or(0),
-                            ));
+                            if suggestion.line_numbering {
+                                max_line_num = Some(max(
+                                    suggestion.line_start + newline_count(&complete),
+                                    max_line_num.unwrap_or(0),
+                                ));
+                            }
                         }
 
                         elements.push(PreProcessedElement::Suggestion((

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -227,6 +227,7 @@ pub struct Snippet<'a, T> {
     pub(crate) line_start: usize,
     pub(crate) source: Cow<'a, str>,
     pub(crate) markers: Vec<T>,
+    pub(crate) line_numbering: bool,
     pub(crate) fold: bool,
 }
 
@@ -246,8 +247,17 @@ impl<'a, T: Clone> Snippet<'a, T> {
             line_start: 1,
             source: source.into(),
             markers: vec![],
+            line_numbering: true,
             fold: true,
         }
+    }
+
+    /// Whether to show the line number for each line (default: `true`)
+    ///
+    /// The default is `line_numbering(true)`, showing line numbers
+    pub fn line_numbering(mut self, yes: bool) -> Self {
+        self.line_numbering = yes;
+        self
     }
 
     /// When manually [`fold`][Self::fold]ing,

--- a/tests/ruff.rs
+++ b/tests/ruff.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{AnnotationKind, Group, Level, Renderer, Snippet};
+use annotate_snippets::{Annotation, AnnotationKind, Group, Level, Renderer, Snippet};
 
 use annotate_snippets::renderer::DecorStyle;
 use snapbox::{assert_data_eq, str};
@@ -25,20 +25,22 @@ fn example_code() {
         Group::with_title(
             Level::HELP.secondary_title("This violates the Liskov Substitution Principle"),
         ),
-        Group::with_title(Level::HELP.secondary_title(
-            "It is recommended for `__eq__` to work with arbitrary objects, for example:",
-        )),
-        Group::with_title(Level::HELP.secondary_title("")),
-        Group::with_title(
-            Level::HELP.secondary_title("    def __eq__(self, other: object) -> bool:"),
-        ),
-        Group::with_title(Level::HELP.secondary_title("        if not isinstance(other, A):")),
-        Group::with_title(Level::HELP.secondary_title("        if not isinstance(other, A):")),
-        Group::with_title(Level::HELP.secondary_title("            return False")),
-        Group::with_title(
-            Level::HELP.secondary_title("        return <logic to compare two `A` instances>"),
-        ),
-        Group::with_title(Level::HELP.secondary_title("")),
+        Level::HELP
+            .secondary_title(
+                "It is recommended for `__eq__` to work with arbitrary objects, for example:",
+            )
+            .element(
+                Snippet::<Annotation<'_>>::source(
+                    "\
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, A):
+        if not isinstance(other, A):
+            return False
+        return <logic to compare two `A` instances>
+",
+                )
+                .fold(false),
+            ),
     ];
     let expected_ascii = str![[r#"
 error[invalid-method-override]: Invalid override of method `__eq__`
@@ -50,13 +52,13 @@ error[invalid-method-override]: Invalid override of method `__eq__`
 info: incompatible return types: `NotBoolable` is not assignable to `bool`
 help: This violates the Liskov Substitution Principle
 help: It is recommended for `__eq__` to work with arbitrary objects, for example:
-help: 
-help:     def __eq__(self, other: object) -> bool:
-help:         if not isinstance(other, A):
-help:         if not isinstance(other, A):
-help:             return False
-help:         return <logic to compare two `A` instances>
-help: 
+  |
+1 | def __eq__(self, other: object) -> bool:
+2 |         if not isinstance(other, A):
+3 |         if not isinstance(other, A):
+4 |             return False
+5 |         return <logic to compare two `A` instances>
+  |
 "#]];
 
     let renderer = Renderer::plain();
@@ -72,13 +74,13 @@ error[invalid-method-override]: Invalid override of method `__eq__`
 info: incompatible return types: `NotBoolable` is not assignable to `bool`
 help: This violates the Liskov Substitution Principle
 help: It is recommended for `__eq__` to work with arbitrary objects, for example:
-help: 
-help:     def __eq__(self, other: object) -> bool:
-help:         if not isinstance(other, A):
-help:         if not isinstance(other, A):
-help:             return False
-help:         return <logic to compare two `A` instances>
-help: 
+  ╭▸ 
+1 │ def __eq__(self, other: object) -> bool:
+2 │         if not isinstance(other, A):
+3 │         if not isinstance(other, A):
+4 │             return False
+5 │         return <logic to compare two `A` instances>
+  ╰╴
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);

--- a/tests/ruff.rs
+++ b/tests/ruff.rs
@@ -1,0 +1,85 @@
+use annotate_snippets::{AnnotationKind, Group, Level, Renderer, Snippet};
+
+use annotate_snippets::renderer::DecorStyle;
+use snapbox::{assert_data_eq, str};
+
+#[test]
+fn example_code() {
+    let input = &[
+        Level::ERROR
+            .primary_title("Invalid override of method `__eq__`")
+            .id("invalid-method-override")
+            .element(
+                Snippet::source("    def __eq__(self, other) -> NotBoolable:")
+                    .path("src/mdtest_snippet.py")
+                    .line_start(6)
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(8..42)
+                            .label("Definition is incompatible with `object.__eq__`"),
+                    ),
+            ),
+        Group::with_title(Level::INFO.secondary_title(
+            "incompatible return types: `NotBoolable` is not assignable to `bool`",
+        )),
+        Group::with_title(
+            Level::HELP.secondary_title("This violates the Liskov Substitution Principle"),
+        ),
+        Group::with_title(Level::HELP.secondary_title(
+            "It is recommended for `__eq__` to work with arbitrary objects, for example:",
+        )),
+        Group::with_title(Level::HELP.secondary_title("")),
+        Group::with_title(
+            Level::HELP.secondary_title("    def __eq__(self, other: object) -> bool:"),
+        ),
+        Group::with_title(Level::HELP.secondary_title("        if not isinstance(other, A):")),
+        Group::with_title(Level::HELP.secondary_title("        if not isinstance(other, A):")),
+        Group::with_title(Level::HELP.secondary_title("            return False")),
+        Group::with_title(
+            Level::HELP.secondary_title("        return <logic to compare two `A` instances>"),
+        ),
+        Group::with_title(Level::HELP.secondary_title("")),
+    ];
+    let expected_ascii = str![[r#"
+error[invalid-method-override]: Invalid override of method `__eq__`
+ --> src/mdtest_snippet.py:6:9
+  |
+6 |     def __eq__(self, other) -> NotBoolable:
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `object.__eq__`
+  |
+info: incompatible return types: `NotBoolable` is not assignable to `bool`
+help: This violates the Liskov Substitution Principle
+help: It is recommended for `__eq__` to work with arbitrary objects, for example:
+help: 
+help:     def __eq__(self, other: object) -> bool:
+help:         if not isinstance(other, A):
+help:         if not isinstance(other, A):
+help:             return False
+help:         return <logic to compare two `A` instances>
+help: 
+"#]];
+
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(input), expected_ascii);
+
+    let expected_unicode = str![[r#"
+error[invalid-method-override]: Invalid override of method `__eq__`
+  ╭▸ src/mdtest_snippet.py:6:9
+  │
+6 │     def __eq__(self, other) -> NotBoolable:
+  │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Definition is incompatible with `object.__eq__`
+  ╰╴
+info: incompatible return types: `NotBoolable` is not assignable to `bool`
+help: This violates the Liskov Substitution Principle
+help: It is recommended for `__eq__` to work with arbitrary objects, for example:
+help: 
+help:     def __eq__(self, other: object) -> bool:
+help:         if not isinstance(other, A):
+help:         if not isinstance(other, A):
+help:             return False
+help:         return <logic to compare two `A` instances>
+help: 
+"#]];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(input), expected_unicode);
+}

--- a/tests/ruff.rs
+++ b/tests/ruff.rs
@@ -39,6 +39,7 @@ fn example_code() {
         return <logic to compare two `A` instances>
 ",
                 )
+                .line_numbering(false)
                 .fold(false),
             ),
     ];
@@ -53,11 +54,11 @@ info: incompatible return types: `NotBoolable` is not assignable to `bool`
 help: This violates the Liskov Substitution Principle
 help: It is recommended for `__eq__` to work with arbitrary objects, for example:
   |
-1 | def __eq__(self, other: object) -> bool:
-2 |         if not isinstance(other, A):
-3 |         if not isinstance(other, A):
-4 |             return False
-5 |         return <logic to compare two `A` instances>
+  | def __eq__(self, other: object) -> bool:
+  |         if not isinstance(other, A):
+  |         if not isinstance(other, A):
+  |             return False
+  |         return <logic to compare two `A` instances>
   |
 "#]];
 
@@ -75,11 +76,11 @@ info: incompatible return types: `NotBoolable` is not assignable to `bool`
 help: This violates the Liskov Substitution Principle
 help: It is recommended for `__eq__` to work with arbitrary objects, for example:
   ╭▸ 
-1 │ def __eq__(self, other: object) -> bool:
-2 │         if not isinstance(other, A):
-3 │         if not isinstance(other, A):
-4 │             return False
-5 │         return <logic to compare two `A` instances>
+  │ def __eq__(self, other: object) -> bool:
+  │         if not isinstance(other, A):
+  │         if not isinstance(other, A):
+  │             return False
+  │         return <logic to compare two `A` instances>
   ╰╴
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);


### PR DESCRIPTION
Having a `true` default happens with `fold` so I figured it would be
fine here.

`line_numbering` was inspired by [zola](https://www.getzola.org/documentation/content/syntax-highlighting/#annotations):

> `linenos` to enable line numbering.

Fixes #383