### PR TITLE
fix: Correctly align continuation lines when Level has wide or multibyte chars

### DIFF
--- a/src/renderer/render.rs
+++ b/src/renderer/render.rs
@@ -357,7 +357,7 @@ fn render_title(
     if level_is_visible || title.id().is_some() {
         if level_is_visible {
             buffer.append(buffer_msg_line_offset, title.level().as_str(), label_style);
-            label_width += title.level().as_str().len();
+            label_width += str_width(title.level().as_str());
         }
 
         if let Some(Id { id: Some(id), url }) = &title.id() {
@@ -375,7 +375,7 @@ fn render_title(
             buffer.append(buffer_msg_line_offset, &format!("{url}"), label_style);
             buffer.append(buffer_msg_line_offset, id, label_style);
             buffer.append(buffer_msg_line_offset, &format!("{url:#}"), label_style);
-            label_width += id.len();
+            label_width += str_width(id);
 
             if level_is_visible {
                 buffer.append(buffer_msg_line_offset, "]", label_style);

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -5464,14 +5464,14 @@ fn multi_byte_chars_in_level_name() {
 
     let expected_ascii = str![[r#"
 Æíóü: first line
-          second line
+      second line
 "#]];
     let renderer = Renderer::plain();
     assert_data_eq!(renderer.render(report), expected_ascii);
 
     let expected_unicode = str![[r#"
 Æíóü: first line
-          second line
+      second line
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(report), expected_unicode);
@@ -5487,14 +5487,14 @@ fn wide_chars_in_level_name() {
 
     let expected_ascii = str![[r#"
 こんにちは: first line
-                 second line
+            second line
 "#]];
     let renderer = Renderer::plain();
     assert_data_eq!(renderer.render(report), expected_ascii);
 
     let expected_unicode = str![[r#"
 こんにちは: first line
-                 second line
+            second line
 "#]];
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(report), expected_unicode);

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -5453,3 +5453,49 @@ error[E0308]: mismatched types
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
+
+#[test]
+fn multi_byte_chars_in_level_name() {
+    let report = &[Group::with_title(
+        Level::ERROR
+            .with_name("Æíóü")
+            .primary_title("first line\nsecond line"),
+    )];
+
+    let expected_ascii = str![[r#"
+Æíóü: first line
+          second line
+"#]];
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(report), expected_ascii);
+
+    let expected_unicode = str![[r#"
+Æíóü: first line
+          second line
+"#]];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(report), expected_unicode);
+}
+
+#[test]
+fn wide_chars_in_level_name() {
+    let report = &[Group::with_title(
+        Level::ERROR
+            .with_name("こんにちは")
+            .primary_title("first line\nsecond line"),
+    )];
+
+    let expected_ascii = str![[r#"
+こんにちは: first line
+                 second line
+"#]];
+    let renderer = Renderer::plain();
+    assert_data_eq!(renderer.render(report), expected_ascii);
+
+    let expected_unicode = str![[r#"
+こんにちは: first line
+                 second line
+"#]];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(renderer.render(report), expected_unicode);
+}


### PR DESCRIPTION
We currently use the byte length of a `Level`'s `name` and `id` when calculating the padding to use for continuation lines. This causes misalignment when there are wide or multibyte characters in either the `name` or `id`. To fix this, I made it so we use the display width of a `Level`'s `name` and `id` for the padding calculation.