### PR TITLE
feat: Footnote support 

### DIFF
--- a/src/level.rs
+++ b/src/level.rs
@@ -83,6 +83,7 @@ impl<'a> Level<'a> {
         Title {
             level: self,
             id: None,
+            footnote_marker: None,
             text: text.into(),
             allows_styling: false,
         }
@@ -104,6 +105,7 @@ impl<'a> Level<'a> {
         Title {
             level: self,
             id: None,
+            footnote_marker: None,
             text: text.into(),
             allows_styling: true,
         }

--- a/src/renderer/graphics.rs
+++ b/src/renderer/graphics.rs
@@ -388,6 +388,10 @@ fn render_title(
             }
         }
 
+        if let Some(footnote_marker) = title.footnote_marker() {
+            buffer.append(buffer_msg_line_offset, footnote_marker, label_style);
+        }
+
         buffer.append(buffer_msg_line_offset, ": ", title_element_style);
         label_width += 2;
     }
@@ -2292,6 +2296,7 @@ fn draw_line_separator(renderer: &Renderer, buffer: &mut StyledBuffer, line: usi
 trait MessageOrTitle {
     fn level(&self) -> &Level<'_>;
     fn id(&self) -> Option<&Id<'_>>;
+    fn footnote_marker(&self) -> Option<&str>;
     fn text(&self) -> &str;
     fn allows_styling(&self) -> bool;
 }
@@ -2302,6 +2307,9 @@ impl MessageOrTitle for Title<'_> {
     }
     fn id(&self) -> Option<&Id<'_>> {
         self.id.as_ref()
+    }
+    fn footnote_marker(&self) -> Option<&str> {
+        self.footnote_marker.as_deref()
     }
     fn text(&self) -> &str {
         self.text.as_ref()
@@ -2316,6 +2324,9 @@ impl MessageOrTitle for Message<'_> {
         &self.level
     }
     fn id(&self) -> Option<&Id<'_>> {
+        None
+    }
+    fn footnote_marker(&self) -> Option<&str> {
         None
     }
     fn text(&self) -> &str {

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -161,6 +161,7 @@ pub struct Padding;
 pub struct Title<'a> {
     pub(crate) level: Level<'a>,
     pub(crate) id: Option<Id<'a>>,
+    pub(crate) footnote_marker: Option<Cow<'a, str>>,
     pub(crate) text: Cow<'a, str>,
     pub(crate) allows_styling: bool,
 }
@@ -191,6 +192,22 @@ impl<'a> Title<'a> {
     /// </div>
     pub fn id_url(mut self, url: impl Into<Cow<'a, str>>) -> Self {
         self.id.get_or_insert(Id::default()).url = Some(url.into());
+        self
+    }
+
+    /// Append a footnote marker to the title
+    ///
+    /// The caller is responsible for rendering the footnote.
+    ///
+    /// <div class="warning">
+    ///
+    /// Text passed to this function is considered "untrusted input", as such
+    /// all text is passed through a normalization function. Styled text is
+    /// not allowed to be passed to this function.
+    ///
+    /// </div>
+    pub fn footnote(mut self, marker: impl Into<OptionCow<'a>>) -> Self {
+        self.footnote_marker = marker.into().0;
         self
     }
 

--- a/tests/ruff.rs
+++ b/tests/ruff.rs
@@ -90,6 +90,7 @@ fn fixable_diagnostic() {
         .no_name()
         .primary_title("`os` imported but unused")
         .id("F401")
+        .footnote("[*]")
         .element(
             Snippet::source("import os\n")
                 .path("-")
@@ -101,7 +102,7 @@ Found 1 error.
 ";
 
     let expected_ascii = str![[r#"
-F401: `os` imported but unused
+F401[*]: `os` imported but unused
  --> -:1:8
   |
 1 | import os
@@ -118,7 +119,7 @@ Found 1 error.
     );
 
     let expected_unicode = str![[r#"
-F401: `os` imported but unused
+F401[*]: `os` imported but unused
   ╭▸ -:1:8
   │
 1 │ import os

--- a/tests/ruff.rs
+++ b/tests/ruff.rs
@@ -83,3 +83,54 @@ help: It is recommended for `__eq__` to work with arbitrary objects, for example
     let renderer = renderer.decor_style(DecorStyle::Unicode);
     assert_data_eq!(renderer.render(input), expected_unicode);
 }
+
+#[test]
+fn fixable_diagnostic() {
+    let input = &[Level::ERROR
+        .no_name()
+        .primary_title("`os` imported but unused")
+        .id("F401")
+        .element(
+            Snippet::source("import os\n")
+                .path("-")
+                .annotation(AnnotationKind::Primary.span(7..9)),
+        )];
+    let suffix = "
+Found 1 error.
+[*] 1 fixable with the `--fix` option.
+";
+
+    let expected_ascii = str![[r#"
+F401: `os` imported but unused
+ --> -:1:8
+  |
+1 | import os
+  |        ^^
+
+Found 1 error.
+[*] 1 fixable with the `--fix` option.
+
+"#]];
+    let renderer = Renderer::plain();
+    assert_data_eq!(
+        format!("{}\n{suffix}", renderer.render(input)),
+        expected_ascii
+    );
+
+    let expected_unicode = str![[r#"
+F401: `os` imported but unused
+  ╭▸ -:1:8
+  │
+1 │ import os
+  ╰╴       ━━
+
+Found 1 error.
+[*] 1 fixable with the `--fix` option.
+
+"#]];
+    let renderer = renderer.decor_style(DecorStyle::Unicode);
+    assert_data_eq!(
+        format!("{}\n{suffix}", renderer.render(input)),
+        expected_unicode
+    );
+}


### PR DESCRIPTION
Like with any unicode in title's, the caller is responsible for deciding whether a footnote should have unicode.

In support of superscript footnotes, the caller is responsible for whether to wrap footnote markers in `[]`.

Fixes #450